### PR TITLE
feat(ui): rediseño hero, admin empresa y panel de administración

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -11,6 +11,7 @@ import type { Noticia, NoticiaInput } from "@/lib/types/noticias";
 import type { ModuloConProgreso } from "@/lib/types/modulos";
 import { MODULO_TIPO_LABEL } from "@/lib/types/modulos";
 import { apiFetch, API_URL } from "@/lib/api";
+import DashboardHero from "@/components/ui/DashboardHero";
 
 const EMPTY_ANUNCIO: NoticiaInput = {
   titulo: "", contenido: "", esGlobal: false, empresaId: null,
@@ -212,588 +213,760 @@ function AdminContent() {
     return new Date(iso).toLocaleDateString("es-ES", { day: "numeric", month: "short", year: "numeric" });
   }
 
+  const tabs = [
+    {
+      key: "empleados" as const,
+      label: "Empleados",
+      icon: (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+          <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+        </svg>
+      ),
+    },
+    {
+      key: "anuncios" as const,
+      label: "Anuncios",
+      icon: (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 11l19-9-9 19-2-8-8-2z" />
+        </svg>
+      ),
+    },
+    {
+      key: "formaciones" as const,
+      label: "Módulos formativos",
+      icon: (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+          <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+        </svg>
+      ),
+    },
+  ];
+
+  // Accent colors per modulo tipo for top strip
+  const tipoAccentColor: Record<string, string> = {
+    PREVENCION: "var(--error)",
+    CALIDAD: "var(--azul-egm)",
+    MEDIO_AMBIENTE: "var(--verde-oliva)",
+    FORMACION_BASICA: "var(--exito)",
+  };
+
   return (
     <>
-      {/* Tabs — desktop */}
-      <div className="hidden sm:flex gap-1 mb-8" style={{ borderBottom: "1px solid var(--gris-borde)" }}>
-        {(["empleados", "anuncios", "formaciones"] as const).map((tab) => (
-          <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
-            className="pb-4 px-3 text-sm font-medium transition-colors relative"
-            style={{ color: activeTab === tab ? "var(--azul-egm)" : "var(--texto-muted)" }}
-          >
-            {tab === "empleados" ? "Empleados" : tab === "anuncios" ? "Anuncios" : "Módulos formativos"}
-            {activeTab === tab && (
-              <div className="absolute bottom-0 left-0 w-full h-0.5 rounded-full"
-                style={{ background: "var(--azul-egm)" }} />
-            )}
-          </button>
-        ))}
-      </div>
+      <DashboardHero
+        prefijo="Panel de "
+        titulo="Administración."
+        imagenFondo="/background-formacion-empleado.jpg"
+      />
 
-      {/* Tabs — móvil (selector) */}
-      <div className="sm:hidden mb-6">
-        <select
-          value={activeTab}
-          onChange={(e) => setActiveTab(e.target.value as "empleados" | "anuncios" | "formaciones")}
-          className="w-full rounded-lg px-3 py-2.5 text-sm font-medium focus:outline-none"
-          style={{
-            border:      "1px solid var(--gris-borde)",
-            background:  "var(--blanco)",
-            color:       "var(--texto-primario)",
-          }}
-        >
-          <option value="empleados">Empleados</option>
-          <option value="anuncios">Anuncios</option>
-          <option value="formaciones">Módulos formativos</option>
-        </select>
-      </div>
-
-      {/* ── TAB EMPLEADOS ── */}
-      {activeTab === "empleados" && (
-        <div className="relative">
-          <div className="flex items-start justify-between mb-6">
-            <div>
-              <h1 className="text-xl font-semibold" style={{ color: "var(--texto-primario)" }}>Empleados</h1>
-              <p className="text-sm mt-0.5" style={{ color: "var(--texto-muted)" }}>
-                {empleados.length} persona{empleados.length !== 1 ? "s" : ""} en tu empresa
-              </p>
-            </div>
+      <div className="px-10 lg:px-16 pt-10 pb-16">
+        {/* Tabs — desktop (pill style) */}
+        <div className="hidden sm:flex gap-2 mb-10 p-1 rounded-2xl w-fit"
+          style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+          {tabs.map((tab) => (
             <button
-              onClick={() => { setShowFormEmpleado(true); setErrorEmpleado(null); }}
-              className="text-sm font-medium px-4 py-2 rounded-lg transition-colors"
-              style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
-              onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold transition-all"
+              style={{
+                background: activeTab === tab.key ? "var(--azul-egm)" : "transparent",
+                color: activeTab === tab.key ? "white" : "var(--texto-muted)",
+              }}
             >
-              + Añadir empleado
+              {tab.icon}
+              {tab.label}
             </button>
-          </div>
+          ))}
+        </div>
 
-          {/* Formulario nuevo empleado */}
-          {showFormEmpleado && (
-            <div className="rounded-xl p-6 mb-6"
-              style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>Nuevo empleado</h2>
-                <button onClick={() => setShowFormEmpleado(false)} className="text-lg leading-none"
-                  style={{ color: "var(--texto-muted)" }}>×</button>
+        {/* Tabs — móvil (selector) */}
+        <div className="sm:hidden mb-8">
+          <select
+            value={activeTab}
+            onChange={(e) => setActiveTab(e.target.value as "empleados" | "anuncios" | "formaciones")}
+            className="w-full rounded-xl px-4 py-3 text-sm font-semibold focus:outline-none"
+            style={{
+              border: "1px solid var(--gris-borde)",
+              background: "var(--blanco)",
+              color: "var(--texto-primario)",
+            }}
+          >
+            <option value="empleados">Empleados</option>
+            <option value="anuncios">Anuncios</option>
+            <option value="formaciones">Módulos formativos</option>
+          </select>
+        </div>
+
+        {/* ── TAB EMPLEADOS ── */}
+        {activeTab === "empleados" && (
+          <div className="relative">
+            {/* Header */}
+            <div className="flex items-start justify-between mb-8">
+              <div>
+                <h1 className="text-2xl font-bold" style={{ color: "var(--texto-primario)" }}>Empleados</h1>
+                <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
+                  {empleados.length} persona{empleados.length !== 1 ? "s" : ""} en tu empresa
+                </p>
               </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {[
-                  { label: "Nombre", key: "nombre", type: "text", placeholder: "María", required: true },
-                  { label: "Apellidos", key: "apellidos", type: "text", placeholder: "García López", required: false },
-                  { label: "Email", key: "email", type: "email", placeholder: "m.garcia@empresa.com", required: true },
-                  { label: "Contraseña inicial", key: "password", type: "password", placeholder: "Mínimo 8 caracteres", required: true },
-                ].map((f) => (
-                  <div key={f.key}>
-                    <label className="block text-xs font-medium mb-1.5" style={{ color: "var(--texto-secundario)" }}>
-                      {f.label} {f.required && <span style={{ color: "var(--error)" }}>*</span>}
+              <button
+                onClick={() => { setShowFormEmpleado(true); setErrorEmpleado(null); }}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors"
+                style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
+                onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+                Añadir empleado
+              </button>
+            </div>
+
+            {/* Formulario nuevo empleado */}
+            {showFormEmpleado && (
+              <div className="rounded-2xl p-6 mb-8"
+                style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                <div className="flex items-center justify-between mb-6">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-xl flex items-center justify-center"
+                      style={{ background: "var(--azul-egm-light)" }}>
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--azul-egm)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                        <circle cx="9" cy="7" r="4" />
+                        <line x1="19" y1="8" x2="19" y2="14" /><line x1="22" y1="11" x2="16" y2="11" />
+                      </svg>
+                    </div>
+                    <h2 className="text-base font-bold" style={{ color: "var(--texto-primario)" }}>Añadir nuevo empleado</h2>
+                  </div>
+                  <button onClick={() => setShowFormEmpleado(false)}
+                    className="w-7 h-7 flex items-center justify-center rounded-lg text-lg leading-none transition-colors"
+                    style={{ color: "var(--texto-muted)", background: "var(--gris-pagina)" }}>×</button>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  {[
+                    { label: "Nombre", key: "nombre", type: "text", placeholder: "María", required: true },
+                    { label: "Apellidos", key: "apellidos", type: "text", placeholder: "García López", required: false },
+                    { label: "Email", key: "email", type: "email", placeholder: "m.garcia@empresa.com", required: true },
+                    { label: "Contraseña inicial", key: "password", type: "password", placeholder: "Mínimo 8 caracteres", required: true },
+                  ].map((f) => (
+                    <div key={f.key}>
+                      <label className="block text-xs font-semibold mb-2" style={{ color: "var(--texto-secundario)" }}>
+                        {f.label} {f.required && <span style={{ color: "var(--error)" }}>*</span>}
+                      </label>
+                      <input
+                        type={f.type}
+                        value={formEmpleado[f.key as keyof NuevoEmpleadoForm]}
+                        onChange={(e) => setFormEmpleado({ ...formEmpleado, [f.key]: e.target.value })}
+                        placeholder={f.placeholder}
+                        className="w-full rounded-xl px-4 py-3 text-sm focus:outline-none"
+                        style={{ border: "1px solid var(--gris-borde)", background: "var(--gris-pagina)", color: "var(--texto-primario)" }}
+                      />
+                    </div>
+                  ))}
+                  <div className="col-span-1 sm:col-span-2">
+                    <label className="block text-xs font-semibold mb-2" style={{ color: "var(--texto-secundario)" }}>
+                      Puesto de trabajo
                     </label>
                     <input
-                      type={f.type}
-                      value={formEmpleado[f.key as keyof NuevoEmpleadoForm]}
-                      onChange={(e) => setFormEmpleado({ ...formEmpleado, [f.key]: e.target.value })}
-                      placeholder={f.placeholder}
-                      className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
-                      style={{ border: "1px solid var(--gris-borde)", background: "var(--blanco)", color: "var(--texto-primario)" }}
+                      type="text"
+                      value={formEmpleado.puestoTrabajo}
+                      onChange={(e) => setFormEmpleado({ ...formEmpleado, puestoTrabajo: e.target.value })}
+                      placeholder="Ej: Técnico de producción"
+                      className="w-full rounded-xl px-4 py-3 text-sm focus:outline-none"
+                      style={{ border: "1px solid var(--gris-borde)", background: "var(--gris-pagina)", color: "var(--texto-primario)" }}
                     />
                   </div>
-                ))}
-                <div className="col-span-1 sm:col-span-2">
-                  <label className="block text-xs font-medium mb-1.5" style={{ color: "var(--texto-secundario)" }}>
-                    Puesto de trabajo
-                  </label>
-                  <input
-                    type="text"
-                    value={formEmpleado.puestoTrabajo}
-                    onChange={(e) => setFormEmpleado({ ...formEmpleado, puestoTrabajo: e.target.value })}
-                    placeholder="Ej: Técnico de producción"
-                    className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
-                    style={{ border: "1px solid var(--gris-borde)", background: "var(--blanco)", color: "var(--texto-primario)" }}
-                  />
+                </div>
+                {errorEmpleado && (
+                  <div className="flex items-center gap-2 mt-4 px-4 py-3 rounded-xl"
+                    style={{ background: "var(--error-light)", border: "1px solid var(--error)" }}>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--error)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+                    </svg>
+                    <p className="text-xs font-medium" style={{ color: "var(--error)" }}>{errorEmpleado}</p>
+                  </div>
+                )}
+                <div className="flex gap-3 justify-end pt-5 mt-4"
+                  style={{ borderTop: "1px solid var(--gris-borde)" }}>
+                  <button onClick={() => setShowFormEmpleado(false)}
+                    className="text-sm font-medium px-5 py-2.5 rounded-xl transition-colors"
+                    style={{ color: "var(--texto-secundario)", background: "var(--gris-pagina)", border: "1px solid var(--gris-borde)" }}>
+                    Cancelar
+                  </button>
+                  <button
+                    onClick={handleCrearEmpleado}
+                    disabled={guardandoEmpleado}
+                    className="text-sm font-semibold px-5 py-2.5 rounded-xl disabled:opacity-50 transition-colors"
+                    style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
+                  >
+                    {guardandoEmpleado ? "Creando..." : "Crear empleado"}
+                  </button>
                 </div>
               </div>
-              {errorEmpleado && (
-                <p className="text-xs mt-3" style={{ color: "var(--error)" }}>{errorEmpleado}</p>
-              )}
-              <div className="flex gap-2 justify-end pt-4 mt-2"
-                style={{ borderTop: "1px solid var(--gris-superficie)" }}>
-                <button onClick={() => setShowFormEmpleado(false)}
-                  className="text-sm px-4 py-2 rounded-lg"
-                  style={{ color: "var(--texto-secundario)" }}>Cancelar</button>
-                <button
-                  onClick={handleCrearEmpleado}
-                  disabled={guardandoEmpleado}
-                  className="text-sm font-medium px-4 py-2 rounded-lg disabled:opacity-50 transition-colors"
-                  style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
-                  onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
-                >
-                  {guardandoEmpleado ? "Creando..." : "Crear empleado"}
-                </button>
-              </div>
-            </div>
-          )}
+            )}
 
-          {/* Layout tabla + drawer */}
-          <div className="flex gap-6">
-            <div className="rounded-xl overflow-hidden flex-1 min-w-0"
-              style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-              {cargandoEmpleados ? (
-                <div className="flex items-center justify-center py-16">
-                  <div className="w-6 h-6 border-2 rounded-full animate-spin"
-                    style={{ borderColor: "var(--gris-borde)", borderTopColor: "var(--azul-egm)" }} />
-                </div>
-              ) : empleados.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-16 text-center">
-                  <p className="text-sm" style={{ color: "var(--texto-muted)" }}>No hay empleados todavía</p>
-                  <button onClick={() => setShowFormEmpleado(true)}
-                    className="mt-2 text-xs font-medium hover:underline"
-                    style={{ color: "var(--azul-egm)" }}>Añadir el primero →</button>
-                </div>
-              ) : (
-                <>
-                  {/* Vista desktop — tabla */}
-                  <div className="hidden md:block">
-                    <table className="w-full">
-                      <thead>
-                        <tr style={{ borderBottom: "1px solid var(--gris-borde)" }}>
-                          {["Empleado", "Puesto", "Rol", "Alta", "Estado"].map((h) => (
-                            <th key={h} className="text-left px-4 py-3 text-xs font-medium"
-                              style={{ color: "var(--texto-muted)" }}>{h}</th>
-                          ))}
-                          <th className="px-4 py-3" />
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {empleados.map((e) => (
-                          <tr
-                            key={e.usuarioId}
-                            className="cursor-pointer transition-colors"
-                            style={{
-                              borderBottom: "1px solid var(--gris-borde)",
-                              background: empleadoSeleccionado?.usuarioId === e.usuarioId
-                                ? "var(--azul-egm-light)" : "transparent",
-                            }}
-                            onClick={() => setEmpleadoSeleccionado(
-                              empleadoSeleccionado?.usuarioId === e.usuarioId ? null : e
-                            )}
-                            onMouseEnter={(el) => {
-                              if (empleadoSeleccionado?.usuarioId !== e.usuarioId)
-                                el.currentTarget.style.background = "var(--gris-superficie)";
-                            }}
-                            onMouseLeave={(el) => {
-                              if (empleadoSeleccionado?.usuarioId !== e.usuarioId)
-                                el.currentTarget.style.background = "transparent";
-                            }}
-                          >
-                            <td className="px-4 py-3">
-                              <div className="flex items-center gap-2.5">
-                                <div className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-semibold shrink-0"
-                                  style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                                  {getInitials(e.nombre, e.apellidos)}
-                                </div>
-                                <div>
-                                  <p className="text-xs font-medium" style={{ color: "var(--texto-primario)" }}>
-                                    {e.nombre} {e.apellidos}
-                                  </p>
-                                  <p className="text-[10px]" style={{ color: "var(--texto-muted)" }}>{e.email}</p>
-                                </div>
-                              </div>
-                            </td>
-                            <td className="px-4 py-3 text-xs" style={{ color: "var(--texto-secundario)" }}>
-                              {e.puestoTrabajo ?? "—"}
-                            </td>
-                            <td className="px-4 py-3">
-                              <span className="text-[10px] font-medium px-2 py-0.5 rounded-full"
-                                style={e.codigoRol === "ROLE_ADMIN_EMPRESA"
-                                  ? { background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }
-                                  : { background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                                {e.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Admin" : "Empleado"}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3 text-xs" style={{ color: "var(--texto-muted)" }}>
-                              {formatFecha(e.fechaRegistro)}
-                            </td>
-                            <td className="px-4 py-3">
-                              <span className="text-[10px] font-medium px-2 py-0.5 rounded-full"
-                                style={e.activo
-                                  ? { background: "var(--exito-light)", color: "var(--exito)" }
-                                  : { background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
-                                {e.activo ? "Activo" : "Inactivo"}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3 text-right">
-                              <button
-                                onClick={(ev) => { ev.stopPropagation(); handleDesactivarEmpleado(e.usuarioId); }}
-                                className="text-[11px] font-medium hover:underline"
-                                style={{ color: "var(--error)" }}>
-                                Desactivar
-                              </button>
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-
-                  {/* Vista móvil — tarjetas */}
-                  <div className="md:hidden flex flex-col divide-y"
-                    style={{ borderColor: "var(--gris-borde)" }}>
-                    {empleados.map((e) => (
-                      <div
-                        key={e.usuarioId}
-                        className="px-4 py-4 flex items-center justify-between gap-3 cursor-pointer"
-                        onClick={() => setEmpleadoSeleccionado(
-                          empleadoSeleccionado?.usuarioId === e.usuarioId ? null : e
-                        )}
-                        style={{
-                          background: empleadoSeleccionado?.usuarioId === e.usuarioId
-                            ? "var(--azul-egm-light)" : "transparent"
-                        }}
-                      >
-                        <div className="flex items-center gap-3 min-w-0">
-                          <div className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold shrink-0"
-                            style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                            {getInitials(e.nombre, e.apellidos)}
-                          </div>
-                          <div className="min-w-0">
-                            <p className="text-sm font-medium truncate" style={{ color: "var(--texto-primario)" }}>
-                              {e.nombre} {e.apellidos}
-                            </p>
-                            <p className="text-xs truncate" style={{ color: "var(--texto-muted)" }}>{e.email}</p>
-                            {e.puestoTrabajo && (
-                              <p className="text-xs mt-0.5" style={{ color: "var(--texto-secundario)" }}>
-                                {e.puestoTrabajo}
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                        <div className="flex flex-col items-end gap-1.5 shrink-0">
-                          <span className="text-[10px] font-medium px-2 py-0.5 rounded-full"
-                            style={e.codigoRol === "ROLE_ADMIN_EMPRESA"
-                              ? { background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }
-                              : { background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                            {e.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Admin" : "Empleado"}
-                          </span>
-                          <span className="text-[10px] font-medium px-2 py-0.5 rounded-full"
-                            style={e.activo
-                              ? { background: "var(--exito-light)", color: "var(--exito)" }
-                              : { background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
-                            {e.activo ? "Activo" : "Inactivo"}
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </>
-              )}
-            </div>
-
-            {/* Drawer desktop */}
-            {empleadoSeleccionado && (
-              <div className="hidden md:flex w-72 shrink-0 rounded-xl p-5 flex-col gap-4"
+            {/* Layout tabla + drawer */}
+            <div className="flex gap-6">
+              <div className="rounded-2xl overflow-hidden flex-1 min-w-0"
                 style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                {cargandoEmpleados ? (
+                  <div className="flex items-center justify-center py-20">
+                    <div className="w-6 h-6 border-2 rounded-full animate-spin"
+                      style={{ borderColor: "var(--gris-borde)", borderTopColor: "var(--azul-egm)" }} />
+                  </div>
+                ) : empleados.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-20 text-center">
+                    <div className="w-12 h-12 rounded-2xl flex items-center justify-center mb-4"
+                      style={{ background: "var(--gris-pagina)" }}>
+                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--texto-muted)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                        <circle cx="9" cy="7" r="4" />
+                      </svg>
+                    </div>
+                    <p className="text-sm font-medium" style={{ color: "var(--texto-primario)" }}>No hay empleados todavía</p>
+                    <p className="text-xs mt-1 mb-4" style={{ color: "var(--texto-muted)" }}>Añade el primer empleado a tu empresa</p>
+                    <button onClick={() => setShowFormEmpleado(true)}
+                      className="text-xs font-semibold px-4 py-2 rounded-xl"
+                      style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                      Añadir el primero →
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    {/* Vista desktop — tabla */}
+                    <div className="hidden md:block">
+                      <table className="w-full">
+                        <thead>
+                          <tr style={{ background: "var(--gris-pagina)", borderBottom: "1px solid var(--gris-borde)" }}>
+                            {["Empleado", "Puesto", "Rol", "Alta", "Estado"].map((h) => (
+                              <th key={h} className="text-left py-3.5 px-5 text-xs font-bold uppercase tracking-wider"
+                                style={{ color: "var(--texto-muted)" }}>{h}</th>
+                            ))}
+                            <th className="py-3.5 px-5" />
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {empleados.map((e, idx) => (
+                            <tr
+                              key={e.usuarioId}
+                              className="cursor-pointer transition-colors"
+                              style={{
+                                borderBottom: idx < empleados.length - 1 ? "1px solid var(--gris-borde)" : "none",
+                                background: empleadoSeleccionado?.usuarioId === e.usuarioId
+                                  ? "var(--azul-egm-light)" : "transparent",
+                              }}
+                              onClick={() => setEmpleadoSeleccionado(
+                                empleadoSeleccionado?.usuarioId === e.usuarioId ? null : e
+                              )}
+                              onMouseEnter={(el) => {
+                                if (empleadoSeleccionado?.usuarioId !== e.usuarioId)
+                                  el.currentTarget.style.background = "var(--gris-superficie)";
+                              }}
+                              onMouseLeave={(el) => {
+                                if (empleadoSeleccionado?.usuarioId !== e.usuarioId)
+                                  el.currentTarget.style.background = "transparent";
+                              }}
+                            >
+                              <td className="py-4 px-5">
+                                <div className="flex items-center gap-3">
+                                  <div className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold shrink-0"
+                                    style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                                    {getInitials(e.nombre, e.apellidos)}
+                                  </div>
+                                  <div>
+                                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
+                                      {e.nombre} {e.apellidos}
+                                    </p>
+                                    <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>{e.email}</p>
+                                  </div>
+                                </div>
+                              </td>
+                              <td className="py-4 px-5 text-sm" style={{ color: "var(--texto-secundario)" }}>
+                                {e.puestoTrabajo ?? "—"}
+                              </td>
+                              <td className="py-4 px-5">
+                                <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
+                                  style={e.codigoRol === "ROLE_ADMIN_EMPRESA"
+                                    ? { background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }
+                                    : { background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                                  {e.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Admin" : "Empleado"}
+                                </span>
+                              </td>
+                              <td className="py-4 px-5 text-sm" style={{ color: "var(--texto-muted)" }}>
+                                {formatFecha(e.fechaRegistro)}
+                              </td>
+                              <td className="py-4 px-5">
+                                <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
+                                  style={e.activo
+                                    ? { background: "var(--exito-light)", color: "var(--exito)" }
+                                    : { background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
+                                  {e.activo ? "Activo" : "Inactivo"}
+                                </span>
+                              </td>
+                              <td className="py-4 px-5 text-right">
+                                <button
+                                  onClick={(ev) => { ev.stopPropagation(); handleDesactivarEmpleado(e.usuarioId); }}
+                                  className="text-xs font-semibold hover:underline"
+                                  style={{ color: "var(--error)" }}>
+                                  Desactivar
+                                </button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+
+                    {/* Vista móvil — tarjetas */}
+                    <div className="md:hidden flex flex-col divide-y"
+                      style={{ borderColor: "var(--gris-borde)" }}>
+                      {empleados.map((e) => (
+                        <div
+                          key={e.usuarioId}
+                          className="px-5 py-4 flex items-center justify-between gap-3 cursor-pointer"
+                          onClick={() => setEmpleadoSeleccionado(
+                            empleadoSeleccionado?.usuarioId === e.usuarioId ? null : e
+                          )}
+                          style={{
+                            background: empleadoSeleccionado?.usuarioId === e.usuarioId
+                              ? "var(--azul-egm-light)" : "transparent"
+                          }}
+                        >
+                          <div className="flex items-center gap-3 min-w-0">
+                            <div className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold shrink-0"
+                              style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                              {getInitials(e.nombre, e.apellidos)}
+                            </div>
+                            <div className="min-w-0">
+                              <p className="text-sm font-semibold truncate" style={{ color: "var(--texto-primario)" }}>
+                                {e.nombre} {e.apellidos}
+                              </p>
+                              <p className="text-xs truncate" style={{ color: "var(--texto-muted)" }}>{e.email}</p>
+                              {e.puestoTrabajo && (
+                                <p className="text-xs mt-0.5" style={{ color: "var(--texto-secundario)" }}>
+                                  {e.puestoTrabajo}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex flex-col items-end gap-1.5 shrink-0">
+                            <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
+                              style={e.codigoRol === "ROLE_ADMIN_EMPRESA"
+                                ? { background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }
+                                : { background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                              {e.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Admin" : "Empleado"}
+                            </span>
+                            <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
+                              style={e.activo
+                                ? { background: "var(--exito-light)", color: "var(--exito)" }
+                                : { background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
+                              {e.activo ? "Activo" : "Inactivo"}
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </div>
+
+              {/* Drawer desktop */}
+              {empleadoSeleccionado && (
+                <div className="hidden md:flex w-80 shrink-0 rounded-2xl p-6 flex-col gap-5"
+                  style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-bold" style={{ color: "var(--texto-primario)" }}>Perfil del empleado</h3>
+                    <button onClick={() => setEmpleadoSeleccionado(null)}
+                      className="w-7 h-7 flex items-center justify-center rounded-lg text-lg leading-none transition-colors"
+                      style={{ color: "var(--texto-muted)", background: "var(--gris-pagina)" }}>×</button>
+                  </div>
+                  <div className="flex items-center gap-4 p-4 rounded-xl"
+                    style={{ background: "var(--gris-pagina)" }}>
+                    <div className="w-14 h-14 rounded-full flex items-center justify-center text-lg font-bold shrink-0"
+                      style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                      {getInitials(empleadoSeleccionado.nombre, empleadoSeleccionado.apellidos)}
+                    </div>
+                    <div>
+                      <p className="text-sm font-bold" style={{ color: "var(--texto-primario)" }}>
+                        {empleadoSeleccionado.nombre} {empleadoSeleccionado.apellidos}
+                      </p>
+                      <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>
+                        {empleadoSeleccionado.email}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-3 pt-1" style={{ borderTop: "1px solid var(--gris-borde)" }}>
+                    <DrawerRow label="Puesto" value={empleadoSeleccionado.puestoTrabajo ?? "—"} />
+                    <DrawerRow label="Rol" value={empleadoSeleccionado.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Administrador" : "Empleado"} />
+                    <DrawerRow label="Estado" value={empleadoSeleccionado.activo ? "Activo" : "Inactivo"} />
+                    <DrawerRow label="Alta" value={formatFecha(empleadoSeleccionado.fechaRegistro)} />
+                  </div>
+                  <div className="pt-1" style={{ borderTop: "1px solid var(--gris-borde)" }}>
+                    <button
+                      onClick={() => handleDesactivarEmpleado(empleadoSeleccionado.usuarioId)}
+                      className="w-full text-sm font-semibold py-2.5 rounded-xl transition-colors"
+                      style={{ background: "var(--error-light)", color: "var(--error)", border: "1px solid var(--error)" }}
+                    >
+                      Desactivar empleado
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Bottom sheet móvil */}
+            {empleadoSeleccionado && (
+              <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl p-6 flex flex-col gap-4"
+                style={{
+                  background: "var(--blanco)",
+                  border: "1px solid var(--gris-borde)",
+                  boxShadow: "0 -4px 24px rgba(0,0,0,0.12)"
+                }}>
                 <div className="flex items-center justify-between">
-                  <h3 className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>Perfil</h3>
+                  <h3 className="text-sm font-bold" style={{ color: "var(--texto-primario)" }}>Perfil del empleado</h3>
                   <button onClick={() => setEmpleadoSeleccionado(null)}
-                    className="text-lg leading-none" style={{ color: "var(--texto-muted)" }}>×</button>
+                    className="w-7 h-7 flex items-center justify-center rounded-lg text-lg leading-none"
+                    style={{ color: "var(--texto-muted)", background: "var(--gris-pagina)" }}>×</button>
                 </div>
                 <div className="flex items-center gap-3">
-                  <div className="w-12 h-12 rounded-full flex items-center justify-center text-base font-semibold shrink-0"
+                  <div className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold shrink-0"
                     style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
                     {getInitials(empleadoSeleccionado.nombre, empleadoSeleccionado.apellidos)}
                   </div>
                   <div>
-                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
+                    <p className="text-sm font-bold" style={{ color: "var(--texto-primario)" }}>
                       {empleadoSeleccionado.nombre} {empleadoSeleccionado.apellidos}
                     </p>
-                    <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>
-                      {empleadoSeleccionado.email}
-                    </p>
+                    <p className="text-xs" style={{ color: "var(--texto-muted)" }}>{empleadoSeleccionado.email}</p>
                   </div>
                 </div>
-                <div className="flex flex-col gap-3 pt-3" style={{ borderTop: "1px solid var(--gris-borde)" }}>
+                <div className="flex flex-col gap-3" style={{ borderTop: "1px solid var(--gris-borde)", paddingTop: "12px" }}>
                   <DrawerRow label="Puesto" value={empleadoSeleccionado.puestoTrabajo ?? "—"} />
                   <DrawerRow label="Rol" value={empleadoSeleccionado.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Administrador" : "Empleado"} />
                   <DrawerRow label="Estado" value={empleadoSeleccionado.activo ? "Activo" : "Inactivo"} />
-                  <DrawerRow label="Alta" value={formatFecha(empleadoSeleccionado.fechaRegistro)} />
                 </div>
-                <div className="flex flex-col gap-2 pt-3" style={{ borderTop: "1px solid var(--gris-borde)" }}>
-                  <button
-                    onClick={() => handleDesactivarEmpleado(empleadoSeleccionado.usuarioId)}
-                    className="w-full text-sm font-medium py-2 rounded-lg transition-colors"
-                    style={{ background: "var(--error-light)", color: "var(--error)" }}
-                  >
-                    Desactivar empleado
-                  </button>
-                </div>
+                <button
+                  onClick={() => handleDesactivarEmpleado(empleadoSeleccionado.usuarioId)}
+                  className="w-full text-sm font-semibold py-3 rounded-xl"
+                  style={{ background: "var(--error-light)", color: "var(--error)", border: "1px solid var(--error)" }}>
+                  Desactivar empleado
+                </button>
               </div>
             )}
           </div>
+        )}
 
-          {/* Bottom sheet móvil */}
-          {empleadoSeleccionado && (
-            <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl p-5 flex flex-col gap-4"
-              style={{
-                background: "var(--blanco)",
-                border: "1px solid var(--gris-borde)",
-                boxShadow: "0 -4px 24px rgba(0,0,0,0.12)"
-              }}>
-              <div className="flex items-center justify-between">
-                <h3 className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>Perfil</h3>
-                <button onClick={() => setEmpleadoSeleccionado(null)}
-                  className="text-lg leading-none" style={{ color: "var(--texto-muted)" }}>×</button>
-              </div>
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold shrink-0"
-                  style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                  {getInitials(empleadoSeleccionado.nombre, empleadoSeleccionado.apellidos)}
-                </div>
-                <div>
-                  <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
-                    {empleadoSeleccionado.nombre} {empleadoSeleccionado.apellidos}
-                  </p>
-                  <p className="text-xs" style={{ color: "var(--texto-muted)" }}>{empleadoSeleccionado.email}</p>
-                </div>
-              </div>
-              <div className="flex flex-col gap-2" style={{ borderTop: "1px solid var(--gris-borde)", paddingTop: "12px" }}>
-                <DrawerRow label="Puesto" value={empleadoSeleccionado.puestoTrabajo ?? "—"} />
-                <DrawerRow label="Rol" value={empleadoSeleccionado.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Administrador" : "Empleado"} />
-                <DrawerRow label="Estado" value={empleadoSeleccionado.activo ? "Activo" : "Inactivo"} />
+        {/* ── TAB ANUNCIOS ── */}
+        {activeTab === "anuncios" && (
+          <>
+            {/* Header */}
+            <div className="flex items-start justify-between mb-8">
+              <div>
+                <h1 className="text-2xl font-bold" style={{ color: "var(--texto-primario)" }}>Gestión de Anuncios</h1>
+                <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>Comunica novedades a todos los empleados</p>
               </div>
               <button
-                onClick={() => handleDesactivarEmpleado(empleadoSeleccionado.usuarioId)}
-                className="w-full text-sm font-medium py-2.5 rounded-lg"
-                style={{ background: "var(--error-light)", color: "var(--error)" }}>
-                Desactivar empleado
+                onClick={() => { resetFormAnuncio(); setShowFormAnuncio(true); }}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors"
+                style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
+                onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+                Nuevo anuncio
               </button>
             </div>
-          )}
-        </div>
-      )}
 
-      {/* ── TAB ANUNCIOS ── */}
-      {activeTab === "anuncios" && (
-        <>
-          <div className="flex items-start justify-between mb-6">
-            <div>
-              <h1 className="text-xl font-semibold" style={{ color: "var(--texto-primario)" }}>Gestión de Anuncios</h1>
-              <p className="text-sm mt-0.5" style={{ color: "var(--texto-muted)" }}>Comunica novedades a todos los empleados</p>
-            </div>
-            <button
-              onClick={() => { resetFormAnuncio(); setShowFormAnuncio(true); }}
-              className="text-sm font-medium px-4 py-2 rounded-lg transition-colors"
-              style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
-              onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
-            >
-              + Nuevo anuncio
-            </button>
-          </div>
-
-          {showFormAnuncio && (
-            <div className="rounded-xl p-6 mb-6"
-              style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
-                  {editingAnuncioId ? "Editar anuncio" : "Crear anuncio"}
-                </h2>
-                <button onClick={resetFormAnuncio} className="text-lg leading-none"
-                  style={{ color: "var(--texto-muted)" }}>×</button>
-              </div>
-              <div className="flex flex-col gap-4">
-                <div>
-                  <label className="block text-xs font-medium mb-1.5" style={{ color: "var(--texto-secundario)" }}>
-                    Título <span style={{ color: "var(--error)" }}>*</span>
-                  </label>
-                  <input type="text" value={formAnuncio.titulo}
-                    onChange={(e) => setFormAnuncio({ ...formAnuncio, titulo: e.target.value })}
-                    placeholder="Ej: Actualización del protocolo de acceso"
-                    className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
-                    style={{ border: "1px solid var(--gris-borde)", background: "var(--blanco)", color: "var(--texto-primario)" }} />
+            {/* Formulario anuncio */}
+            {showFormAnuncio && (
+              <div className="rounded-2xl p-6 mb-8"
+                style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                <div className="flex items-center justify-between mb-6">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-xl flex items-center justify-center"
+                      style={{ background: "var(--azul-egm-light)" }}>
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--azul-egm)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M3 11l19-9-9 19-2-8-8-2z" />
+                      </svg>
+                    </div>
+                    <h2 className="text-base font-bold" style={{ color: "var(--texto-primario)" }}>
+                      {editingAnuncioId ? "Editar anuncio" : "Crear anuncio"}
+                    </h2>
+                  </div>
+                  <button onClick={resetFormAnuncio}
+                    className="w-7 h-7 flex items-center justify-center rounded-lg text-lg leading-none"
+                    style={{ color: "var(--texto-muted)", background: "var(--gris-pagina)" }}>×</button>
                 </div>
-                <div>
-                  <label className="block text-xs font-medium mb-1.5" style={{ color: "var(--texto-secundario)" }}>
-                    Contenido <span style={{ color: "var(--error)" }}>*</span>
-                  </label>
-                  <textarea value={formAnuncio.contenido}
-                    onChange={(e) => setFormAnuncio({ ...formAnuncio, contenido: e.target.value })}
-                    rows={4} placeholder="Escribe el contenido del anuncio..."
-                    className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none resize-none"
-                    style={{ border: "1px solid var(--gris-borde)", background: "var(--blanco)", color: "var(--texto-primario)" }} />
-                </div>
-                <div className="flex items-center gap-3">
-                  <button type="button"
-                    onClick={() => setFormAnuncio({ ...formAnuncio, esGlobal: !formAnuncio.esGlobal })}
-                    className="relative w-9 h-5 rounded-full transition-colors"
-                    style={{ background: formAnuncio.esGlobal ? "var(--azul-egm)" : "var(--gris-superficie)" }}>
-                    <span className="absolute top-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-all"
-                      style={{ left: formAnuncio.esGlobal ? "calc(100% - 18px)" : "2px" }} />
-                  </button>
-                  <label className="text-xs" style={{ color: "var(--texto-secundario)" }}>Visible para todos (global)</label>
-                </div>
-                <div className="flex gap-2 justify-end pt-2" style={{ borderTop: "1px solid var(--gris-superficie)" }}>
-                  <button onClick={resetFormAnuncio} className="text-sm px-4 py-2 rounded-lg"
-                    style={{ color: "var(--texto-secundario)" }}>Cancelar</button>
-                  <button onClick={handleSaveAnuncio}
-                    className="text-sm font-medium px-4 py-2 rounded-lg transition-colors"
-                    style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
-                    onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
-                    onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}>
-                    {editingAnuncioId ? "Guardar cambios" : "Publicar anuncio"}
-                  </button>
+                <div className="flex flex-col gap-4">
+                  <div>
+                    <label className="block text-xs font-semibold mb-2" style={{ color: "var(--texto-secundario)" }}>
+                      Título <span style={{ color: "var(--error)" }}>*</span>
+                    </label>
+                    <input type="text" value={formAnuncio.titulo}
+                      onChange={(e) => setFormAnuncio({ ...formAnuncio, titulo: e.target.value })}
+                      placeholder="Ej: Actualización del protocolo de acceso"
+                      className="w-full rounded-xl px-4 py-3 text-sm focus:outline-none"
+                      style={{ border: "1px solid var(--gris-borde)", background: "var(--gris-pagina)", color: "var(--texto-primario)" }} />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-semibold mb-2" style={{ color: "var(--texto-secundario)" }}>
+                      Contenido <span style={{ color: "var(--error)" }}>*</span>
+                    </label>
+                    <textarea value={formAnuncio.contenido}
+                      onChange={(e) => setFormAnuncio({ ...formAnuncio, contenido: e.target.value })}
+                      rows={5} placeholder="Escribe el contenido del anuncio..."
+                      className="w-full rounded-xl px-4 py-3 text-sm focus:outline-none resize-none"
+                      style={{ border: "1px solid var(--gris-borde)", background: "var(--gris-pagina)", color: "var(--texto-primario)" }} />
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <button type="button"
+                      onClick={() => setFormAnuncio({ ...formAnuncio, esGlobal: !formAnuncio.esGlobal })}
+                      className="relative w-9 h-5 rounded-full transition-colors shrink-0"
+                      style={{ background: formAnuncio.esGlobal ? "var(--azul-egm)" : "var(--gris-superficie)" }}>
+                      <span className="absolute top-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-all"
+                        style={{ left: formAnuncio.esGlobal ? "calc(100% - 18px)" : "2px" }} />
+                    </button>
+                    <label className="text-sm font-medium" style={{ color: "var(--texto-secundario)" }}>Visible para todos (global)</label>
+                  </div>
+                  <div className="flex gap-3 justify-end pt-4" style={{ borderTop: "1px solid var(--gris-borde)" }}>
+                    <button onClick={resetFormAnuncio}
+                      className="text-sm font-medium px-5 py-2.5 rounded-xl"
+                      style={{ color: "var(--texto-secundario)", background: "var(--gris-pagina)", border: "1px solid var(--gris-borde)" }}>
+                      Cancelar
+                    </button>
+                    <button onClick={handleSaveAnuncio}
+                      className="text-sm font-semibold px-5 py-2.5 rounded-xl transition-colors"
+                      style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
+                      onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
+                      onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}>
+                      {editingAnuncioId ? "Guardar cambios" : "Publicar anuncio"}
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          )}
+            )}
 
-          <div className="rounded-xl p-6" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-            <h2 className="text-sm font-semibold mb-5" style={{ color: "var(--texto-primario)" }}>Anuncios publicados</h2>
+            {/* Lista de anuncios */}
             {noticias.filter((n) => n.activo).length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-12 text-center">
-                <p className="text-sm" style={{ color: "var(--texto-muted)" }}>No hay anuncios publicados todavía</p>
+              <div className="rounded-2xl flex flex-col items-center justify-center py-20 text-center"
+                style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                <div className="w-14 h-14 rounded-2xl flex items-center justify-center mb-4"
+                  style={{ background: "var(--gris-pagina)" }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--texto-muted)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M3 11l19-9-9 19-2-8-8-2z" />
+                  </svg>
+                </div>
+                <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>No hay anuncios publicados todavía</p>
+                <p className="text-xs mt-1 mb-4" style={{ color: "var(--texto-muted)" }}>Crea tu primer anuncio para comunicar novedades</p>
                 <button onClick={() => { resetFormAnuncio(); setShowFormAnuncio(true); }}
-                  className="mt-2 text-xs font-medium hover:underline" style={{ color: "var(--azul-egm)" }}>
+                  className="text-xs font-semibold px-4 py-2 rounded-xl"
+                  style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
                   Crear el primero →
                 </button>
               </div>
             ) : (
-              <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-4">
                 {noticias.filter((n) => n.activo).map((n) => (
-                  <div key={n.anuncioId} className="flex items-start justify-between rounded-lg px-4 py-3"
-                    style={{ border: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
+                  <div key={n.anuncioId}
+                    className="rounded-2xl px-5 py-4"
+                    style={{
+                      background: "var(--blanco)",
+                      border: "1px solid var(--gris-borde)",
+                      borderLeft: `4px solid ${n.esGlobal ? "var(--verde-oliva)" : "var(--azul-egm)"}`,
+                    }}>
+                    <p className="text-base font-semibold" style={{ color: "var(--texto-primario)" }}>{n.titulo}</p>
+                    <p className="text-sm mt-1 line-clamp-2" style={{ color: "var(--texto-secundario)" }}>{n.contenido}</p>
+                    <div className="flex items-center justify-between mt-3 pt-3"
+                      style={{ borderTop: "1px solid var(--gris-borde)" }}>
+                      <div className="flex items-center gap-2">
                         {n.esGlobal && (
-                          <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
-                            style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                          <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
+                            style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}>
                             Global
                           </span>
                         )}
+                        <span className="text-xs" style={{ color: "var(--texto-muted)" }}>
+                          {formatFecha(n.creadoEn)}
+                        </span>
                       </div>
-                      <p className="text-xs font-medium" style={{ color: "var(--texto-primario)" }}>{n.titulo}</p>
-                      <p className="text-[11px] mt-0.5 line-clamp-1" style={{ color: "var(--texto-muted)" }}>{n.contenido}</p>
-                    </div>
-                    <div className="flex items-center gap-3 ml-4 shrink-0">
-                      <button onClick={() => handleEditAnuncio(n)}
-                        className="text-[11px] font-medium hover:underline" style={{ color: "var(--azul-egm)" }}>
-                        Editar
-                      </button>
-                      <button onClick={() => handleDeleteAnuncio(n.anuncioId)}
-                        className="text-[11px] font-medium hover:underline" style={{ color: "var(--error)" }}>
-                        Desactivar
-                      </button>
+                      <div className="flex items-center gap-4">
+                        <button onClick={() => handleEditAnuncio(n)}
+                          className="text-xs font-semibold hover:underline" style={{ color: "var(--azul-egm)" }}>
+                          Editar
+                        </button>
+                        <button onClick={() => handleDeleteAnuncio(n.anuncioId)}
+                          className="text-xs font-semibold hover:underline" style={{ color: "var(--error)" }}>
+                          Desactivar
+                        </button>
+                      </div>
                     </div>
                   </div>
                 ))}
               </div>
             )}
-          </div>
-        </>
-      )}
+          </>
+        )}
 
-      {/* ── TAB MÓDULOS FORMATIVOS ── */}
-      {activeTab === "formaciones" && (
-        <>
-          <div className="flex items-start justify-between mb-6">
-            <div>
-              <h1 className="text-xl font-semibold" style={{ color: "var(--texto-primario)" }}>Gestión de Módulos</h1>
-              <p className="text-sm mt-0.5" style={{ color: "var(--texto-muted)" }}>Administra los módulos formativos de tu empresa</p>
+        {/* ── TAB MÓDULOS FORMATIVOS ── */}
+        {activeTab === "formaciones" && (
+          <>
+            {/* Header */}
+            <div className="flex items-start justify-between mb-8">
+              <div>
+                <h1 className="text-2xl font-bold" style={{ color: "var(--texto-primario)" }}>Gestión de Módulos</h1>
+                <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>Administra los módulos formativos de tu empresa</p>
+              </div>
+              <button
+                onClick={() => router.push("/dashboard/admin/modulos/crear")}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors"
+                style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
+                onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+                Nuevo módulo
+              </button>
             </div>
-            <button
-              onClick={() => router.push("/dashboard/admin/modulos/crear")}
-              className="text-sm font-medium px-4 py-2 rounded-lg transition-colors"
-              style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
-              onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
-            >
-              + Nuevo módulo
-            </button>
-          </div>
 
-          {showFormModulo && (
-            <div className="mb-6">
-              <ModuloForm
-                editando={editingModulo}
-                empresaId={usuario?.empresaId}
-                onSave={() => { resetFormModulo(); refreshData(); }}
-                onCancel={resetFormModulo}
-              />
-            </div>
-          )}
+            {/* ModuloForm */}
+            {showFormModulo && (
+              <div className="mb-8">
+                <ModuloForm
+                  editando={editingModulo}
+                  empresaId={usuario?.empresaId}
+                  onSave={() => { resetFormModulo(); refreshData(); }}
+                  onCancel={resetFormModulo}
+                />
+              </div>
+            )}
 
-          <div className="rounded-xl p-6" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-            <h2 className="text-sm font-semibold mb-5" style={{ color: "var(--texto-primario)" }}>Módulos activos</h2>
+            {/* Grid de módulos */}
             {formaciones.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-12 text-center">
-                <p className="text-sm" style={{ color: "var(--texto-muted)" }}>No hay módulos creados todavía</p>
+              <div className="rounded-2xl flex flex-col items-center justify-center py-20 text-center mb-6"
+                style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                <div className="w-14 h-14 rounded-2xl flex items-center justify-center mb-4"
+                  style={{ background: "var(--gris-pagina)" }}>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--texto-muted)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+                    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+                  </svg>
+                </div>
+                <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>No hay módulos creados todavía</p>
+                <p className="text-xs mt-1 mb-4" style={{ color: "var(--texto-muted)" }}>Crea el primer módulo formativo para tus empleados</p>
                 <button onClick={() => { resetFormModulo(); setShowFormModulo(true); }}
-                  className="mt-2 text-xs font-medium hover:underline" style={{ color: "var(--azul-egm)" }}>
+                  className="text-xs font-semibold px-4 py-2 rounded-xl"
+                  style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
                   Crear el primero →
                 </button>
               </div>
             ) : (
-              <div className="flex flex-col gap-3">
-                {formaciones.map((f) => (
-                  <div key={f.moduloId} className="flex items-start justify-between rounded-lg px-4 py-3"
-                    style={{ border: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1.5">
-                        <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+                {formaciones.map((f) => {
+                  const accentColor = tipoAccentColor[f.tipoModulo] ?? "var(--azul-egm)";
+                  return (
+                    <div
+                      key={f.moduloId}
+                      className="rounded-2xl p-5 flex flex-col transition-shadow"
+                      style={{
+                        background: "var(--blanco)",
+                        border: "1px solid var(--gris-borde)",
+                        borderTop: `3px solid ${accentColor}`,
+                      }}
+                      onMouseEnter={(e) => (e.currentTarget.style.boxShadow = "0 4px 16px rgba(0,0,0,0.08)")}
+                      onMouseLeave={(e) => (e.currentTarget.style.boxShadow = "none")}
+                    >
+                      {/* Badges */}
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
                           style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
                           {MODULO_TIPO_LABEL[f.tipoModulo] ?? f.tipoModulo}
                         </span>
                         {f.empresaId === null ? (
-                          <span className="text-[10px] px-2 py-0.5 rounded-full italic"
+                          <span className="text-xs px-2.5 py-1 rounded-full italic"
                             style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
                             EGM Global
                           </span>
                         ) : (
-                          <span className="text-[10px] px-2 py-0.5 rounded-full"
+                          <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
                             style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}>
                             Tu empresa
                           </span>
                         )}
                       </div>
-                      <p className="text-xs font-medium" style={{ color: "var(--texto-primario)" }}>{f.nombre}</p>
-                      <p className="text-[11px] mt-0.5 line-clamp-1" style={{ color: "var(--texto-muted)" }}>{f.descripcion}</p>
+
+                      {/* Title + description */}
+                      <p className="text-base font-semibold mt-3 mb-1" style={{ color: "var(--texto-primario)" }}>
+                        {f.nombre}
+                      </p>
+                      <p className="text-sm line-clamp-2 flex-1" style={{ color: "var(--texto-muted)" }}>
+                        {f.descripcion}
+                      </p>
+
+                      {/* Actions */}
+                      <div className="flex items-center justify-end gap-3 mt-4 pt-3"
+                        style={{ borderTop: "1px solid var(--gris-borde)" }}>
+                        {f.empresaId !== null ? (
+                          <>
+                            <button onClick={() => handleEditModulo(f)}
+                              className="text-xs font-semibold hover:underline" style={{ color: "var(--azul-egm)" }}>
+                              Editar
+                            </button>
+                            <button onClick={() => handleDeleteModulo(f.moduloId)}
+                              className="text-xs font-semibold hover:underline" style={{ color: "var(--error)" }}>
+                              Desactivar
+                            </button>
+                          </>
+                        ) : (
+                          <span className="text-xs font-medium px-2.5 py-1 rounded-lg"
+                            style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)", border: "1px solid var(--gris-borde)" }}>
+                            Solo lectura
+                          </span>
+                        )}
+                      </div>
                     </div>
-                    <div className="flex items-center gap-3 ml-4 shrink-0">
-                      {f.empresaId !== null ? (
-                        <>
-                          <button onClick={() => handleEditModulo(f)}
-                            className="text-[11px] font-medium hover:underline" style={{ color: "var(--azul-egm)" }}>
-                            Editar
-                          </button>
-                          <button onClick={() => handleDeleteModulo(f.moduloId)}
-                            className="text-[11px] font-medium hover:underline" style={{ color: "var(--error)" }}>
-                            Desactivar
-                          </button>
-                        </>
-                      ) : (
-                        <span className="text-[10px] px-2 py-0.5 rounded"
-                          style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)", border: "1px solid var(--gris-borde)" }}>
-                          Solo lectura
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
-          </div>
 
-          <div className="rounded-xl p-6 mt-6" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-            <h2 className="text-sm font-semibold mb-4" style={{ color: "var(--texto-primario)" }}>Seguimiento de empleados</h2>
-            <div className="flex flex-col items-center justify-center py-10 text-center">
-              <p className="text-sm" style={{ color: "var(--texto-muted)" }}>Próximamente — progreso por empleado</p>
+            {/* Seguimiento de empleados */}
+            <div className="rounded-2xl p-8"
+              style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+              <div className="flex flex-col items-center justify-center text-center py-6">
+                <div className="w-16 h-16 rounded-2xl flex items-center justify-center mb-5"
+                  style={{ background: "var(--azul-egm-light)" }}>
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--azul-egm)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                    <circle cx="9" cy="7" r="4" />
+                    <polyline points="22 12 18 12 20 9 18 6" />
+                    <line x1="22" y1="12" x2="16" y2="12" />
+                  </svg>
+                </div>
+                <div className="flex items-center gap-2 mb-3">
+                  <h2 className="text-lg font-bold" style={{ color: "var(--texto-primario)" }}>Seguimiento de empleados</h2>
+                  <span className="text-xs font-bold px-3 py-1 rounded-full"
+                    style={{ background: "var(--azul-egm)", color: "white", letterSpacing: "0.05em" }}>
+                    PRÓXIMAMENTE
+                  </span>
+                </div>
+                <p className="text-sm max-w-sm" style={{ color: "var(--texto-muted)" }}>
+                  Pronto podrás consultar el progreso individual de cada empleado en sus módulos formativos.
+                </p>
+              </div>
             </div>
-          </div>
-        </>
-      )}
+          </>
+        )}
+      </div>
     </>
   );
 }

--- a/components/pages/AdminEmpresa.tsx
+++ b/components/pages/AdminEmpresa.tsx
@@ -6,25 +6,42 @@ import { useAuth } from "@/context/AuthContext";
 import { apiFetch, API_URL } from "@/lib/api";
 
 interface ResumenAdmin {
-  nombreEmpresa:    string;
-  usuariosActivos:  number;
+  nombreEmpresa:     string;
+  usuariosActivos:   number;
   usuariosInactivos: number;
 }
 
 interface Anuncio {
-  anuncioId:    string;
-  empresaId:    string;
-  titulo:       string;
-  contenido:    string;
-  esGlobal:     boolean;
-  activo:       boolean;
-  creadoPor:    string;
-  creadoEn:     string;
+  anuncioId:     string;
+  empresaId:     string;
+  titulo:        string;
+  contenido:     string;
+  esGlobal:      boolean;
+  activo:        boolean;
+  creadoPor:     string;
+  creadoEn:      string;
   actualizadoEn: string;
 }
 
 function formatFecha(iso: string) {
   return new Date(iso).toLocaleDateString("es-ES", { day: "numeric", month: "short" });
+}
+
+function TituloSeccion({ children, noMargin }: { children: React.ReactNode; noMargin?: boolean }) {
+  return (
+    <h2
+      className={noMargin ? "" : "mb-6"}
+      style={{
+        fontSize:      "clamp(2rem, 2.8vw, 2.8rem)",
+        fontFamily:    "'Instrument Serif', serif",
+        fontWeight:    400,
+        color:         "var(--texto-primario)",
+        letterSpacing: "-0.02em",
+      }}
+    >
+      {children}
+    </h2>
+  );
 }
 
 export default function AdminEmpresa() {
@@ -56,337 +73,657 @@ export default function AdminEmpresa() {
   if (cargando) {
     return (
       <div className="flex items-center justify-center py-32">
-        <div className="w-6 h-6 border-2 rounded-full animate-spin"
-          style={{ borderColor: "var(--gris-borde)", borderTopColor: "var(--azul-egm)" }} />
+        <div
+          className="w-6 h-6 border-2 rounded-full animate-spin"
+          style={{ borderColor: "var(--gris-borde)", borderTopColor: "var(--azul-egm)" }}
+        />
       </div>
     );
   }
 
   const nombreEmpresa = resumen?.nombreEmpresa ?? usuario?.nombreEmpresa ?? "Mi empresa";
+  const firstName     = (usuario?.nombre ?? "Administrador").split(" ")[0];
+  const fechaHoy      = new Date().toLocaleDateString("es-ES", {
+    day: "numeric", month: "long", year: "numeric",
+  });
 
   return (
     <div>
-      {/* ── BANDA DE BIENVENIDA ── */}
+      {/* ── KEYFRAMES ── */}
+      <style>{`
+        @keyframes heroFadeUp {
+          from { opacity: 0; transform: translateY(22px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes gradientShift {
+          0%   { background-position: 0% 50%; }
+          50%  { background-position: 100% 50%; }
+          100% { background-position: 0% 50%; }
+        }
+      `}</style>
+
+      {/* ══════════════════════════════════════════
+          HERO
+      ══════════════════════════════════════════ */}
       <div
-        className="-mx-8 -mt-8 px-8 pt-10 pb-8 mb-8"
-        style={{ background: "var(--marino)" }}
+        className="-mx-8 -mt-8 mb-0 relative overflow-hidden"
+        style={{ minHeight: "340px" }}
       >
-        {/* Saludo */}
-        <div className="max-w-7xl mx-auto">
-          <p className="text-xs font-semibold uppercase tracking-widest mb-1"
-            style={{ color: "var(--verde-oliva-hover)" }}>
-            Panel de administración
-          </p>
-          <h1 className="text-2xl sm:text-3xl font-bold text-white mb-1">
-            Hola, {usuario?.nombre ?? "Administrador"}
-          </h1>
-          <p className="text-sm mb-8" style={{ color: "rgba(255,255,255,0.5)" }}>
-            {nombreEmpresa} · {new Date().toLocaleDateString("es-ES", { day: "numeric", month: "long", year: "numeric" })}
+        {/* Background image */}
+        <div
+          style={{
+            position:           "absolute",
+            inset:              0,
+            backgroundImage:    "url('/background-dashboard.jpg')",
+            backgroundSize:     "cover",
+            backgroundPosition: "center",
+          }}
+        />
+        {/* Dark overlays */}
+        <div style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.52)" }} />
+        <div
+          style={{
+            position:   "absolute",
+            inset:      0,
+            background: "linear-gradient(135deg, rgba(10,20,40,0.55) 0%, rgba(0,0,0,0.2) 100%)",
+          }}
+        />
+
+        {/* Hero content */}
+        <div
+          className="relative z-10 px-10 lg:px-16 flex flex-col justify-center"
+          style={{ minHeight: "340px", paddingTop: "3.5rem", paddingBottom: "3.5rem" }}
+        >
+          {/* Top line: empresa · fecha */}
+          <p
+            className="text-xs font-bold uppercase tracking-widest mb-4"
+            style={{
+              color:     "var(--verde-oliva-hover)",
+              animation: "heroFadeUp 0.6s ease both",
+            }}
+          >
+            {nombreEmpresa} · {fechaHoy}
           </p>
 
-          {/* Métricas */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <MetricCard
-              label="Empleados activos"
-              value={resumen?.usuariosActivos ?? "—"}
-              acento="azul"
-              onClick={() => router.push("/dashboard/admin?tab=empleados")}
-            />
-            <MetricCard
-              label="Empleados inactivos"
-              value={resumen?.usuariosInactivos ?? "—"}
-              acento="gris"
-              onClick={() => router.push("/dashboard/admin?tab=empleados")}
-            />
-            <MetricCard
-              label="Progreso medio"
-              value="—"
-              nota="Próximamente"
-              acento="verde"
-            />
-            <MetricCard
-              label="Módulos activos"
-              value="—"
-              nota="Próximamente"
-              acento="naranja"
-            />
+          {/* Title */}
+          <div
+            style={{
+              display:       "flex",
+              flexWrap:      "wrap",
+              alignItems:    "baseline",
+              gap:           "0.4em",
+              animation:     "heroFadeUp 0.7s ease both",
+              animationDelay: "0.08s",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "'Poppins', sans-serif",
+                fontWeight: 300,
+                fontSize:   "clamp(3.5rem, 7vw, 4.5rem)",
+                color:      "#ffffff",
+                lineHeight: 1.1,
+              }}
+            >
+              Hola,
+            </span>
+            <span
+              style={{
+                fontFamily:              "'Instrument Serif', serif",
+                fontStyle:               "italic",
+                fontWeight:              400,
+                fontSize:                "clamp(3.5rem, 7vw, 6rem)",
+                lineHeight:              1.05,
+                background:              "linear-gradient(90deg, #A3B535, #ffffff, #A3B535)",
+                backgroundSize:          "300% auto",
+                WebkitBackgroundClip:    "text",
+                WebkitTextFillColor:     "transparent",
+                backgroundClip:          "text",
+                animation:               "heroFadeUp 0.7s ease both, gradientShift 6s ease infinite",
+                animationDelay:          "0.12s, 0s",
+              }}
+            >
+              {firstName}
+            </span>
           </div>
+
+          {/* Subtitle */}
+          <p
+            className="text-sm mt-3"
+            style={{
+              color:          "rgba(255,255,255,0.55)",
+              animation:      "heroFadeUp 0.7s ease both",
+              animationDelay: "0.2s",
+            }}
+          >
+            Panel de administración · {nombreEmpresa}
+          </p>
         </div>
       </div>
 
-      {/* ── ACCIONES RÁPIDAS ── */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
-        <AccionCard
-          titulo="Añadir empleado"
-          descripcion="Registra un nuevo miembro del equipo"
-          acento="azul"
-          icono={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
-            </svg>
-          }
-          onClick={() => router.push("/dashboard/admin?tab=empleados")}
-        />
-        <AccionCard
-          titulo="Nuevo módulo"
-          descripcion="Crea contenido formativo para tu equipo"
-          acento="verde"
-          icono={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-            </svg>
-          }
-          onClick={() => router.push("/dashboard/admin/modulos/crear")}
-        />
-        <AccionCard
-          titulo="Nuevo anuncio"
-          descripcion="Comunica algo importante a tu equipo"
-          acento="naranja"
-          icono={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
-            </svg>
-          }
-          onClick={() => router.push("/dashboard/admin?tab=anuncios")}
-        />
-      </div>
+      {/* ══════════════════════════════════════════
+          CONTENT AREA
+      ══════════════════════════════════════════ */}
+      <div className="px-10 lg:px-16 pt-14 pb-16 flex flex-col gap-16">
 
-      {/* ── GRID PRINCIPAL ── */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+        {/* ── SECCIÓN 1: MÉTRICAS ── */}
+        <section>
+          <TituloSeccion>Resumen</TituloSeccion>
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
 
-        {/* Últimos anuncios */}
-        <div className="lg:col-span-2 rounded-xl p-6"
-          style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
-              Últimos anuncios
-            </h2>
+            {/* Empleados activos */}
             <button
-              onClick={() => router.push("/dashboard/admin?tab=anuncios")}
-              className="text-xs font-medium hover:underline"
-              style={{ color: "var(--azul-egm)" }}
+              onClick={() => router.push("/dashboard/admin?tab=empleados")}
+              className="text-left rounded-2xl px-6 py-5 transition-all group"
+              style={{
+                background:   "var(--blanco)",
+                border:       "1px solid var(--gris-borde)",
+                position:     "relative",
+                overflow:     "hidden",
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.boxShadow  = "0 6px 24px rgba(0,0,0,0.08)";
+                e.currentTarget.style.transform  = "translateY(-2px)";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.boxShadow  = "none";
+                e.currentTarget.style.transform  = "translateY(0)";
+              }}
             >
-              Ver todos →
+              {/* Top accent strip */}
+              <div
+                style={{
+                  position:   "absolute",
+                  top:        0,
+                  left:       0,
+                  right:      0,
+                  height:     "3px",
+                  background: "var(--azul-egm)",
+                }}
+              />
+              <p
+                className="text-4xl font-bold mt-1"
+                style={{ color: "var(--azul-egm)" }}
+              >
+                {resumen?.usuariosActivos ?? "—"}
+              </p>
+              <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
+                Empleados activos
+              </p>
             </button>
-          </div>
 
-          {anuncios.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center rounded-lg"
-              style={{ background: "var(--gris-pagina)", border: "1px dashed var(--gris-borde)" }}>
-              <div className="w-10 h-10 rounded-full flex items-center justify-center mb-3"
-                style={{ background: "var(--azul-egm-light)" }}>
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}
-                  style={{ color: "var(--azul-egm)" }}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+            {/* Empleados inactivos */}
+            <button
+              onClick={() => router.push("/dashboard/admin?tab=empleados")}
+              className="text-left rounded-2xl px-6 py-5 transition-all"
+              style={{
+                background: "var(--blanco)",
+                border:     "1px solid var(--gris-borde)",
+                position:   "relative",
+                overflow:   "hidden",
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.boxShadow = "0 6px 24px rgba(0,0,0,0.08)";
+                e.currentTarget.style.transform = "translateY(-2px)";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.boxShadow = "none";
+                e.currentTarget.style.transform = "translateY(0)";
+              }}
+            >
+              <div
+                style={{
+                  position:   "absolute",
+                  top:        0,
+                  left:       0,
+                  right:      0,
+                  height:     "3px",
+                  background: "var(--texto-muted)",
+                  opacity:    0.4,
+                }}
+              />
+              <p
+                className="text-4xl font-bold mt-1"
+                style={{ color: "var(--texto-muted)" }}
+              >
+                {resumen?.usuariosInactivos ?? "—"}
+              </p>
+              <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
+                Empleados inactivos
+              </p>
+            </button>
+
+            {/* Progreso medio */}
+            <div
+              className="rounded-2xl px-6 py-5"
+              style={{
+                background: "var(--blanco)",
+                border:     "1px solid var(--gris-borde)",
+                position:   "relative",
+                overflow:   "hidden",
+              }}
+            >
+              <div
+                style={{
+                  position:   "absolute",
+                  top:        0,
+                  left:       0,
+                  right:      0,
+                  height:     "3px",
+                  background: "var(--verde-oliva)",
+                }}
+              />
+              <p
+                className="text-4xl font-bold mt-1"
+                style={{ color: "var(--verde-oliva)" }}
+              >
+                —
+              </p>
+              <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
+                Progreso medio
+              </p>
+              <span
+                className="inline-block text-xs px-2 py-0.5 rounded-full mt-2"
+                style={{
+                  background: "var(--verde-oliva-light)",
+                  color:      "var(--verde-oliva)",
+                  fontWeight: 500,
+                }}
+              >
+                Próximamente
+              </span>
+            </div>
+
+            {/* Módulos activos */}
+            <div
+              className="rounded-2xl px-6 py-5"
+              style={{
+                background: "var(--blanco)",
+                border:     "1px solid var(--gris-borde)",
+                position:   "relative",
+                overflow:   "hidden",
+              }}
+            >
+              <div
+                style={{
+                  position:   "absolute",
+                  top:        0,
+                  left:       0,
+                  right:      0,
+                  height:     "3px",
+                  background: "var(--advertencia)",
+                }}
+              />
+              <p
+                className="text-4xl font-bold mt-1"
+                style={{ color: "var(--advertencia)" }}
+              >
+                —
+              </p>
+              <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
+                Módulos activos
+              </p>
+              <span
+                className="inline-block text-xs px-2 py-0.5 rounded-full mt-2"
+                style={{
+                  background: "var(--advertencia-light)",
+                  color:      "var(--advertencia)",
+                  fontWeight: 500,
+                }}
+              >
+                Próximamente
+              </span>
+            </div>
+
+          </div>
+        </section>
+
+        {/* ── SECCIÓN 2: ACCIONES + ANUNCIOS ── */}
+        <section>
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+
+            {/* LEFT: Acciones rápidas */}
+            <div className="lg:col-span-1">
+              <TituloSeccion>Acciones rápidas</TituloSeccion>
+              <div className="flex flex-col gap-3">
+
+                {/* Añadir empleado */}
+                <button
+                  onClick={() => router.push("/dashboard/admin?tab=empleados")}
+                  className="flex items-center gap-4 rounded-2xl px-5 py-4 text-left w-full transition-all"
+                  style={{
+                    background: "var(--blanco)",
+                    border:     "1px solid var(--gris-borde)",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.boxShadow = "0 4px 16px rgba(0,0,0,0.08)";
+                    e.currentTarget.style.transform = "translateY(-1px)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.boxShadow = "none";
+                    e.currentTarget.style.transform = "translateY(0)";
+                  }}
+                >
+                  <div
+                    className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                    style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}
+                  >
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+                    </svg>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
+                      Añadir empleado
+                    </p>
+                    <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>
+                      Registra un nuevo miembro del equipo
+                    </p>
+                  </div>
+                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                    style={{ color: "var(--texto-muted)" }}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+
+                {/* Nuevo módulo */}
+                <button
+                  onClick={() => router.push("/dashboard/admin/modulos/crear")}
+                  className="flex items-center gap-4 rounded-2xl px-5 py-4 text-left w-full transition-all"
+                  style={{
+                    background: "var(--blanco)",
+                    border:     "1px solid var(--gris-borde)",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.boxShadow = "0 4px 16px rgba(0,0,0,0.08)";
+                    e.currentTarget.style.transform = "translateY(-1px)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.boxShadow = "none";
+                    e.currentTarget.style.transform = "translateY(0)";
+                  }}
+                >
+                  <div
+                    className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                    style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}
+                  >
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                    </svg>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
+                      Nuevo módulo
+                    </p>
+                    <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>
+                      Crea contenido formativo para tu equipo
+                    </p>
+                  </div>
+                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                    style={{ color: "var(--texto-muted)" }}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+
+                {/* Publicar anuncio */}
+                <button
+                  onClick={() => router.push("/dashboard/admin?tab=anuncios")}
+                  className="flex items-center gap-4 rounded-2xl px-5 py-4 text-left w-full transition-all"
+                  style={{
+                    background: "var(--blanco)",
+                    border:     "1px solid var(--gris-borde)",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.boxShadow = "0 4px 16px rgba(0,0,0,0.08)";
+                    e.currentTarget.style.transform = "translateY(-1px)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.boxShadow = "none";
+                    e.currentTarget.style.transform = "translateY(0)";
+                  }}
+                >
+                  <div
+                    className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                    style={{ background: "var(--advertencia-light)", color: "var(--advertencia)" }}
+                  >
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+                    </svg>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
+                      Publicar anuncio
+                    </p>
+                    <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>
+                      Comunica algo importante a tu equipo
+                    </p>
+                  </div>
+                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                    style={{ color: "var(--texto-muted)" }}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+
+              </div>
+            </div>
+
+            {/* RIGHT: Últimos comunicados */}
+            <div className="lg:col-span-2">
+              <div className="flex items-center justify-between mb-6">
+                <TituloSeccion noMargin>Últimos comunicados</TituloSeccion>
+                <button
+                  onClick={() => router.push("/dashboard/admin?tab=anuncios")}
+                  className="text-sm font-medium hover:underline shrink-0"
+                  style={{ color: "var(--azul-egm)" }}
+                >
+                  Ver todos →
+                </button>
+              </div>
+
+              {anuncios.length === 0 ? (
+                <div
+                  className="flex flex-col items-center justify-center py-12 text-center rounded-2xl"
+                  style={{
+                    background: "var(--gris-pagina)",
+                    border:     "1px dashed var(--gris-borde)",
+                  }}
+                >
+                  <div
+                    className="w-12 h-12 rounded-xl flex items-center justify-center mb-4"
+                    style={{ background: "var(--azul-egm-light)" }}
+                  >
+                    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}
+                      style={{ color: "var(--azul-egm)" }}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+                    </svg>
+                  </div>
+                  <p className="text-sm font-semibold mb-1" style={{ color: "var(--texto-primario)" }}>
+                    Sin comunicados publicados
+                  </p>
+                  <p className="text-xs mb-4" style={{ color: "var(--texto-muted)" }}>
+                    Comunica novedades importantes a tu equipo
+                  </p>
+                  <button
+                    onClick={() => router.push("/dashboard/admin?tab=anuncios")}
+                    className="text-xs font-semibold px-4 py-2 rounded-lg transition-opacity"
+                    style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
+                    onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.85")}
+                    onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
+                  >
+                    Crear primer comunicado
+                  </button>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  {anuncios.map((a) => (
+                    <div
+                      key={a.anuncioId}
+                      className="flex items-start justify-between rounded-xl px-4 py-3"
+                      style={{
+                        background:  "var(--blanco)",
+                        border:      "1px solid var(--gris-borde)",
+                        borderLeft:  "3px solid var(--azul-egm)",
+                      }}
+                    >
+                      <div className="flex-1 min-w-0">
+                        <p
+                          className="text-sm font-semibold truncate"
+                          style={{ color: "var(--texto-primario)" }}
+                        >
+                          {a.titulo}
+                        </p>
+                        <p
+                          className="text-xs mt-0.5 line-clamp-2"
+                          style={{ color: "var(--texto-muted)" }}
+                        >
+                          {a.contenido}
+                        </p>
+                      </div>
+                      <span
+                        className="text-xs ml-4 shrink-0 mt-0.5"
+                        style={{ color: "var(--texto-muted)" }}
+                      >
+                        {formatFecha(a.creadoEn)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+          </div>
+        </section>
+
+        {/* ── SECCIÓN 3: ESTADO DEL EQUIPO ── */}
+        <section>
+          <TituloSeccion>Estado del equipo</TituloSeccion>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+
+            {/* Empleados activos */}
+            <div
+              className="rounded-2xl px-5 py-5"
+              style={{
+                background: "var(--blanco)",
+                border:     "1px solid var(--gris-borde)",
+                position:   "relative",
+                overflow:   "hidden",
+              }}
+            >
+              <div
+                style={{
+                  position:   "absolute",
+                  bottom:     0,
+                  left:       0,
+                  right:      0,
+                  height:     "2px",
+                  background: "linear-gradient(90deg, var(--azul-egm), var(--azul-egm-light))",
+                }}
+              />
+              <div
+                className="w-10 h-10 rounded-xl flex items-center justify-center mb-3"
+                style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
                 </svg>
               </div>
-              <p className="text-sm font-medium mb-1" style={{ color: "var(--texto-primario)" }}>
-                Sin anuncios publicados
+              <p className="text-xs mb-1" style={{ color: "var(--texto-muted)" }}>
+                Empleados activos
               </p>
-              <p className="text-xs mb-3" style={{ color: "var(--texto-muted)" }}>
-                Comunica novedades a tu equipo
+              <p
+                className="text-3xl font-bold"
+                style={{ color: "var(--azul-egm)" }}
+              >
+                {resumen?.usuariosActivos ?? "—"}
+              </p>
+            </div>
+
+            {/* Módulos de formación */}
+            <div
+              className="rounded-2xl px-5 py-5"
+              style={{
+                background: "var(--blanco)",
+                border:     "1px solid var(--gris-borde)",
+                position:   "relative",
+                overflow:   "hidden",
+              }}
+            >
+              <div
+                style={{
+                  position:   "absolute",
+                  bottom:     0,
+                  left:       0,
+                  right:      0,
+                  height:     "2px",
+                  background: "linear-gradient(90deg, var(--verde-oliva), var(--verde-oliva-light))",
+                }}
+              />
+              <div
+                className="w-10 h-10 rounded-xl flex items-center justify-center mb-3"
+                style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                </svg>
+              </div>
+              <p className="text-xs mb-2" style={{ color: "var(--texto-muted)" }}>
+                Módulos de formación
               </p>
               <button
-                onClick={() => router.push("/dashboard/admin?tab=anuncios")}
-                className="text-xs font-semibold px-4 py-2 rounded-lg transition-colors"
-                style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
-                onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
-                onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
+                onClick={() => router.push("/dashboard/admin?tab=formaciones")}
+                className="text-xs font-semibold transition-opacity"
+                style={{ color: "var(--verde-oliva)" }}
+                onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.7")}
+                onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
               >
-                Crear primer anuncio
+                Gestionar módulos →
               </button>
             </div>
-          ) : (
-            <div className="flex flex-col gap-3">
-              {anuncios.map((a) => (
-                <div key={a.anuncioId}
-                  className="flex items-start justify-between rounded-lg px-4 py-3"
-                  style={{ border: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-xs font-medium truncate" style={{ color: "var(--texto-primario)" }}>{a.titulo}</p>
-                    <p className="text-[11px] mt-0.5 line-clamp-1" style={{ color: "var(--texto-muted)" }}>{a.contenido}</p>
-                  </div>
-                  <span className="text-[10px] ml-4 shrink-0" style={{ color: "var(--texto-muted)" }}>
-                    {formatFecha(a.creadoEn)}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
 
-        {/* Estado del equipo */}
-        <div className="rounded-xl p-6"
-          style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-          <h2 className="text-sm font-semibold mb-4" style={{ color: "var(--texto-primario)" }}>
-            Estado del equipo
-          </h2>
-          <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-              <span className="text-xs" style={{ color: "var(--texto-muted)" }}>Empleados activos</span>
-              <span className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
-                {resumen?.usuariosActivos ?? "—"}
-              </span>
-            </div>
-            <div className="h-px" style={{ background: "var(--gris-borde)" }} />
-            <div className="flex items-center justify-between">
-              <span className="text-xs" style={{ color: "var(--texto-muted)" }}>Empleados inactivos</span>
-              <span className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
+            {/* Empleados inactivos */}
+            <div
+              className="rounded-2xl px-5 py-5"
+              style={{
+                background: "var(--blanco)",
+                border:     "1px solid var(--gris-borde)",
+                position:   "relative",
+                overflow:   "hidden",
+              }}
+            >
+              <div
+                style={{
+                  position:   "absolute",
+                  bottom:     0,
+                  left:       0,
+                  right:      0,
+                  height:     "2px",
+                  background: "linear-gradient(90deg, var(--texto-muted), var(--gris-superficie))",
+                  opacity:    0.5,
+                }}
+              />
+              <div
+                className="w-10 h-10 rounded-xl flex items-center justify-center mb-3"
+                style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)" }}
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                </svg>
+              </div>
+              <p className="text-xs mb-1" style={{ color: "var(--texto-muted)" }}>
+                Empleados inactivos
+              </p>
+              <p
+                className="text-3xl font-bold"
+                style={{ color: "var(--texto-muted)" }}
+              >
                 {resumen?.usuariosInactivos ?? "—"}
-              </span>
+              </p>
             </div>
-            <div className="h-px" style={{ background: "var(--gris-borde)" }} />
-            <div className="flex items-center justify-between">
-              <span className="text-xs" style={{ color: "var(--texto-muted)" }}>Progreso medio</span>
-              <span className="text-xs px-2 py-0.5 rounded-full"
-                style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
-                Próximamente
-              </span>
-            </div>
-            <div className="h-px" style={{ background: "var(--gris-borde)" }} />
-            <div className="flex items-center justify-between">
-              <span className="text-xs" style={{ color: "var(--texto-muted)" }}>Módulos activos</span>
-              <span className="text-xs px-2 py-0.5 rounded-full"
-                style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
-                Próximamente
-              </span>
-            </div>
-          </div>
-          <button
-            onClick={() => router.push("/dashboard/admin?tab=empleados")}
-            className="w-full mt-6 text-xs font-medium py-2.5 rounded-lg transition-colors"
-            style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}
-            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--gris-superficie)")}
-            onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm-light)")}
-          >
-            Ver todos los empleados →
-          </button>
-        </div>
-      </div>
 
-      {/* ── MÓDULOS ── */}
-      <div className="rounded-xl p-6"
-        style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
-            Módulos de formación
-          </h2>
-          <button
-            onClick={() => router.push("/dashboard/admin?tab=formaciones")}
-            className="text-xs font-medium hover:underline"
-            style={{ color: "var(--azul-egm)" }}
-          >
-            Gestionar →
-          </button>
-        </div>
-        <div className="flex flex-col items-center justify-center py-8 text-center rounded-lg"
-          style={{ background: "var(--gris-pagina)", border: "1px dashed var(--gris-borde)" }}>
-          <div className="w-10 h-10 rounded-full flex items-center justify-center mb-3"
-            style={{ background: "var(--verde-oliva-light)" }}>
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}
-              style={{ color: "var(--verde-oliva)" }}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-            </svg>
           </div>
-          <p className="text-sm font-medium mb-1" style={{ color: "var(--texto-primario)" }}>
-            Sin módulos creados
-          </p>
-          <p className="text-xs mb-3" style={{ color: "var(--texto-muted)" }}>
-            Crea el primer módulo formativo para tu equipo
-          </p>
-          <button
-            onClick={() => router.push("/dashboard/admin/modulos/crear")}
-            className="text-xs font-semibold px-4 py-2 rounded-lg transition-colors"
-            style={{ background: "var(--verde-oliva)", color: "var(--blanco)" }}
-            onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.85")}
-            onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
-          >
-            Crear primer módulo
-          </button>
-        </div>
+        </section>
+
       </div>
     </div>
-  );
-}
-
-// ── SUBCOMPONENTES ────────────────────────────────────────────────────────────
-
-function MetricCard({
-  label, value, nota, acento, onClick,
-}: {
-  label:    string;
-  value:    string | number;
-  nota?:    string;
-  acento:   "azul" | "verde" | "naranja" | "gris";
-  onClick?: () => void;
-}) {
-  const acentos = {
-    azul:    "var(--azul-egm)",
-    verde:   "var(--verde-oliva)",
-    naranja: "var(--advertencia)",
-    gris:    "var(--texto-muted)",
-  };
-
-  return (
-    <div
-      className="rounded-xl px-5 py-4 cursor-pointer transition-opacity"
-      style={{
-        background:  "rgba(255,255,255,0.08)",
-        border:      `1px solid rgba(255,255,255,0.12)`,
-        borderLeft:  `3px solid ${acentos[acento]}`,
-      }}
-      onClick={onClick}
-      onMouseEnter={(e) => onClick && (e.currentTarget.style.background = "rgba(255,255,255,0.12)")}
-      onMouseLeave={(e) => onClick && (e.currentTarget.style.background = "rgba(255,255,255,0.08)")}
-    >
-      <p className="text-xs mb-1" style={{ color: "rgba(255,255,255,0.6)" }}>{label}</p>
-      <p className="text-3xl font-bold text-white">{value}</p>
-      {nota && <p className="text-[10px] mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>{nota}</p>}
-    </div>
-  );
-}
-
-function AccionCard({
-  titulo, descripcion, acento, icono, onClick,
-}: {
-  titulo:      string;
-  descripcion: string;
-  acento:      "azul" | "verde" | "naranja";
-  icono:       React.ReactNode;
-  onClick:     () => void;
-}) {
-  const acentos = {
-    azul:    { bg: "var(--azul-egm-light)",   text: "var(--azul-egm)",   hover: "var(--azul-egm)",   hoverText: "var(--blanco)" },
-    verde:   { bg: "var(--verde-oliva-light)", text: "var(--verde-oliva)", hover: "var(--verde-oliva)", hoverText: "var(--blanco)" },
-    naranja: { bg: "var(--advertencia-light)", text: "var(--advertencia)", hover: "var(--advertencia)", hoverText: "var(--blanco)" },
-  };
-
-  const c = acentos[acento];
-
-  return (
-    <button
-      onClick={onClick}
-      className="rounded-xl p-5 text-left flex items-center gap-4 transition-all w-full group"
-      style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.background    = c.hover;
-        e.currentTarget.style.borderColor   = c.hover;
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.background  = "var(--blanco)";
-        e.currentTarget.style.borderColor = "var(--gris-borde)";
-      }}
-    >
-      <div
-        className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 transition-colors"
-        style={{ background: c.bg, color: c.text }}
-      >
-        {icono}
-      </div>
-      <div className="min-w-0">
-        <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>{titulo}</p>
-        <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>{descripcion}</p>
-      </div>
-    </button>
   );
 }

--- a/components/pages/Empleado.tsx
+++ b/components/pages/Empleado.tsx
@@ -8,8 +8,6 @@ import { getNoticias } from "@/lib/api/noticias";
 import { getModulosConProgreso } from "@/lib/api/modulos";
 import type { Noticia } from "@/lib/types/noticias";
 import type { ModuloConProgreso } from "@/lib/types/modulos";
-import SplitText from "@/components/ui/SplitText";
-import GradientText from "@/components/ui/GradientText";
 import ComunicadosCarousel, { ComunicadoItem } from "@/components/ui/ComunicadosCarousel";
 
 function formatFecha(iso: string) {
@@ -277,35 +275,40 @@ export default function Empleado() {
                   fontFamily:    "var(--font-poppins), sans-serif",
                   fontWeight:    300,
                   letterSpacing: "-0.03em",
+                  animation:     "heroFadeUp 0.8s ease both",
                 }}
               >
                 Hola,
               </span>
-              <GradientText
+              <span
                 style={{
-                  fontSize:      "clamp(3.5rem, 7vw, 6rem)",
-                  fontFamily:    "'Instrument Serif', serif",
-                  fontStyle:     "italic",
-                  fontWeight:    400,
-                  letterSpacing: "-0.01em",
-                  lineHeight:    1,
+                  fontSize:        "clamp(3.5rem, 7vw, 6rem)",
+                  fontFamily:      "'Instrument Serif', serif",
+                  fontStyle:       "italic",
+                  fontWeight:      400,
+                  letterSpacing:   "-0.01em",
+                  lineHeight:      1,
+                  background:      "linear-gradient(90deg, #A3B535, #ffffff, #A3B535)",
+                  backgroundSize:  "300% 100%",
+                  WebkitBackgroundClip: "text",
+                  WebkitTextFillColor: "transparent",
+                  backgroundClip: "text",
+                  animation:       "heroFadeUp 0.8s ease 0.15s both, gradientShift 8s ease infinite",
                 }}
               >
-                <SplitText
-                  text={usuario?.nombre?.split(" ")[0] ?? "Empleado"}
-                  tag="span"
-                  textAlign="left"
-                  delay={40}
-                  duration={0.9}
-                  ease="power3.out"
-                  splitType="chars"
-                  from={{ opacity: 0, y: 60 }}
-                  to={{ opacity: 1, y: 0 }}
-                  threshold={0.1}
-                  rootMargin="0px"
-                />
-              </GradientText>
+                {usuario?.nombre?.split(" ")[0] ?? "Empleado"}
+              </span>
             </div>
+            <style>{`
+              @keyframes heroFadeUp {
+                from { opacity: 0; transform: translateY(24px); }
+                to   { opacity: 1; transform: translateY(0); }
+              }
+              @keyframes gradientShift {
+                0%, 100% { background-position: 0% 50%; }
+                50%       { background-position: 100% 50%; }
+              }
+            `}</style>
         </div>
       </div>
 

--- a/components/ui/DashboardHero.tsx
+++ b/components/ui/DashboardHero.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useAuth } from "@/context/AuthContext";
-import SplitText from "@/components/ui/SplitText";
-import GradientText from "@/components/ui/GradientText";
 
 interface DashboardHeroProps {
   prefijo?:     string;    // texto en Poppins bold, ej: "Centro de "
@@ -50,36 +48,41 @@ export default function DashboardHero({ prefijo, titulo, imagenFondo = "/backgro
                 fontFamily:    "var(--font-poppins), sans-serif",
                 fontWeight:    300,
                 letterSpacing: "-0.03em",
+                animation:     "heroFadeUp 0.7s ease both",
               }}
             >
               {prefijo}
             </span>
           )}
-          <GradientText
+          <span
             style={{
-              fontSize:      "clamp(3rem, 6vw, 5rem)",
-              fontFamily:    "'Instrument Serif', serif",
-              fontStyle:     "italic",
-              fontWeight:    400,
-              letterSpacing: "-0.01em",
-              lineHeight:    1,
+              fontSize:             "clamp(3rem, 6vw, 5rem)",
+              fontFamily:           "'Instrument Serif', serif",
+              fontStyle:            "italic",
+              fontWeight:           400,
+              letterSpacing:        "-0.01em",
+              lineHeight:           1,
+              background:           "linear-gradient(90deg, #A3B535, #ffffff, #A3B535)",
+              backgroundSize:       "300% 100%",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor:  "transparent",
+              backgroundClip:       "text",
+              animation:            "heroFadeUp 0.7s ease 0.12s both, gradientShift 8s ease infinite",
             }}
           >
-            <SplitText
-              text={titulo}
-              tag="span"
-              textAlign="left"
-              delay={40}
-              duration={0.9}
-              ease="power3.out"
-              splitType="chars"
-              from={{ opacity: 0, y: 50 }}
-              to={{ opacity: 1, y: 0 }}
-              threshold={0.1}
-              rootMargin="0px"
-            />
-          </GradientText>
+            {titulo}
+          </span>
         </div>
+        <style>{`
+          @keyframes heroFadeUp {
+            from { opacity: 0; transform: translateY(20px); }
+            to   { opacity: 1; transform: translateY(0); }
+          }
+          @keyframes gradientShift {
+            0%, 100% { background-position: 0% 50%; }
+            50%       { background-position: 100% 50%; }
+          }
+        `}</style>
       </div>
     </div>
   );


### PR DESCRIPTION
- DashboardHero y Empleado: reemplazar SplitText+GSAP por CSS animations puras (heroFadeUp) para evitar texto invisible
- Gradiente hero cambiado a oliva (#A3B535) → blanco
- AdminEmpresa: nuevo diseño tipo empleado con hero, métricas, acciones y estado del equipo
- Admin panel (/dashboard/admin): hero + tabs pill-style + cards en empleados/anuncios/formaciones