### PR TITLE
Fix gestión de anuncios: errores, fallback y console.log

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -25,6 +25,8 @@ export default function AdminPage() {
   const [noticias, setNoticias] = useState<Noticia[]>([]);
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
   const [form, setForm] = useState<NoticiaInput>({
     titulo: "",
     cuerpo: "",
@@ -35,7 +37,11 @@ export default function AdminPage() {
 
   useEffect(() => {
     if (usuario?.empresaId) {
-      getNoticias(usuario.empresaId).then(setNoticias);
+      setLoading(true);
+      getNoticias(usuario.empresaId)
+        .then(setNoticias)
+        .catch((err) => setError(err.message))
+        .finally(() => setLoading(false));
     }
   }, [usuario?.empresaId]);
 
@@ -49,15 +55,23 @@ export default function AdminPage() {
     if (!form.titulo.trim() || !form.cuerpo.trim()) return;
     const payload = { ...form, empresa_id: usuario?.empresaId ?? null };
 
-    if (editingId) {
-      await editarNoticia(editingId, payload);
-    } else {
-      await crearNoticia(payload);
-    }
+    try {
+      setError("");
+      setLoading(true);
+      if (editingId) {
+        await editarNoticia(editingId, payload);
+      } else {
+        await crearNoticia(payload);
+      }
 
-    const updated = await getNoticias(usuario?.empresaId);
-    setNoticias(updated);
-    resetForm();
+      const updated = await getNoticias(usuario?.empresaId);
+      setNoticias(updated);
+      resetForm();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleEdit = (n: Noticia) => {
@@ -67,9 +81,17 @@ export default function AdminPage() {
   };
 
   const handleDelete = async (id: number) => {
-    await desactivarNoticia(id);
-    const updated = await getNoticias(usuario?.empresaId);
-    setNoticias(updated);
+    try {
+      setError("");
+      setLoading(true);
+      await desactivarNoticia(id);
+      const updated = await getNoticias(usuario?.empresaId);
+      setNoticias(updated);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -81,6 +103,23 @@ export default function AdminPage() {
       />
 
       <main className="max-w-5xl mx-auto px-8 py-10">
+        {/* Error */}
+        {error && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6 flex items-start gap-3">
+            <span className="text-xl">⚠️</span>
+            <div>
+              <p className="text-sm font-semibold text-red-800">Error</p>
+              <p className="text-xs text-red-600 mt-1">{error}</p>
+            </div>
+            <button
+              onClick={() => setError("")}
+              className="ml-auto text-red-400 hover:text-red-600"
+            >
+              ✕
+            </button>
+          </div>
+        )}
+
         {/* Header */}
         <div className="flex items-center justify-between mb-8">
           <div>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -53,7 +53,6 @@ export default function ProtectedRoute({ children }: { children: React.ReactNode
   }
 
   if (!usuario) return null;
-  console.log("ROL ACTUAL:", usuario.codigoRol);
   const esSuperAdmin = usuario.codigoRol === "ROLE_ADMIN";
 
   const esAdmin = usuario.codigoRol === "ROLE_ADMIN";

--- a/lib/api/noticias.ts
+++ b/lib/api/noticias.ts
@@ -8,7 +8,7 @@ import { MOCK_NOTICIAS as mockData } from "../mocks/noticias.mock";
 /**
  * Admin General: devuelve todas las noticias.
  * Admin Empresa: devuelve solo las de su empresa (filtra por empresa_id).
- * Intenta backend primero; si falla, usa mock data.
+ * Intenta backend primero; si falla, usa mock data solo para lectura.
  */
 export async function getNoticias(empresaId?: string): Promise<Noticia[]> {
   try {
@@ -20,7 +20,7 @@ export async function getNoticias(empresaId?: string): Promise<Noticia[]> {
     if (!res.ok) throw new Error("Backend error");
     return res.json();
   } catch {
-    // Fallback a mock data
+    // Fallback a mock data solo para lectura
     if (empresaId !== undefined) {
       return mockData.filter(
         (n) => n.empresa_id === empresaId || n.empresa_id === null
@@ -47,68 +47,49 @@ export async function getNoticiaById(id: number): Promise<Noticia> {
 // ─── POST crear noticia ───────────────────────────────────────────────────────
 
 export async function crearNoticia(data: NoticiaInput): Promise<Noticia> {
-  try {
-    const res = await fetch(`${API_URL}/anuncios`, {
-      method: "POST",
-      credentials: "include",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(data),
-    });
-    if (!res.ok) throw new Error("Backend error");
-    return res.json();
-  } catch {
-    // Fallback: crea en mock local
-    const nueva: Noticia = {
-      anuncio_id: Date.now(),
-      ...data,
-      empresa_id: data.empresa_id ?? null,
-      activo: true,
-      creado_por: 1,
-      creado_en: new Date().toISOString(),
-      actualizado_en: new Date().toISOString(),
-    };
-    mockData.unshift(nueva);
-    return nueva;
+  // Siempre intenta guardar en backend (no fallback a mock)
+  const res = await fetch(`${API_URL}/anuncios`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    throw new Error("Error al crear anuncio. Verifica tu conexión e intenta de nuevo.");
   }
+
+  return res.json();
 }
 
 // ─── PUT editar noticia ───────────────────────────────────────────────────────
 
 export async function editarNoticia(id: number, data: Partial<NoticiaInput>): Promise<Noticia> {
-  try {
-    const res = await fetch(`${API_URL}/anuncios/${id}`, {
-      method: "PUT",
-      credentials: "include",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(data),
-    });
-    if (!res.ok) throw new Error("Backend error");
-    return res.json();
-  } catch {
-    // Fallback: edita en mock local
-    const idx = mockData.findIndex((n) => n.anuncio_id === id);
-    if (idx === -1) throw new Error("Noticia no encontrada");
-    mockData[idx] = {
-      ...mockData[idx],
-      ...data,
-      actualizado_en: new Date().toISOString(),
-    };
-    return mockData[idx];
+  // Siempre intenta guardar en backend (no fallback a mock)
+  const res = await fetch(`${API_URL}/anuncios/${id}`, {
+    method: "PUT",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    throw new Error("Error al editar anuncio. Verifica tu conexión e intenta de nuevo.");
   }
+
+  return res.json();
 }
 
 // ─── DELETE (desactivar) noticia ──────────────────────────────────────────────
 
 export async function desactivarNoticia(id: number): Promise<void> {
-  try {
-    const res = await fetch(`${API_URL}/anuncios/${id}`, {
-      method: "DELETE",
-      credentials: "include",
-    });
-    if (!res.ok) throw new Error("Backend error");
-  } catch {
-    // Fallback: desactiva en mock local
-    const idx = mockData.findIndex((n) => n.anuncio_id === id);
-    if (idx !== -1) mockData[idx].activo = false;
+  // Siempre intenta eliminar en backend (no fallback a mock)
+  const res = await fetch(`${API_URL}/anuncios/${id}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    throw new Error("Error al desactivar anuncio. Verifica tu conexión e intenta de nuevo.");
   }
 }


### PR DESCRIPTION
- Escritura (crear/editar/borrar) siempre va al backend real
- Lectura con fallback a mock si el backend falla
- Mensajes de error visibles en la UI del panel de anuncios