### PR TITLE
Fix ruta Administración en Noticias.tsx

### DIFF
--- a/components/pages/Noticias.tsx
+++ b/components/pages/Noticias.tsx
@@ -71,7 +71,7 @@ export default function NoticiasPage() {
     "Onboarding": "/dashboard/onboarding",
     "Formación": "/dashboard/formacion",
     "Comunicación": "/dashboard/noticias",
-    "Administración": "/dashboard/administracion",
+    "Administración": "/dashboard/admin",
   };
 
   // ── Carga inicial ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Noticias.tsx tenía su propia copia de NAV_ROUTES con la ruta incorrecta "/dashboard/administracion" en lugar de "/dashboard/admin"