### PR TITLE
feat: mejoras visuales dashboard empleado y admin para demo

### DIFF
--- a/app/dashboard/admin/modulos/crear/page.tsx
+++ b/app/dashboard/admin/modulos/crear/page.tsx
@@ -8,20 +8,19 @@ import { useAuth } from "@/context/AuthContext";
 
 // ── TIPOS ─────────────────────────────────────────────────────────────────────
 type Paso = 1 | 2 | 3 | 4;
-
 type TipoGeneracion = "formativo" | "video" | "podcast" | "resumen";
 
 interface ArchivoSubido {
   nombre: string;
   tamano: string;
-  tipo: "pdf" | "docx" | "video" | "audio" | "otro";
+  tipo:   "pdf" | "docx" | "video" | "audio" | "otro";
   estado: "listo" | "procesando";
 }
 
 interface ConfigModulo {
-  nombre: string;
+  nombre:   string;
   categoria: string;
-  idioma: string;
+  idioma:   string;
   duracion: string;
   asignarA: string;
 }
@@ -31,7 +30,6 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
-
 function getTipo(nombre: string): ArchivoSubido["tipo"] {
   const ext = nombre.split(".").pop()?.toLowerCase();
   if (ext === "pdf" || ext === "docx" || ext === "txt" || ext === "ppt" || ext === "pptx") return "pdf";
@@ -42,102 +40,93 @@ function getTipo(nombre: string): ArchivoSubido["tipo"] {
 
 // ── ICONOS ────────────────────────────────────────────────────────────────────
 const IconUpload = () => (
-  <svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+  <svg viewBox="0 0 24 24" className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
     <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>
   </svg>
 );
-const IconFile = () => (
-  <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
-    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/>
-  </svg>
-);
-const IconVideo = () => (
-  <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
-    <polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2"/>
-  </svg>
-);
-const IconMic = () => (
-  <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
-    <path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2M12 19v4M8 23h8"/>
-  </svg>
-);
-const IconDoc = () => (
-  <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
-    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/>
-  </svg>
-);
-const IconBook = () => (
-  <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
-    <path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/>
-  </svg>
-);
-const IconAI = () => (
-  <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
-    <path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>
-  </svg>
-);
-const IconCheck = () => (
-  <svg viewBox="0 0 24 24" className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="20 6 9 17 4 12"/>
-  </svg>
-);
-const IconTrash = () => (
-  <svg viewBox="0 0 24 24" className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/>
-  </svg>
-);
-const IconChevron = () => (
-  <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="9 18 15 12 9 6"/>
-  </svg>
-);
+const IconFile  = () => (<svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>);
+const IconVideo = () => (<svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2"/></svg>);
+const IconMic   = () => (<svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2M12 19v4M8 23h8"/></svg>);
+const IconDoc   = () => (<svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>);
+const IconBook  = () => (<svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>);
+const IconAI    = () => (<svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>);
+const IconCheck = () => (<svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>);
+const IconTrash = () => (<svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>);
+const IconSpark = () => (<svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>);
 
-// ── COMPONENTE PRINCIPAL ──────────────────────────────────────────────────────
 const ROLES_BLOQUEADOS = ["ROLE_EMPLEADO", "INVITADO"];
 
+const TIPOS_CONFIG = [
+  {
+    id:     "formativo" as TipoGeneracion,
+    nombre: "Contenido formativo",
+    desc:   "Módulo completo con lecciones, objetivos y cuestionarios de comprensión.",
+    bg:     "var(--azul-egm-light)",
+    color:  "var(--azul-egm)",
+    icono:  <IconBook />,
+  },
+  {
+    id:     "video" as TipoGeneracion,
+    nombre: "Vídeo formativo",
+    desc:   "Vídeo con narración automática generada por IA y subtítulos.",
+    bg:     "#fef3c7",
+    color:  "#b45309",
+    icono:  <IconVideo />,
+  },
+  {
+    id:     "podcast" as TipoGeneracion,
+    nombre: "Podcast interno",
+    desc:   "Audio con voz sintética optimizado para escuchar en movilidad.",
+    bg:     "#dcfce7",
+    color:  "#15803d",
+    icono:  <IconMic />,
+  },
+  {
+    id:     "resumen" as TipoGeneracion,
+    nombre: "Resumen estructurado",
+    desc:   "Documento PDF con los puntos clave organizados y resumidos.",
+    bg:     "#e0f2fe",
+    color:  "#0284c7",
+    icono:  <IconDoc />,
+  },
+];
+
+const PASOS_LABELS = ["Subir contenido", "Configurar", "Generar con IA", "Publicar"];
+
 export default function CrearModuloPage() {
-  const router = useRouter();
+  const router   = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const { usuario } = useAuth();
 
-  // Protección: empleados e invitados no tienen acceso
   useEffect(() => {
     if (usuario && ROLES_BLOQUEADOS.includes(usuario.codigoRol)) {
       router.replace("/dashboard");
     }
   }, [usuario]);
 
-  // No renderizar hasta que el usuario esté cargado
-  if (!usuario) return null;
-  // Si es rol bloqueado, no mostrar nada mientras redirige
-  if (ROLES_BLOQUEADOS.includes(usuario.codigoRol)) return null;
+  if (!usuario || ROLES_BLOQUEADOS.includes(usuario.codigoRol)) return null;
 
-  const [paso, setPaso] = useState<Paso>(1);
-  const [archivos, setArchivos] = useState<ArchivoSubido[]>([]);
-  const [archivosRaw, setArchivosRaw] = useState<File[]>([]);
-  const [dragging, setDragging] = useState(false);
-  const [resultadoIA, setResultadoIA] = useState<{ titulo: string; descripcion: string; contenido: string } | null>(null);
+  const [paso,            setPaso]            = useState<Paso>(1);
+  const [archivos,        setArchivos]        = useState<ArchivoSubido[]>([]);
+  const [archivosRaw,     setArchivosRaw]     = useState<File[]>([]);
+  const [dragging,        setDragging]        = useState(false);
+  const [resultadoIA,     setResultadoIA]     = useState<{ titulo: string; descripcion: string; contenido: string } | null>(null);
   const [tipoSeleccionado, setTipoSeleccionado] = useState<TipoGeneracion>("formativo");
-  const [config, setConfig] = useState<ConfigModulo>({
-    nombre: "",
-    categoria: "ESPECIFICA",
-    idioma: "es",
-    duracion: "medio",
-    asignarA: "todos",
+  const [config,          setConfig]          = useState<ConfigModulo>({
+    nombre: "", categoria: "ESPECIFICA", idioma: "es", duracion: "medio", asignarA: "todos",
   });
-  const [generando, setGenerando] = useState(false);
-  const [progreso, setProgreso] = useState(0);
+  const [generando,       setGenerando]       = useState(false);
+  const [progreso,        setProgreso]        = useState(0);
   const [mensajeProgreso, setMensajeProgreso] = useState("");
-  const [generado, setGenerado] = useState(false);
+  const [generado,        setGenerado]        = useState(false);
 
-  // ── Subida de archivos ──
   const procesarArchivos = (files: FileList | null) => {
     if (!files) return;
     const nuevos: ArchivoSubido[] = Array.from(files).map((f) => ({
       nombre: f.name,
       tamano: formatBytes(f.size),
-      tipo: getTipo(f.name),
-      estado: "listo",
+      tipo:   getTipo(f.name),
+      estado: "listo" as const,
     }));
     setArchivos((prev) => [...prev, ...nuevos]);
     setArchivosRaw((prev) => [...prev, ...Array.from(files)]);
@@ -145,23 +134,16 @@ export default function CrearModuloPage() {
   };
 
   const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    setDragging(false);
+    e.preventDefault(); setDragging(false);
     procesarArchivos(e.dataTransfer.files);
   };
 
   const eliminarArchivo = (idx: number) => {
-    setArchivos((prev) => prev.filter((_, i) => i !== idx));
-    setArchivosRaw((prev) => prev.filter((_, i) => i !== idx));
+    setArchivos((p) => p.filter((_, i) => i !== idx));
+    setArchivosRaw((p) => p.filter((_, i) => i !== idx));
   };
 
-  // ── Selección de tipo (única) ──
-  const seleccionarTipo = (tipo: TipoGeneracion) => {
-    setTipoSeleccionado(tipo);
-  };
-
-  // ── Generación con IA (backend real) ──
-  const mensajesProgreso = [
+  const MENSAJES_PROGRESO = [
     "Analizando documentos subidos…",
     "Extrayendo conceptos clave con IA…",
     "Estructurando lecciones y objetivos…",
@@ -172,470 +154,636 @@ export default function CrearModuloPage() {
 
   const iniciarGeneracion = async () => {
     if (generando || archivos.length === 0 || !config.nombre.trim()) return;
-    setGenerando(true);
-    setGenerado(false);
-    setProgreso(0);
-    setPaso(3);
-
-    // Animación de progreso mientras esperamos la respuesta
+    setGenerando(true); setGenerado(false); setProgreso(0); setPaso(3);
     let i = 0;
-    setMensajeProgreso(mensajesProgreso[0]);
+    setMensajeProgreso(MENSAJES_PROGRESO[0]);
     const interval = setInterval(() => {
       i++;
-      if (i < mensajesProgreso.length - 1) {
-        setProgreso(Math.round((i / mensajesProgreso.length) * 85));
-        setMensajeProgreso(mensajesProgreso[i]);
+      if (i < MENSAJES_PROGRESO.length - 1) {
+        setProgreso(Math.round((i / MENSAJES_PROGRESO.length) * 85));
+        setMensajeProgreso(MENSAJES_PROGRESO[i]);
       }
     }, 1200);
-
     try {
-      // 1. Generar contenido con IA desde el archivo
       const formData = new FormData();
       formData.append("archivo", archivosRaw[0]);
-
       const resIA = await fetch(`${API_URL}/ai/generar-desde-archivo`, {
-        method: "POST",
-        credentials: "include",
-        body: formData,
+        method: "POST", credentials: "include", body: formData,
       });
-
       clearInterval(interval);
-
       if (!resIA.ok) throw new Error(`HTTP ${resIA.status}`);
-
       const dataIA = await resIA.json();
-      const titulo    = dataIA.titulo      || config.nombre;
+      const titulo      = dataIA.titulo      || config.nombre;
       const descripcion = dataIA.descripcion || "";
-      const contenido = dataIA.contenido   || "";
-
+      const contenido   = dataIA.contenido   || "";
       setResultadoIA({ titulo, descripcion, contenido });
       setProgreso(90);
       setMensajeProgreso("Guardando módulo en la plataforma…");
-
-      // 2. Guardar el módulo en la plataforma via POST /api/v1/modulos
       const resModulo = await fetch(`${API_URL}/modulos`, {
-        method: "POST",
-        credentials: "include",
+        method: "POST", credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          nombre:          titulo,
-          descripcion:     descripcion,
-          tipoModulo:      "ESPECIALIZADO_IA",
-          esEspecializadoIa: true,
-          activo:          true,
-          empresaId:       usuario?.empresaId ?? null,
+          nombre: titulo, descripcion, tipoModulo: "ESPECIALIZADO_IA",
+          esEspecializadoIa: true, activo: true, empresaId: usuario?.empresaId ?? null,
         }),
       });
-
-      if (!resModulo.ok) throw new Error(`Guardar módulo: HTTP ${resModulo.status}`);
-
+      if (!resModulo.ok) throw new Error(`HTTP ${resModulo.status}`);
       setProgreso(100);
-      setMensajeProgreso("¡Módulo creado y guardado correctamente!");
-      setGenerado(true);
-      setPaso(4);
-    } catch (err) {
+      setMensajeProgreso("¡Módulo creado correctamente!");
+      setGenerado(true); setPaso(4);
+    } catch {
       clearInterval(interval);
       setMensajeProgreso("Error al generar el módulo. Inténtalo de nuevo.");
-      setProgreso(0);
-      setGenerando(false);
-      setPaso(2);
+      setProgreso(0); setGenerando(false); setPaso(2);
     }
   };
 
-  // ── UI helpers ──
-  const pasoLabel = ["Subir contenido", "Elegir formato", "Generar con IA", "Publicar"];
-
-  const tiposConfig = [
-    { id: "formativo" as TipoGeneracion, nombre: "Contenido formativo", desc: "Módulo con lecciones, objetivos y cuestionarios.", color: "var(--azul-egm-light)", stroke: "var(--azul-egm)", icono: <IconBook /> },
-    { id: "video" as TipoGeneracion, nombre: "Vídeo formativo", desc: "Vídeo con narración automática y subtítulos.", color: "#fef3c7", stroke: "#d97706", icono: <IconVideo /> },
-    { id: "podcast" as TipoGeneracion, nombre: "Podcast interno", desc: "Audio con voz sintética para escuchar en movilidad.", color: "var(--exito-light)", stroke: "var(--exito)", icono: <IconMic /> },
-    { id: "resumen" as TipoGeneracion, nombre: "Resumen estructurado", desc: "Documento de puntos clave y documentación resumida.", color: "#e0f2fe", stroke: "#0284c7", icono: <IconDoc /> },
-  ];
-
-  const iconoArchivo = (tipo: ArchivoSubido["tipo"]) => {
-    if (tipo === "video") return { bg: "#fef3c7", stroke: "#d97706", icon: <IconVideo /> };
-    if (tipo === "audio") return { bg: "var(--exito-light)", stroke: "var(--exito)", icon: <IconMic /> };
-    return { bg: "var(--azul-egm-light)", stroke: "var(--azul-egm)", icon: <IconFile /> };
-  };
+  const puedeGenerar = archivos.length > 0 && config.nombre.trim().length > 0;
 
   return (
     <div className="w-full">
+      <style>{`
+        @keyframes fadeUp {
+          from { opacity:0; transform:translateY(16px); }
+          to   { opacity:1; transform:translateY(0); }
+        }
+        @keyframes shimmer {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        @keyframes pulse-ring {
+          0%   { box-shadow: 0 0 0 0 rgba(163,181,53,0.4); }
+          70%  { box-shadow: 0 0 0 10px rgba(163,181,53,0); }
+          100% { box-shadow: 0 0 0 0 rgba(163,181,53,0); }
+        }
+      `}</style>
 
-        {/* ── Cabecera ── */}
-        <div className="mb-6">
-          <div className="flex items-center gap-2 text-xs mb-3" style={{ color: "var(--texto-muted)" }}>
-            <Link href="/dashboard" className="hover:underline">Dashboard</Link>
+      {/* ══════════════ HERO ══════════════ */}
+      <div
+        className="-mx-8 -mt-8 relative overflow-hidden"
+        style={{ minHeight: "220px" }}
+      >
+        <div style={{ position: "absolute", inset: 0, backgroundImage: "url('/background-formacion-empleado.jpg')", backgroundSize: "cover", backgroundPosition: "center 30%" }} />
+        <div style={{ position: "absolute", inset: 0, background: "rgba(10,20,40,0.72)" }} />
+        <div style={{ position: "absolute", inset: 0, background: "linear-gradient(to right, rgba(10,20,40,0.95) 0%, rgba(10,20,40,0.5) 60%, transparent 100%)" }} />
+
+        <div className="relative z-10 px-10 lg:px-16 flex flex-col justify-center" style={{ minHeight: "220px", paddingTop: "2.5rem", paddingBottom: "2.5rem" }}>
+          {/* Breadcrumb */}
+          <div className="flex items-center gap-1.5 text-xs mb-5" style={{ color: "rgba(255,255,255,0.45)" }}>
+            <Link href="/dashboard" className="hover:text-white transition-colors">Dashboard</Link>
             <span>/</span>
-            <Link href="/dashboard/admin" className="hover:underline">Admin</Link>
+            <Link href="/dashboard/admin" className="hover:text-white transition-colors">Administración</Link>
             <span>/</span>
-            <span style={{ color: "var(--texto-primario)" }}>Crear módulo</span>
+            <span style={{ color: "rgba(255,255,255,0.8)" }}>Crear módulo</span>
           </div>
-          <h1 className="text-2xl font-bold mb-1" style={{ color: "var(--texto-primario)" }}>
-            Crear nuevo módulo formativo
-          </h1>
-          <p className="text-sm" style={{ color: "var(--texto-muted)" }}>
-            Sube contenido de tu empresa y la IA generará automáticamente el material formativo.
-          </p>
-        </div>
 
-        {/* ── Stepper ── */}
-        <div className="flex items-center gap-0 mb-8 overflow-x-auto pb-1">
-          {pasoLabel.map((label, idx) => {
-            const num = idx + 1;
+          <div style={{ animation: "fadeUp 0.6s ease both" }}>
+            <div className="flex items-center gap-3 mb-2">
+              <div
+                className="w-10 h-10 rounded-xl flex items-center justify-center"
+                style={{ background: "rgba(163,181,53,0.2)", color: "#A3B535", border: "1px solid rgba(163,181,53,0.3)" }}
+              >
+                <IconSpark />
+              </div>
+              <span className="text-xs font-bold uppercase tracking-widest" style={{ color: "#A3B535" }}>
+                Generación con IA
+              </span>
+            </div>
+            <h1 style={{
+              fontFamily:   "'Instrument Serif', serif",
+              fontStyle:    "italic",
+              fontSize:     "clamp(2.2rem, 4vw, 3.2rem)",
+              fontWeight:   400,
+              color:        "#fff",
+              lineHeight:   1.15,
+              letterSpacing: "-0.02em",
+            }}>
+              Crear nuevo módulo formativo
+            </h1>
+            <p className="mt-2 text-sm" style={{ color: "rgba(255,255,255,0.5)", maxWidth: "480px" }}>
+              Sube documentos de tu empresa y la IA generará automáticamente el material formativo listo para asignar.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* ══════════════ STEPPER ══════════════ */}
+      <div className="px-10 lg:px-16 py-8" style={{ borderBottom: "1px solid var(--gris-borde)" }}>
+        <div className="flex items-center gap-0 overflow-x-auto">
+          {PASOS_LABELS.map((label, idx) => {
+            const num    = idx + 1;
             const estado = num < paso ? "done" : num === paso ? "active" : "pending";
+            const isLast = idx === PASOS_LABELS.length - 1;
             return (
-              <div key={label} className="flex items-center shrink-0">
-                <div className="flex items-center gap-2">
+              <div key={label} className="flex items-center shrink-0" style={{ flex: isLast ? "0 0 auto" : "1 1 auto" }}>
+                <div className="flex items-center gap-3">
+                  {/* Círculo numerado */}
                   <div
-                    className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-semibold shrink-0"
+                    className="flex items-center justify-center rounded-full font-bold text-sm shrink-0"
                     style={{
-                      background: estado === "done" ? "var(--exito-light)" : estado === "active" ? "var(--marino)" : "var(--gris-superficie)",
-                      color: estado === "done" ? "var(--exito)" : estado === "active" ? "#fff" : "var(--texto-muted)",
+                      width:      "36px",
+                      height:     "36px",
+                      background: estado === "done"   ? "var(--verde-oliva)"
+                                : estado === "active" ? "var(--azul-egm)"
+                                : "var(--gris-superficie)",
+                      color:      estado === "pending" ? "var(--texto-muted)" : "#fff",
+                      boxShadow:  estado === "active"  ? "0 0 0 4px rgba(var(--azul-egm-rgb,30,64,175),0.15)" : "none",
+                      transition: "all 0.3s ease",
                     }}
                   >
                     {estado === "done" ? <IconCheck /> : num}
                   </div>
-                  <span
-                    className="text-xs font-medium whitespace-nowrap"
-                    style={{ color: estado === "done" ? "var(--exito)" : estado === "active" ? "var(--texto-primario)" : "var(--texto-muted)" }}
-                  >
-                    {label}
-                  </span>
+                  {/* Label */}
+                  <div>
+                    <p
+                      className="text-xs font-semibold whitespace-nowrap"
+                      style={{
+                        color: estado === "done"   ? "var(--verde-oliva)"
+                             : estado === "active" ? "var(--texto-primario)"
+                             : "var(--texto-muted)",
+                      }}
+                    >
+                      {label}
+                    </p>
+                    <p className="text-[10px]" style={{ color: "var(--texto-muted)" }}>
+                      {estado === "done" ? "Completado" : estado === "active" ? "En curso" : "Pendiente"}
+                    </p>
+                  </div>
                 </div>
-                {idx < pasoLabel.length - 1 && (
-                  <div className="w-8 h-px mx-3 shrink-0" style={{ background: "var(--gris-borde)" }} />
+                {/* Línea conectora */}
+                {!isLast && (
+                  <div
+                    className="flex-1 mx-4 rounded-full"
+                    style={{
+                      height:     "2px",
+                      minWidth:   "32px",
+                      background: num < paso ? "var(--verde-oliva)" : "var(--gris-borde)",
+                      transition: "background 0.3s ease",
+                    }}
+                  />
                 )}
               </div>
             );
           })}
         </div>
+      </div>
 
-        {/* ── Layout dos columnas ── */}
-        <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5 items-start">
+      {/* ══════════════ CONTENIDO PRINCIPAL ══════════════ */}
+      <div className="px-10 lg:px-16 pt-8 pb-16">
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-8 items-start">
 
-          {/* ── COLUMNA IZQUIERDA ── */}
-          <div className="flex flex-col gap-5">
+          {/* ────── COLUMNA IZQUIERDA ────── */}
+          <div className="flex flex-col gap-6">
 
-            {/* Panel subida */}
-            <div className="rounded-xl p-5" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-              <p className="text-sm font-semibold mb-4" style={{ color: "var(--texto-primario)" }}>
-                Contenido subido
-              </p>
-
-              {/* Zona drop */}
+            {/* Panel 1: Subida de archivos */}
+            <div
+              className="rounded-2xl overflow-hidden"
+              style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", boxShadow: "0 1px 8px rgba(0,0,0,0.04)" }}
+            >
               <div
-                onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
-                onDragLeave={() => setDragging(false)}
-                onDrop={handleDrop}
-                onClick={() => inputRef.current?.click()}
-                className="rounded-xl p-8 flex flex-col items-center gap-3 cursor-pointer transition-all"
-                style={{
-                  border: `1.5px dashed ${dragging ? "var(--azul-egm)" : "var(--gris-borde)"}`,
-                  background: dragging ? "var(--azul-egm-light)" : "var(--gris-pagina)",
-                }}
+                className="px-6 py-4 flex items-center gap-3"
+                style={{ borderBottom: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}
               >
-                <div className="w-10 h-10 rounded-xl flex items-center justify-center" style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
+                <div className="w-8 h-8 rounded-lg flex items-center justify-center" style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
                   <IconUpload />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-center" style={{ color: "var(--texto-primario)" }}>
-                    Arrastra archivos o haz clic para subir
-                  </p>
-                  <p className="text-xs text-center mt-1" style={{ color: "var(--texto-muted)" }}>
-                    Documentos, manuales, procedimientos operativos
-                  </p>
+                  <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>Contenido a transformar</p>
+                  <p className="text-xs" style={{ color: "var(--texto-muted)" }}>Sube los documentos base para generar el módulo</p>
                 </div>
-                <div className="flex gap-2 flex-wrap justify-center mt-1">
-                  {["PDF", "DOCX", "PPT", "MP4", "MP3", "TXT"].map((ext) => (
-                    <span key={ext} className="text-[10px] px-2 py-0.5 rounded" style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)", border: "1px solid var(--gris-borde)" }}>
-                      {ext}
-                    </span>
-                  ))}
-                </div>
-                <input ref={inputRef} type="file" multiple accept=".pdf,.docx,.ppt,.pptx,.mp4,.mp3,.txt" className="hidden" onChange={(e) => procesarArchivos(e.target.files)} />
+                {archivos.length > 0 && (
+                  <span
+                    className="ml-auto text-xs font-semibold px-2.5 py-1 rounded-full"
+                    style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}
+                  >
+                    {archivos.length} archivo{archivos.length !== 1 ? "s" : ""}
+                  </span>
+                )}
               </div>
 
-              {/* Lista archivos */}
-              {archivos.length > 0 && (
-                <div className="flex flex-col gap-2 mt-4">
-                  {archivos.map((archivo, idx) => {
-                    const { bg, stroke, icon } = iconoArchivo(archivo.tipo);
-                    return (
-                      <div key={idx} className="flex items-center gap-3 px-3 py-2.5 rounded-lg" style={{ background: "var(--gris-pagina)", border: "1px solid var(--gris-borde)" }}>
-                        <div className="w-7 h-7 rounded-md flex items-center justify-center shrink-0" style={{ background: bg, color: stroke }}>
-                          {icon}
+              <div className="p-6">
+                {/* Zona drop */}
+                <div
+                  onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+                  onDragLeave={() => setDragging(false)}
+                  onDrop={handleDrop}
+                  onClick={() => inputRef.current?.click()}
+                  className="rounded-xl flex flex-col items-center gap-4 cursor-pointer transition-all"
+                  style={{
+                    padding:    "2.5rem 1.5rem",
+                    border:     `2px dashed ${dragging ? "var(--azul-egm)" : "var(--gris-borde)"}`,
+                    background: dragging ? "var(--azul-egm-light)" : "var(--gris-pagina)",
+                    transform:  dragging ? "scale(1.01)" : "scale(1)",
+                    transition: "all 0.2s ease",
+                  }}
+                >
+                  <div
+                    className="w-16 h-16 rounded-2xl flex items-center justify-center"
+                    style={{
+                      background: dragging ? "var(--azul-egm)" : "var(--gris-superficie)",
+                      color:      dragging ? "#fff" : "var(--texto-muted)",
+                      transition: "all 0.2s ease",
+                    }}
+                  >
+                    <IconUpload />
+                  </div>
+                  <div className="text-center">
+                    <p className="text-sm font-semibold mb-1" style={{ color: "var(--texto-primario)" }}>
+                      Arrastra archivos aquí o{" "}
+                      <span style={{ color: "var(--azul-egm)", textDecoration: "underline" }}>selecciona desde tu equipo</span>
+                    </p>
+                    <p className="text-xs" style={{ color: "var(--texto-muted)" }}>
+                      Documentos, manuales, procedimientos, presentaciones, vídeos
+                    </p>
+                  </div>
+                  <div className="flex gap-2 flex-wrap justify-center">
+                    {["PDF", "DOCX", "PPT", "MP4", "MP3", "TXT"].map((ext) => (
+                      <span
+                        key={ext}
+                        className="text-[11px] px-2.5 py-1 rounded-md font-medium"
+                        style={{ background: "var(--blanco)", color: "var(--texto-muted)", border: "1px solid var(--gris-borde)" }}
+                      >
+                        .{ext}
+                      </span>
+                    ))}
+                  </div>
+                  <input
+                    ref={inputRef} type="file" multiple
+                    accept=".pdf,.docx,.ppt,.pptx,.mp4,.mp3,.txt"
+                    className="hidden"
+                    onChange={(e) => procesarArchivos(e.target.files)}
+                  />
+                </div>
+
+                {/* Lista de archivos subidos */}
+                {archivos.length > 0 && (
+                  <div className="mt-4 flex flex-col gap-2">
+                    {archivos.map((archivo, idx) => {
+                      const esVideo = archivo.tipo === "video";
+                      const esAudio = archivo.tipo === "audio";
+                      const bg    = esVideo ? "#fef3c7" : esAudio ? "#dcfce7" : "var(--azul-egm-light)";
+                      const color = esVideo ? "#b45309"  : esAudio ? "#15803d"  : "var(--azul-egm)";
+                      const Icon  = esVideo ? <IconVideo /> : esAudio ? <IconMic /> : <IconFile />;
+                      return (
+                        <div
+                          key={idx}
+                          className="flex items-center gap-3 rounded-xl px-4 py-3"
+                          style={{ background: "var(--gris-pagina)", border: "1px solid var(--gris-borde)" }}
+                        >
+                          <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0" style={{ background: bg, color }}>
+                            {Icon}
+                          </div>
+                          <span className="text-sm font-medium flex-1 truncate" style={{ color: "var(--texto-primario)" }}>{archivo.nombre}</span>
+                          <span className="text-xs shrink-0" style={{ color: "var(--texto-muted)" }}>{archivo.tamano}</span>
+                          <span
+                            className="text-xs px-2 py-0.5 rounded-full font-medium shrink-0"
+                            style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}
+                          >
+                            Listo
+                          </span>
+                          <button
+                            onClick={() => eliminarArchivo(idx)}
+                            className="shrink-0 rounded-lg p-1 transition-colors"
+                            style={{ color: "var(--texto-muted)" }}
+                            onMouseEnter={(e) => { e.currentTarget.style.background = "#fee2e2"; e.currentTarget.style.color = "#dc2626"; }}
+                            onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--texto-muted)"; }}
+                          >
+                            <IconTrash />
+                          </button>
                         </div>
-                        <span className="text-xs font-medium flex-1 truncate" style={{ color: "var(--texto-primario)" }}>{archivo.nombre}</span>
-                        <span className="text-[11px] shrink-0" style={{ color: "var(--texto-muted)" }}>{archivo.tamano}</span>
-                        <span className="text-[10px] px-2 py-0.5 rounded-full shrink-0" style={{
-                          background: archivo.estado === "listo" ? "var(--exito-light)" : "var(--azul-egm-light)",
-                          color: archivo.estado === "listo" ? "var(--exito)" : "var(--azul-egm)",
-                        }}>
-                          {archivo.estado === "listo" ? "Listo" : "Procesando"}
-                        </span>
-                        <button onClick={() => eliminarArchivo(idx)} className="shrink-0 transition-opacity hover:opacity-70" style={{ color: "var(--texto-muted)" }}>
-                          <IconTrash />
-                        </button>
-                      </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Panel 2: Tipo de generación */}
+            <div
+              className="rounded-2xl overflow-hidden"
+              style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", boxShadow: "0 1px 8px rgba(0,0,0,0.04)" }}
+            >
+              <div
+                className="px-6 py-4 flex items-center gap-3"
+                style={{ borderBottom: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}
+              >
+                <div className="w-8 h-8 rounded-lg flex items-center justify-center" style={{ background: "#ede9fe", color: "#7c3aed" }}>
+                  <IconSpark />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>Formato de salida</p>
+                  <p className="text-xs" style={{ color: "var(--texto-muted)" }}>¿Cómo quieres que la IA transforme el contenido?</p>
+                </div>
+              </div>
+
+              <div className="p-6">
+                <div className="grid grid-cols-2 gap-3">
+                  {TIPOS_CONFIG.map((tipo) => {
+                    const sel = tipoSeleccionado === tipo.id;
+                    return (
+                      <button
+                        key={tipo.id}
+                        onClick={() => setTipoSeleccionado(tipo.id)}
+                        className="rounded-xl p-4 text-left transition-all flex flex-col gap-3"
+                        style={{
+                          border:     `2px solid ${sel ? "var(--azul-egm)" : "var(--gris-borde)"}`,
+                          background: sel ? "var(--azul-egm-light)" : "var(--gris-pagina)",
+                          transform:  sel ? "translateY(-1px)" : "translateY(0)",
+                          boxShadow:  sel ? "0 4px 16px rgba(0,0,0,0.08)" : "none",
+                        }}
+                      >
+                        <div className="flex items-start justify-between">
+                          <div
+                            className="w-9 h-9 rounded-xl flex items-center justify-center"
+                            style={{ background: tipo.bg, color: tipo.color }}
+                          >
+                            {tipo.icono}
+                          </div>
+                          <div
+                            className="w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0"
+                            style={{
+                              background:   sel ? "var(--azul-egm)" : "transparent",
+                              borderColor:  sel ? "var(--azul-egm)" : "var(--gris-borde)",
+                              color:        "#fff",
+                            }}
+                          >
+                            {sel && <IconCheck />}
+                          </div>
+                        </div>
+                        <div>
+                          <p className="text-sm font-semibold mb-1" style={{ color: "var(--texto-primario)" }}>{tipo.nombre}</p>
+                          <p className="text-xs leading-relaxed" style={{ color: "var(--texto-muted)" }}>{tipo.desc}</p>
+                        </div>
+                      </button>
                     );
                   })}
                 </div>
-              )}
-            </div>
-
-            {/* Panel tipos de generación */}
-            <div className="rounded-xl p-5" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-              <p className="text-sm font-semibold mb-4" style={{ color: "var(--texto-primario)" }}>
-                ¿Qué quieres generar?
-              </p>
-              <div className="grid grid-cols-2 gap-3">
-                {tiposConfig.map((tipo) => {
-                  const sel = tipoSeleccionado === tipo.id;
-                  return (
-                    <div
-                      key={tipo.id}
-                      onClick={() => seleccionarTipo(tipo.id)}
-                      className="rounded-xl p-4 cursor-pointer transition-all flex flex-col gap-2"
-                      style={{
-                        border: `1.5px solid ${sel ? "var(--azul-egm)" : "var(--gris-borde)"}`,
-                        background: sel ? "var(--azul-egm-light)" : "var(--blanco)",
-                      }}
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="w-7 h-7 rounded-lg flex items-center justify-center" style={{ background: tipo.color, color: tipo.stroke }}>
-                          {tipo.icono}
-                        </div>
-                        <div
-                          className="w-4 h-4 rounded-full border flex items-center justify-center"
-                          style={{
-                            background: sel ? "var(--azul-egm)" : "transparent",
-                            borderColor: sel ? "var(--azul-egm)" : "var(--gris-borde)",
-                            color: "#fff",
-                          }}
-                        >
-                          {sel && <IconCheck />}
-                        </div>
-                      </div>
-                      <p className="text-xs font-semibold" style={{ color: "var(--texto-primario)" }}>{tipo.nombre}</p>
-                      <p className="text-[11px] leading-relaxed" style={{ color: "var(--texto-muted)" }}>{tipo.desc}</p>
-                    </div>
-                  );
-                })}
               </div>
             </div>
 
           </div>
 
-          {/* ── COLUMNA DERECHA ── */}
-          <div className="flex flex-col gap-5">
+          {/* ────── COLUMNA DERECHA ────── */}
+          <div className="flex flex-col gap-6">
 
-            {/* Formulario configuración */}
-            <div className="rounded-xl p-5" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-
-              {/* Nombre */}
-              <div className="mb-4">
-                <label className="block text-xs font-medium mb-1.5" style={{ color: "var(--texto-secundario)" }}>Nombre del módulo</label>
-                <input
-                  type="text"
-                  value={config.nombre}
-                  onChange={(e) => setConfig({ ...config, nombre: e.target.value })}
-                  placeholder="Ej: Manual de seguridad — Planta A"
-                  className="w-full text-sm px-3 py-2.5 rounded-lg outline-none transition-all"
-                  style={{ border: "1px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}
-                  onFocus={(e) => { e.target.style.borderColor = "var(--azul-egm)"; e.target.style.boxShadow = "0 0 0 3px var(--azul-egm-light)"; }}
-                  onBlur={(e) => { e.target.style.borderColor = "var(--gris-borde)"; e.target.style.boxShadow = "none"; }}
-                />
-              </div>
-
-              {/* Categoría */}
-              <div className="mb-4">
-                <label className="block text-xs font-medium mb-1.5" style={{ color: "var(--texto-secundario)" }}>Categoría</label>
-                <select value={config.categoria} onChange={(e) => setConfig({ ...config, categoria: e.target.value })}
-                  className="w-full text-sm px-3 py-2.5 rounded-lg outline-none cursor-pointer"
-                  style={{ border: "1px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}>
-                  <option value="ESPECIFICA">Formación específica</option>
-                  <option value="BASICA">Formación básica</option>
-                  <option value="DESARROLLO">Desarrollo profesional</option>
-                  <option value="IDENTIDAD">Identidad corporativa</option>
-                </select>
-              </div>
-
-              {/* Idioma */}
-              <div className="mb-4">
-                <label className="block text-xs font-medium mb-1.5" style={{ color: "var(--texto-secundario)" }}>Idioma del contenido</label>
-                <select value={config.idioma} onChange={(e) => setConfig({ ...config, idioma: e.target.value })}
-                  className="w-full text-sm px-3 py-2.5 rounded-lg outline-none cursor-pointer"
-                  style={{ border: "1px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}>
-                  <option value="es">Español</option>
-                  <option value="en">Inglés</option>
-                  <option value="ca">Valenciano</option>
-                </select>
-              </div>
-
-              {/* Duración */}
-              <div className="mb-4">
-                <label className="block text-xs font-medium mb-1.5" style={{ color: "var(--texto-secundario)" }}>Duración estimada</label>
-                <select value={config.duracion} onChange={(e) => setConfig({ ...config, duracion: e.target.value })}
-                  className="w-full text-sm px-3 py-2.5 rounded-lg outline-none cursor-pointer"
-                  style={{ border: "1px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}>
-                  <option value="corto">Corto (hasta 15 min)</option>
-                  <option value="medio">Medio (15–45 min)</option>
-                  <option value="largo">Largo (más de 45 min)</option>
-                </select>
-              </div>
-
-              {/* Asignar a */}
-              <div className="mb-5">
-                <label className="block text-xs font-medium mb-1.5" style={{ color: "var(--texto-secundario)" }}>Asignar a</label>
-                <select value={config.asignarA} onChange={(e) => setConfig({ ...config, asignarA: e.target.value })}
-                  className="w-full text-sm px-3 py-2.5 rounded-lg outline-none cursor-pointer"
-                  style={{ border: "1px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}>
-                  <option value="todos">Todos los empleados</option>
-                  <option value="nuevos">Nuevos empleados</option>
-                  <option value="tecnicos">Técnicos de planta</option>
-                  <option value="manual">Selección manual</option>
-                </select>
-              </div>
-
-              <div className="h-px mb-5" style={{ background: "var(--gris-borde)" }} />
-
-              {/* Validación */}
-              {archivos.length === 0 && (
-                <p className="text-xs text-center mb-3" style={{ color: "var(--advertencia)" }}>
-                  ⚠ Sube al menos un archivo para continuar
-                </p>
-              )}
-              {!config.nombre.trim() && archivos.length > 0 && (
-                <p className="text-xs text-center mb-3" style={{ color: "var(--advertencia)" }}>
-                  ⚠ Escribe un nombre para el módulo
-                </p>
-              )}
-
-              {/* Botón generar */}
-              <button
-                onClick={iniciarGeneracion}
-                disabled={generando || archivos.length === 0 || !config.nombre.trim()}
-                className="w-full py-3 rounded-lg text-sm font-semibold flex items-center justify-center gap-2 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                style={{
-                  background: generado ? "var(--exito)" : "var(--marino)",
-                  color: "#fff",
-                }}
+            {/* Formulario de configuración */}
+            <div
+              className="rounded-2xl overflow-hidden"
+              style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", boxShadow: "0 1px 8px rgba(0,0,0,0.04)" }}
+            >
+              <div
+                className="px-6 py-4"
+                style={{ borderBottom: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}
               >
-                {generado ? (
-                  <><IconCheck /> Generado</>
-                ) : generando ? (
-                  <span>Generando…</span>
-                ) : (
-                  <><IconAI /> Generar</>
-                )}
-              </button>
+                <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>Configuración del módulo</p>
+                <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>Define los parámetros del módulo formativo</p>
+              </div>
 
-              {/* Barra de progreso */}
-              {generando && (
-                <div className="mt-3">
-                  <div className="w-full h-1 rounded-full overflow-hidden" style={{ background: "var(--gris-superficie)" }}>
-                    <div
-                      className="h-1 rounded-full transition-all duration-700"
-                      style={{ width: `${progreso}%`, background: "var(--azul-egm)" }}
-                    />
-                  </div>
-                  <p className="text-[11px] text-center mt-2" style={{ color: "var(--texto-muted)" }}>{mensajeProgreso}</p>
+              <div className="p-6 flex flex-col gap-4">
+
+                {/* Nombre */}
+                <div>
+                  <label className="block text-xs font-semibold mb-1.5" style={{ color: "var(--texto-secundario)" }}>
+                    Nombre del módulo <span style={{ color: "#dc2626" }}>*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={config.nombre}
+                    onChange={(e) => setConfig({ ...config, nombre: e.target.value })}
+                    placeholder="Ej: Manual de seguridad — Planta A"
+                    className="w-full text-sm px-4 py-3 rounded-xl outline-none transition-all"
+                    style={{ border: "1.5px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}
+                    onFocus={(e) => { e.target.style.borderColor = "var(--azul-egm)"; e.target.style.background = "var(--blanco)"; e.target.style.boxShadow = "0 0 0 3px var(--azul-egm-light)"; }}
+                    onBlur={(e)  => { e.target.style.borderColor = "var(--gris-borde)"; e.target.style.background = "var(--gris-pagina)"; e.target.style.boxShadow = "none"; }}
+                  />
                 </div>
-              )}
+
+                {/* Categoría + Idioma */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-xs font-semibold mb-1.5" style={{ color: "var(--texto-secundario)" }}>Categoría</label>
+                    <select
+                      value={config.categoria}
+                      onChange={(e) => setConfig({ ...config, categoria: e.target.value })}
+                      className="w-full text-sm px-3 py-3 rounded-xl outline-none cursor-pointer"
+                      style={{ border: "1.5px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}
+                    >
+                      <option value="ESPECIFICA">Específica</option>
+                      <option value="BASICA">Básica</option>
+                      <option value="DESARROLLO">Desarrollo</option>
+                      <option value="IDENTIDAD">Corporativa</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-semibold mb-1.5" style={{ color: "var(--texto-secundario)" }}>Idioma</label>
+                    <select
+                      value={config.idioma}
+                      onChange={(e) => setConfig({ ...config, idioma: e.target.value })}
+                      className="w-full text-sm px-3 py-3 rounded-xl outline-none cursor-pointer"
+                      style={{ border: "1.5px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}
+                    >
+                      <option value="es">Español</option>
+                      <option value="en">Inglés</option>
+                      <option value="ca">Valenciano</option>
+                    </select>
+                  </div>
+                </div>
+
+                {/* Duración + Asignar a */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-xs font-semibold mb-1.5" style={{ color: "var(--texto-secundario)" }}>Duración</label>
+                    <select
+                      value={config.duracion}
+                      onChange={(e) => setConfig({ ...config, duracion: e.target.value })}
+                      className="w-full text-sm px-3 py-3 rounded-xl outline-none cursor-pointer"
+                      style={{ border: "1.5px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}
+                    >
+                      <option value="corto">Corto (−15 min)</option>
+                      <option value="medio">Medio (15–45 min)</option>
+                      <option value="largo">Largo (+45 min)</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-semibold mb-1.5" style={{ color: "var(--texto-secundario)" }}>Asignar a</label>
+                    <select
+                      value={config.asignarA}
+                      onChange={(e) => setConfig({ ...config, asignarA: e.target.value })}
+                      className="w-full text-sm px-3 py-3 rounded-xl outline-none cursor-pointer"
+                      style={{ border: "1.5px solid var(--gris-borde)", color: "var(--texto-primario)", background: "var(--gris-pagina)" }}
+                    >
+                      <option value="todos">Todos</option>
+                      <option value="nuevos">Nuevos</option>
+                      <option value="tecnicos">Técnicos</option>
+                      <option value="manual">Manual</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div style={{ height: "1px", background: "var(--gris-borde)" }} />
+
+                {/* Validaciones */}
+                {archivos.length === 0 && (
+                  <div className="flex items-center gap-2 text-xs px-3 py-2 rounded-lg" style={{ background: "#fef9c3", color: "#854d0e" }}>
+                    <span>⚠</span> Sube al menos un archivo para continuar
+                  </div>
+                )}
+                {!config.nombre.trim() && archivos.length > 0 && (
+                  <div className="flex items-center gap-2 text-xs px-3 py-2 rounded-lg" style={{ background: "#fef9c3", color: "#854d0e" }}>
+                    <span>⚠</span> Escribe un nombre para el módulo
+                  </div>
+                )}
+
+                {/* Botón generar */}
+                <button
+                  onClick={iniciarGeneracion}
+                  disabled={generando || !puedeGenerar}
+                  className="w-full py-3.5 rounded-xl text-sm font-bold flex items-center justify-center gap-2.5 transition-all"
+                  style={{
+                    background:  generado     ? "var(--verde-oliva)"
+                               : puedeGenerar ? "var(--azul-egm)"
+                               : "var(--gris-superficie)",
+                    color:       puedeGenerar || generado ? "#fff" : "var(--texto-muted)",
+                    cursor:      !puedeGenerar || generando ? "not-allowed" : "pointer",
+                    boxShadow:   puedeGenerar && !generando ? "0 4px 14px rgba(30,64,175,0.3)" : "none",
+                    transform:   puedeGenerar && !generando ? "translateY(0)" : "none",
+                  }}
+                  onMouseEnter={(e) => { if (puedeGenerar && !generando) e.currentTarget.style.transform = "translateY(-1px)"; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.transform = "translateY(0)"; }}
+                >
+                  {generado ? (
+                    <><IconCheck /> Módulo generado</>
+                  ) : generando ? (
+                    <>
+                      <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                      Generando…
+                    </>
+                  ) : (
+                    <><IconAI /> Generar con IA</>
+                  )}
+                </button>
+
+                {/* Barra de progreso */}
+                {generando && (
+                  <div>
+                    <div className="w-full rounded-full overflow-hidden" style={{ height: "6px", background: "var(--gris-superficie)" }}>
+                      <div
+                        className="h-full rounded-full transition-all duration-700"
+                        style={{ width: `${progreso}%`, background: "linear-gradient(90deg, var(--azul-egm), #A3B535)" }}
+                      />
+                    </div>
+                    <p className="text-xs text-center mt-2" style={{ color: "var(--texto-muted)" }}>{mensajeProgreso}</p>
+                  </div>
+                )}
+              </div>
             </div>
 
-            {/* Vista previa */}
-            <div className="rounded-xl p-5" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-              <div className="flex items-center justify-between mb-4">
-                <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>Vista previa del módulo</p>
-                <span className="text-[10px] px-2 py-1 rounded-full font-medium" style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                  Generado por IA
+            {/* Vista previa estructural */}
+            <div
+              className="rounded-2xl overflow-hidden"
+              style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", boxShadow: "0 1px 8px rgba(0,0,0,0.04)" }}
+            >
+              <div
+                className="px-6 py-4 flex items-center justify-between"
+                style={{ background: "var(--marino)", borderBottom: "1px solid rgba(255,255,255,0.1)" }}
+              >
+                <div>
+                  <p className="text-sm font-semibold text-white truncate">
+                    {config.nombre || "Vista previa del módulo"}
+                  </p>
+                  <p className="text-xs mt-0.5" style={{ color: "rgba(255,255,255,0.5)" }}>
+                    {config.categoria === "ESPECIFICA" ? "Form. específica"
+                     : config.categoria === "BASICA"   ? "Form. básica"
+                     : config.categoria === "DESARROLLO" ? "Desarrollo"
+                     : "Corporativo"} · {config.idioma === "es" ? "Español" : config.idioma === "en" ? "Inglés" : "Valenciano"}
+                  </p>
+                </div>
+                <span className="text-[10px] px-2 py-1 rounded-full font-semibold shrink-0" style={{ background: "rgba(163,181,53,0.2)", color: "#A3B535" }}>
+                  IA
                 </span>
               </div>
 
-              <div className="rounded-xl overflow-hidden" style={{ border: "1px solid var(--gris-borde)" }}>
-                {/* Cabecera módulo */}
-                <div className="px-4 py-3 flex items-center justify-between" style={{ background: "var(--marino)" }}>
-                  <span className="text-sm font-medium text-white truncate">
-                    {config.nombre || "Nombre del módulo"}
-                  </span>
-                  <span className="text-[10px] px-2 py-0.5 rounded-full ml-2 shrink-0" style={{ background: "rgba(255,255,255,0.15)", color: "#fff" }}>
-                    {config.categoria === "ESPECIFICA" ? "Form. específica" :
-                      config.categoria === "BASICA" ? "Form. básica" :
-                      config.categoria === "DESARROLLO" ? "Desarrollo" : "Identidad"}
-                  </span>
-                </div>
-
-                {/* Secciones */}
-                <div className="p-4 flex flex-col divide-y" style={{ borderColor: "var(--gris-superficie)" }}>
-                  {[
-                    { bg: "var(--azul-egm-light)", stroke: "var(--azul-egm)", titulo: "Objetivos del módulo", desc: "3 objetivos clave extraídos del manual", tag: "Auto" },
-                    { bg: "var(--exito-light)", stroke: "var(--exito)", titulo: "Lecciones generadas", desc: "5 lecciones · 30 min estimados", tag: "5 lec." },
-                    { bg: "#fef3c7", stroke: "#d97706", titulo: "Cuestionario final", desc: "10 preguntas de comprensión", tag: "Auto" },
-                    { bg: "#e0f2fe", stroke: "#0284c7", titulo: "Resumen descargable", desc: "PDF con puntos clave estructurados", tag: "PDF" },
-                  ].map((s) => (
-                    <div key={s.titulo} className="flex items-start gap-3 py-2.5">
-                      <div className="w-6 h-6 rounded-md flex items-center justify-center shrink-0" style={{ background: s.bg, color: s.stroke }}>
-                        <IconDoc />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-xs font-medium" style={{ color: "var(--texto-primario)" }}>{s.titulo}</p>
-                        <p className="text-[11px] mt-0.5" style={{ color: "var(--texto-muted)" }}>{s.desc}</p>
-                      </div>
-                      <span className="text-[10px] px-2 py-0.5 rounded-full shrink-0" style={{ background: s.bg, color: s.stroke }}>
-                        {s.tag}
-                      </span>
+              <div className="divide-y" style={{ borderColor: "var(--gris-borde)" }}>
+                {[
+                  { bg: "var(--azul-egm-light)", color: "var(--azul-egm)", titulo: "Objetivos del módulo",  desc: "3 objetivos extraídos automáticamente",   tag: "Auto" },
+                  { bg: "#dcfce7",               color: "#15803d",          titulo: "Lecciones generadas",  desc: "5 lecciones · estimado 30 min",            tag: "5 lec." },
+                  { bg: "#fef3c7",               color: "#b45309",          titulo: "Cuestionario final",   desc: "10 preguntas de comprensión lectora",       tag: "Auto" },
+                  { bg: "#e0f2fe",               color: "#0284c7",          titulo: "Resumen descargable",  desc: "PDF con puntos clave estructurados",        tag: "PDF" },
+                ].map((s, i) => (
+                  <div key={i} className="flex items-center gap-3 px-5 py-3.5">
+                    <div className="w-7 h-7 rounded-lg flex items-center justify-center shrink-0" style={{ background: s.bg, color: s.color }}>
+                      <IconDoc />
                     </div>
-                  ))}
-                </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-semibold" style={{ color: "var(--texto-primario)" }}>{s.titulo}</p>
+                      <p className="text-[11px] mt-0.5" style={{ color: "var(--texto-muted)" }}>{s.desc}</p>
+                    </div>
+                    <span className="text-[10px] px-2 py-0.5 rounded-full font-medium shrink-0" style={{ background: s.bg, color: s.color }}>{s.tag}</span>
+                  </div>
+                ))}
               </div>
             </div>
 
           </div>
         </div>
 
-        {/* ── Banner de éxito ── */}
+        {/* ══════════════ BANNER ÉXITO ══════════════ */}
         {generado && (
-          <div className="mt-6 rounded-xl p-5" style={{ background: "var(--exito-light)", border: "1.5px solid var(--exito)" }}>
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 rounded-full flex items-center justify-center shrink-0" style={{ background: "var(--exito)", color: "#fff" }}>
-                <svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-                  <polyline points="20 6 9 17 4 12"/>
-                </svg>
-              </div>
-              <div className="flex-1">
-                <p className="text-sm font-bold mb-1" style={{ color: "var(--texto-primario)" }}>
-                  Módulo generado y subido a la plataforma con éxito
-                </p>
-                <p className="text-xs" style={{ color: "var(--texto-secundario)" }}>
-                  El módulo <strong>{resultadoIA?.titulo || config.nombre}</strong> se ha creado correctamente y ya está disponible en la plataforma para ser asignado a los empleados.
-                </p>
-              </div>
+          <div
+            className="mt-8 rounded-2xl p-6 flex items-start gap-5"
+            style={{ background: "#f0fdf4", border: "2px solid var(--verde-oliva)" }}
+          >
+            <div
+              className="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
+              style={{ background: "var(--verde-oliva)", color: "#fff" }}
+            >
+              <IconCheck />
+            </div>
+            <div className="flex-1">
+              <p className="text-base font-bold mb-1" style={{ color: "var(--texto-primario)" }}>
+                ¡Módulo generado y publicado con éxito!
+              </p>
+              <p className="text-sm" style={{ color: "var(--texto-muted)" }}>
+                <strong>{resultadoIA?.titulo || config.nombre}</strong> ya está disponible en la plataforma y listo para asignar a los empleados.
+              </p>
+            </div>
+            <div className="flex gap-3 shrink-0">
               <button
-                onClick={() => router.push("/dashboard/formacion")}
-                className="shrink-0 text-xs font-semibold px-4 py-2 rounded-lg transition-opacity hover:opacity-80"
-                style={{ background: "var(--exito)", color: "#fff" }}
+                onClick={() => router.push("/dashboard/admin?tab=formaciones")}
+                className="text-sm font-semibold px-4 py-2.5 rounded-xl transition-opacity hover:opacity-80"
+                style={{ background: "var(--blanco)", color: "var(--texto-primario)", border: "1px solid var(--gris-borde)" }}
               >
                 Ver módulos
+              </button>
+              <button
+                onClick={() => { setGenerado(false); setArchivos([]); setArchivosRaw([]); setConfig({ nombre: "", categoria: "ESPECIFICA", idioma: "es", duracion: "medio", asignarA: "todos" }); setPaso(1); setResultadoIA(null); }}
+                className="text-sm font-semibold px-4 py-2.5 rounded-xl transition-opacity hover:opacity-80"
+                style={{ background: "var(--verde-oliva)", color: "#fff" }}
+              >
+                Crear otro
               </button>
             </div>
           </div>
         )}
 
-        {/* ── Contenido generado ── */}
+        {/* Contenido IA generado */}
         {generado && resultadoIA && (
-          <div className="mt-4 rounded-xl p-5" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-            <p className="text-sm font-semibold mb-4" style={{ color: "var(--texto-primario)" }}>
-              Contenido generado por IA
-            </p>
-            <div className="rounded-lg p-4" style={{ background: "var(--gris-pagina)", border: "1px solid var(--gris-borde)" }}>
-              <p className="text-base font-bold mb-1" style={{ color: "var(--texto-primario)" }}>{resultadoIA.titulo}</p>
-              <p className="text-sm mb-3" style={{ color: "var(--texto-secundario)" }}>{resultadoIA.descripcion}</p>
-              <p className="text-sm leading-relaxed whitespace-pre-wrap" style={{ color: "var(--texto-secundario)" }}>{resultadoIA.contenido}</p>
+          <div className="mt-4 rounded-2xl overflow-hidden" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+            <div className="px-6 py-4 flex items-center gap-2" style={{ borderBottom: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}>
+              <IconAI />
+              <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>Contenido generado por IA</p>
+            </div>
+            <div className="p-6">
+              <p className="text-lg font-bold mb-1" style={{ color: "var(--texto-primario)" }}>{resultadoIA.titulo}</p>
+              <p className="text-sm mb-4" style={{ color: "var(--texto-muted)" }}>{resultadoIA.descripcion}</p>
+              <div className="rounded-xl p-4" style={{ background: "var(--gris-pagina)", border: "1px solid var(--gris-borde)" }}>
+                <p className="text-sm leading-relaxed whitespace-pre-wrap" style={{ color: "var(--texto-secundario)" }}>{resultadoIA.contenido}</p>
+              </div>
             </div>
           </div>
         )}
 
+      </div>
     </div>
   );
 }

--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -19,6 +19,15 @@ const EMPTY_ANUNCIO: NoticiaInput = {
 
 const ROL_EMPLEADO_ID = "6251ef28-e6a3-4a3b-8121-e622da855d86";
 
+const MOCK_MODULO_STATS = [
+  { asignados: 28, completado: 64 },
+  { asignados: 28, completado: 89 },
+  { asignados: 28, completado: 43 },
+  { asignados: 28, completado: 17 },
+  { asignados: 28, completado: 71 },
+  { asignados: 28, completado: 55 },
+];
+
 interface Usuario {
   usuarioId: string;
   nombre: string;
@@ -307,7 +316,9 @@ function AdminContent() {
             {/* Header */}
             <div className="flex items-start justify-between mb-8">
               <div>
-                <h1 className="text-2xl font-bold" style={{ color: "var(--texto-primario)" }}>Empleados</h1>
+                <h1 style={{ fontFamily: "'Instrument Serif', serif", fontStyle: "italic", fontSize: "clamp(1.8rem, 2.5vw, 2.2rem)", fontWeight: 400, color: "var(--texto-primario)", letterSpacing: "-0.02em" }}>
+                  Empleados
+                </h1>
                 <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
                   {empleados.length} persona{empleados.length !== 1 ? "s" : ""} en tu empresa
                 </p>
@@ -510,12 +521,9 @@ function AdminContent() {
                                 </span>
                               </td>
                               <td className="py-4 px-5 text-right">
-                                <button
-                                  onClick={(ev) => { ev.stopPropagation(); handleDesactivarEmpleado(e.usuarioId); }}
-                                  className="text-xs font-semibold hover:underline"
-                                  style={{ color: "var(--error)" }}>
-                                  Desactivar
-                                </button>
+                                <svg className="w-4 h-4 ml-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} style={{ color: "var(--gris-borde)" }}>
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                                </svg>
                               </td>
                             </tr>
                           ))}
@@ -607,6 +615,27 @@ function AdminContent() {
                     <DrawerRow label="Estado" value={empleadoSeleccionado.activo ? "Activo" : "Inactivo"} />
                     <DrawerRow label="Alta" value={formatFecha(empleadoSeleccionado.fechaRegistro)} />
                   </div>
+                  {/* Formación asignada */}
+                  <div className="pt-4" style={{ borderTop: "1px solid var(--gris-borde)" }}>
+                    <p className="text-xs font-semibold mb-3" style={{ color: "var(--texto-muted)", textTransform: "uppercase", letterSpacing: "0.08em" }}>Formación asignada</p>
+                    <div className="flex flex-col gap-2.5">
+                      {[
+                        { nombre: "Prevención de Riesgos", pct: 100, color: "var(--verde-oliva)" },
+                        { nombre: "Protección de Datos",   pct: 72,  color: "var(--azul-egm)" },
+                        { nombre: "Onboarding Corporativo", pct: 45, color: "#f59e0b" },
+                      ].map((m) => (
+                        <div key={m.nombre}>
+                          <div className="flex items-center justify-between mb-1">
+                            <p className="text-xs" style={{ color: "var(--texto-primario)" }}>{m.nombre}</p>
+                            <span className="text-xs font-semibold" style={{ color: m.color }}>{m.pct}%</span>
+                          </div>
+                          <div className="w-full rounded-full overflow-hidden" style={{ height: "4px", background: "var(--gris-superficie)" }}>
+                            <div style={{ width: `${m.pct}%`, height: "100%", background: m.color, borderRadius: "9999px" }} />
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
                   <div className="pt-1" style={{ borderTop: "1px solid var(--gris-borde)" }}>
                     <button
                       onClick={() => handleDesactivarEmpleado(empleadoSeleccionado.usuarioId)}
@@ -668,7 +697,9 @@ function AdminContent() {
             {/* Header */}
             <div className="flex items-start justify-between mb-8">
               <div>
-                <h1 className="text-2xl font-bold" style={{ color: "var(--texto-primario)" }}>Gestión de Anuncios</h1>
+                <h1 style={{ fontFamily: "'Instrument Serif', serif", fontStyle: "italic", fontSize: "clamp(1.8rem, 2.5vw, 2.2rem)", fontWeight: 400, color: "var(--texto-primario)", letterSpacing: "-0.02em" }}>
+                  Gestión de Anuncios
+                </h1>
                 <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>Comunica novedades a todos los empleados</p>
               </div>
               <button
@@ -776,37 +807,38 @@ function AdminContent() {
               <div className="flex flex-col gap-4">
                 {noticias.filter((n) => n.activo).map((n) => (
                   <div key={n.anuncioId}
-                    className="rounded-2xl px-5 py-4"
-                    style={{
-                      background: "var(--blanco)",
-                      border: "1px solid var(--gris-borde)",
-                      borderLeft: `4px solid ${n.esGlobal ? "var(--verde-oliva)" : "var(--azul-egm)"}`,
-                    }}>
-                    <p className="text-base font-semibold" style={{ color: "var(--texto-primario)" }}>{n.titulo}</p>
-                    <p className="text-sm mt-1 line-clamp-2" style={{ color: "var(--texto-secundario)" }}>{n.contenido}</p>
-                    <div className="flex items-center justify-between mt-3 pt-3"
-                      style={{ borderTop: "1px solid var(--gris-borde)" }}>
-                      <div className="flex items-center gap-2">
-                        {n.esGlobal && (
-                          <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
-                            style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}>
-                            Global
+                    className="rounded-2xl overflow-hidden"
+                    style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                    {/* Franja superior de color */}
+                    <div style={{ height: "3px", background: n.esGlobal ? "var(--verde-oliva)" : "var(--azul-egm)" }} />
+                    <div className="px-6 py-5">
+                      <div className="flex items-start justify-between gap-4 mb-2">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="text-xs font-bold uppercase tracking-wider px-2.5 py-1 rounded-full"
+                            style={{ background: n.esGlobal ? "var(--verde-oliva-light)" : "var(--azul-egm-light)", color: n.esGlobal ? "var(--verde-oliva)" : "var(--azul-egm)" }}>
+                            {n.esGlobal ? "Global" : "Empresa"}
                           </span>
-                        )}
-                        <span className="text-xs" style={{ color: "var(--texto-muted)" }}>
-                          {formatFecha(n.creadoEn)}
-                        </span>
+                          <span className="text-xs" style={{ color: "var(--texto-muted)" }}>{formatFecha(n.creadoEn)}</span>
+                        </div>
+                        <div className="flex items-center gap-3 shrink-0">
+                          <button onClick={() => handleEditAnuncio(n)}
+                            className="text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors"
+                            style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}
+                            onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.75")}
+                            onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}>
+                            Editar
+                          </button>
+                          <button onClick={() => handleDeleteAnuncio(n.anuncioId)}
+                            className="text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors"
+                            style={{ background: "var(--error-light)", color: "var(--error)" }}
+                            onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.75")}
+                            onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}>
+                            Desactivar
+                          </button>
+                        </div>
                       </div>
-                      <div className="flex items-center gap-4">
-                        <button onClick={() => handleEditAnuncio(n)}
-                          className="text-xs font-semibold hover:underline" style={{ color: "var(--azul-egm)" }}>
-                          Editar
-                        </button>
-                        <button onClick={() => handleDeleteAnuncio(n.anuncioId)}
-                          className="text-xs font-semibold hover:underline" style={{ color: "var(--error)" }}>
-                          Desactivar
-                        </button>
-                      </div>
+                      <p className="text-base font-semibold mb-1" style={{ color: "var(--texto-primario)" }}>{n.titulo}</p>
+                      <p className="text-sm leading-relaxed" style={{ color: "var(--texto-muted)" }}>{n.contenido}</p>
                     </div>
                   </div>
                 ))}
@@ -821,7 +853,9 @@ function AdminContent() {
             {/* Header */}
             <div className="flex items-start justify-between mb-8">
               <div>
-                <h1 className="text-2xl font-bold" style={{ color: "var(--texto-primario)" }}>Gestión de Módulos</h1>
+                <h1 style={{ fontFamily: "'Instrument Serif', serif", fontStyle: "italic", fontSize: "clamp(1.8rem, 2.5vw, 2.2rem)", fontWeight: 400, color: "var(--texto-primario)", letterSpacing: "-0.02em" }}>
+                  Gestión de Módulos
+                </h1>
                 <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>Administra los módulos formativos de tu empresa</p>
               </div>
               <button
@@ -871,8 +905,9 @@ function AdminContent() {
               </div>
             ) : (
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
-                {formaciones.map((f) => {
+                {formaciones.map((f, fIdx) => {
                   const accentColor = tipoAccentColor[f.tipoModulo] ?? "var(--azul-egm)";
+                  const mockStats = MOCK_MODULO_STATS[fIdx % MOCK_MODULO_STATS.length];
                   return (
                     <div
                       key={f.moduloId}
@@ -912,6 +947,22 @@ function AdminContent() {
                         {f.descripcion}
                       </p>
 
+                      {/* Mock stats */}
+                      <div className="flex items-center gap-4 mt-3 mb-1">
+                        <span className="text-xs flex items-center gap-1.5" style={{ color: "var(--texto-muted)" }}>
+                          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+                          </svg>
+                          {mockStats.asignados} asignados
+                        </span>
+                        <span className="text-xs flex items-center gap-1.5" style={{ color: "var(--verde-oliva)" }}>
+                          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                          </svg>
+                          {mockStats.completado}% completado
+                        </span>
+                      </div>
+
                       {/* Actions */}
                       <div className="flex items-center justify-end gap-3 mt-4 pt-3"
                         style={{ borderTop: "1px solid var(--gris-borde)" }}>
@@ -939,29 +990,68 @@ function AdminContent() {
               </div>
             )}
 
-            {/* Seguimiento de empleados */}
-            <div className="rounded-2xl p-8"
-              style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-              <div className="flex flex-col items-center justify-center text-center py-6">
-                <div className="w-16 h-16 rounded-2xl flex items-center justify-center mb-5"
-                  style={{ background: "var(--azul-egm-light)" }}>
-                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--azul-egm)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-                    <circle cx="9" cy="7" r="4" />
-                    <polyline points="22 12 18 12 20 9 18 6" />
-                    <line x1="22" y1="12" x2="16" y2="12" />
-                  </svg>
+            {/* Seguimiento de empleados — tabla mockeada */}
+            <div className="rounded-2xl overflow-hidden" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+              <div className="px-6 py-4 flex items-center justify-between" style={{ borderBottom: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}>
+                <div>
+                  <p style={{ fontFamily: "'Instrument Serif', serif", fontStyle: "italic", fontSize: "1.4rem", fontWeight: 400, color: "var(--texto-primario)" }}>
+                    Progreso del equipo
+                  </p>
+                  <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>Seguimiento individual por empleado</p>
                 </div>
-                <div className="flex items-center gap-2 mb-3">
-                  <h2 className="text-lg font-bold" style={{ color: "var(--texto-primario)" }}>Seguimiento de empleados</h2>
-                  <span className="text-xs font-bold px-3 py-1 rounded-full"
-                    style={{ background: "var(--azul-egm)", color: "white", letterSpacing: "0.05em" }}>
-                    PRÓXIMAMENTE
-                  </span>
-                </div>
-                <p className="text-sm max-w-sm" style={{ color: "var(--texto-muted)" }}>
-                  Pronto podrás consultar el progreso individual de cada empleado en sus módulos formativos.
-                </p>
+                <span className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                  {empleados.length > 0 ? empleados.length : 4} empleados
+                </span>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr style={{ background: "var(--gris-pagina)", borderBottom: "1px solid var(--gris-borde)" }}>
+                      {["Empleado", "Prevención RR.LL.", "Protección Datos", "Comunicación", "Onboarding", "Media"].map((h) => (
+                        <th key={h} className="text-left py-3 px-4 text-xs font-bold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[
+                      { nombre: "Ana García",    apellidos: "Martínez", pcts: [100, 72, 45, 100] },
+                      { nombre: "Carlos Ruiz",   apellidos: "López",    pcts: [100, 100, 80, 100] },
+                      { nombre: "María López",   apellidos: "Sánchez",  pcts: [65,  40,  20, 100] },
+                      { nombre: "David Torres",  apellidos: "Gil",      pcts: [30,  15,  0,  80]  },
+                    ].map((emp, idx, arr) => {
+                      const media = Math.round(emp.pcts.reduce((a, b) => a + b, 0) / emp.pcts.length);
+                      const initials = [emp.nombre, emp.apellidos].join(" ").split(" ").slice(0, 2).map(p => p[0]).join("");
+                      return (
+                        <tr key={emp.nombre} style={{ borderBottom: idx < arr.length - 1 ? "1px solid var(--gris-borde)" : "none" }}>
+                          <td className="py-3.5 px-4">
+                            <div className="flex items-center gap-2.5">
+                              <div className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+                                style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                                {initials}
+                              </div>
+                              <div>
+                                <p className="text-sm font-medium" style={{ color: "var(--texto-primario)" }}>{emp.nombre} {emp.apellidos}</p>
+                              </div>
+                            </div>
+                          </td>
+                          {emp.pcts.map((pct, i) => (
+                            <td key={i} className="py-3.5 px-4">
+                              <div className="flex items-center gap-2">
+                                <div className="w-16 rounded-full overflow-hidden" style={{ height: "5px", background: "var(--gris-superficie)" }}>
+                                  <div style={{ width: `${pct}%`, height: "100%", background: pct === 100 ? "var(--verde-oliva)" : pct >= 50 ? "var(--azul-egm)" : "#f59e0b", borderRadius: "9999px" }} />
+                                </div>
+                                <span className="text-xs font-semibold" style={{ color: pct === 100 ? "var(--verde-oliva)" : pct >= 50 ? "var(--azul-egm)" : "#b45309" }}>{pct}%</span>
+                              </div>
+                            </td>
+                          ))}
+                          <td className="py-3.5 px-4">
+                            <span className="text-sm font-bold" style={{ color: media >= 80 ? "var(--verde-oliva)" : media >= 50 ? "var(--azul-egm)" : "#b45309" }}>{media}%</span>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
               </div>
             </div>
           </>

--- a/app/dashboard/formacion/page.tsx
+++ b/app/dashboard/formacion/page.tsx
@@ -69,6 +69,15 @@ function leerPorcentajeLS(moduloId: string): number | null {
   } catch { return null; }
 }
 
+const DURACION_POR_TIPO: Record<string, string> = {
+  IDENTIDAD:  "20 min",
+  BASICA:     "35 min",
+  ESPECIFICA: "50 min",
+  DESARROLLO: "45 min",
+  COMUNIDAD:  "25 min",
+  RECOMPENSAS:"15 min",
+};
+
 function enriquecer(m: ModuloConProgreso): ModuloEnriquecido {
   const pctLS = leerPorcentajeLS(m.moduloId);
   const porcentaje = pctLS !== null ? pctLS
@@ -76,7 +85,8 @@ function enriquecer(m: ModuloConProgreso): ModuloEnriquecido {
   const status = pctLS !== null
     ? (pctLS >= 100 ? "completado" : pctLS > 0 ? "en progreso" : "pendiente")
     : m.status;
-  return { ...m, status, duracion: "—", porcentaje };
+  const duracion = DURACION_POR_TIPO[m.tipoModulo] ?? "30 min";
+  return { ...m, status, duracion, porcentaje };
 }
 
 // ── Tipos de filtro ───────────────────────────────────────────────────────────
@@ -175,7 +185,7 @@ export default function FormacionPage() {
         <>
           {/* ── Barra de búsqueda + filtros ──────────────────────────── */}
           <div className="flex items-center justify-between gap-2 mb-10">
-            <h2 className="text-4xl font-bold" style={{ color: "var(--texto-primario)", fontFamily: "var(--font-poppins), sans-serif" }}>
+            <h2 style={{ fontFamily: "'Instrument Serif', serif", fontStyle: "italic", fontWeight: 400, fontSize: "clamp(2rem, 3vw, 2.6rem)", color: "var(--texto-primario)", letterSpacing: "-0.02em" }}>
               Módulos
             </h2>
             <div className="flex items-center gap-2">

--- a/components/pages/AdminEmpresa.tsx
+++ b/components/pages/AdminEmpresa.tsx
@@ -23,6 +23,22 @@ interface Anuncio {
   actualizadoEn: string;
 }
 
+// ── Mock data (sustituir cuando la API lo soporte) ──────────────────────────
+const MOCK_MODULOS = [
+  { id: "m1", nombre: "Prevención de Riesgos Laborales", completados: 18, enProgreso: 6, pendientes: 4, total: 28 },
+  { id: "m2", nombre: "Protección de Datos (RGPD)",      completados: 22, enProgreso: 3, pendientes: 3, total: 28 },
+  { id: "m3", nombre: "Habilidades de Comunicación",     completados: 12, enProgreso: 9, pendientes: 7, total: 28 },
+  { id: "m4", nombre: "Onboarding Corporativo",          completados: 25, enProgreso: 2, pendientes: 1, total: 28 },
+];
+
+const MOCK_ACTIVIDAD = [
+  { hora: "Hace 5 min",   texto: "Ana García completó «Prevención de Riesgos»",    tipo: "completado" },
+  { hora: "Hace 22 min",  texto: "Carlos Ruiz inició «Protección de Datos»",        tipo: "inicio"     },
+  { hora: "Hace 1 h",     texto: "María López obtuvo el 100% en Onboarding",        tipo: "logro"      },
+  { hora: "Hace 3 h",     texto: "5 empleados completaron «Habilidades Comunicación»", tipo: "grupo"   },
+  { hora: "Ayer",         texto: "Nuevo módulo «Excel Avanzado» publicado",          tipo: "nuevo"      },
+];
+
 function formatFecha(iso: string) {
   return new Date(iso).toLocaleDateString("es-ES", { day: "numeric", month: "short" });
 }
@@ -32,15 +48,52 @@ function TituloSeccion({ children, noMargin }: { children: React.ReactNode; noMa
     <h2
       className={noMargin ? "" : "mb-6"}
       style={{
-        fontSize:      "clamp(2rem, 2.8vw, 2.8rem)",
+        fontSize:      "clamp(1.6rem, 2.4vw, 2.4rem)",
         fontFamily:    "'Instrument Serif', serif",
         fontWeight:    400,
         color:         "var(--texto-primario)",
         letterSpacing: "-0.02em",
+        lineHeight:    1.2,
       }}
     >
       {children}
     </h2>
+  );
+}
+
+function ActividadIcon({ tipo }: { tipo: string }) {
+  const configs: Record<string, { bg: string; color: string; path: string }> = {
+    completado: {
+      bg: "var(--verde-oliva-light)", color: "var(--verde-oliva)",
+      path: "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z",
+    },
+    inicio: {
+      bg: "var(--azul-egm-light)", color: "var(--azul-egm)",
+      path: "M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z",
+    },
+    logro: {
+      bg: "#fef9c3", color: "#b45309",
+      path: "M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z",
+    },
+    grupo: {
+      bg: "#ede9fe", color: "#7c3aed",
+      path: "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z",
+    },
+    nuevo: {
+      bg: "#fce7f3", color: "#be185d",
+      path: "M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253",
+    },
+  };
+  const c = configs[tipo] ?? configs.inicio;
+  return (
+    <div
+      className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
+      style={{ background: c.bg, color: c.color }}
+    >
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d={c.path} />
+      </svg>
+    </div>
   );
 }
 
@@ -62,7 +115,7 @@ export default function AdminEmpresa() {
         if (resRes.ok)      setResumen(await resRes.json());
         if (anunciosRes.ok) {
           const data = await anunciosRes.json();
-          setAnuncios(data.filter((a: Anuncio) => a.activo).slice(0, 3));
+          setAnuncios(data.filter((a: Anuncio) => a.activo).slice(0, 4));
         }
       } catch {}
       finally { setCargando(false); }
@@ -81,11 +134,17 @@ export default function AdminEmpresa() {
     );
   }
 
-  const nombreEmpresa = resumen?.nombreEmpresa ?? usuario?.nombreEmpresa ?? "Mi empresa";
-  const firstName     = (usuario?.nombre ?? "Administrador").split(" ")[0];
-  const fechaHoy      = new Date().toLocaleDateString("es-ES", {
-    day: "numeric", month: "long", year: "numeric",
-  });
+  const nombreEmpresa   = resumen?.nombreEmpresa ?? usuario?.nombreEmpresa ?? "Mi empresa";
+  const firstName       = (usuario?.nombre ?? "Administrador").split(" ")[0];
+  const fechaHoy        = new Date().toLocaleDateString("es-ES", { weekday: "long", day: "numeric", month: "long" })
+    .replace(/^\w/, (c) => c.toUpperCase());
+
+  // Métricas reales + mockeadas
+  const activos        = resumen?.usuariosActivos   ?? 0;
+  const inactivos      = resumen?.usuariosInactivos ?? 0;
+  const totalEmpleados = activos + inactivos;
+  const progresoMedio  = 67; // mock — API pendiente
+  const modulosTotal   = MOCK_MODULOS.length;
 
   return (
     <div>
@@ -107,9 +166,8 @@ export default function AdminEmpresa() {
       ══════════════════════════════════════════ */}
       <div
         className="-mx-8 -mt-8 mb-0 relative overflow-hidden"
-        style={{ minHeight: "340px" }}
+        style={{ minHeight: "300px" }}
       >
-        {/* Background image */}
         <div
           style={{
             position:           "absolute",
@@ -119,82 +177,48 @@ export default function AdminEmpresa() {
             backgroundPosition: "center",
           }}
         />
-        {/* Dark overlays */}
-        <div style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.52)" }} />
-        <div
-          style={{
-            position:   "absolute",
-            inset:      0,
-            background: "linear-gradient(135deg, rgba(10,20,40,0.55) 0%, rgba(0,0,0,0.2) 100%)",
-          }}
-        />
+        <div style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.50)" }} />
+        <div style={{ position: "absolute", inset: 0, background: "linear-gradient(135deg, rgba(10,20,40,0.55) 0%, rgba(0,0,0,0.15) 100%)" }} />
 
-        {/* Hero content */}
         <div
           className="relative z-10 px-10 lg:px-16 flex flex-col justify-center"
-          style={{ minHeight: "340px", paddingTop: "3.5rem", paddingBottom: "3.5rem" }}
+          style={{ minHeight: "300px", paddingTop: "3rem", paddingBottom: "3rem" }}
         >
-          {/* Top line: empresa · fecha */}
           <p
             className="text-xs font-bold uppercase tracking-widest mb-4"
-            style={{
-              color:     "var(--verde-oliva-hover)",
-              animation: "heroFadeUp 0.6s ease both",
-            }}
+            style={{ color: "var(--verde-oliva-hover)", animation: "heroFadeUp 0.6s ease both" }}
           >
-            {nombreEmpresa} · {fechaHoy}
+            {nombreEmpresa}
+            <span style={{ color: "rgba(255,255,255,0.25)" }}> · </span>
+            {fechaHoy}
           </p>
 
-          {/* Title */}
-          <div
-            style={{
-              display:       "flex",
-              flexWrap:      "wrap",
-              alignItems:    "baseline",
-              gap:           "0.4em",
-              animation:     "heroFadeUp 0.7s ease both",
-              animationDelay: "0.08s",
-            }}
-          >
-            <span
-              style={{
-                fontFamily: "'Poppins', sans-serif",
-                fontWeight: 300,
-                fontSize:   "clamp(3.5rem, 7vw, 4.5rem)",
-                color:      "#ffffff",
-                lineHeight: 1.1,
-              }}
-            >
+          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "baseline", gap: "0.4em", animation: "heroFadeUp 0.7s ease 0.08s both" }}>
+            <span style={{ fontFamily: "'Poppins', sans-serif", fontWeight: 300, fontSize: "clamp(3rem, 6vw, 4rem)", color: "#ffffff", lineHeight: 1.1 }}>
               Hola,
             </span>
             <span
               style={{
-                fontFamily:              "'Instrument Serif', serif",
-                fontStyle:               "italic",
-                fontWeight:              400,
-                fontSize:                "clamp(3.5rem, 7vw, 6rem)",
-                lineHeight:              1.05,
-                background:              "linear-gradient(90deg, #A3B535, #ffffff, #A3B535)",
-                backgroundSize:          "300% auto",
-                WebkitBackgroundClip:    "text",
-                WebkitTextFillColor:     "transparent",
-                backgroundClip:          "text",
-                animation:               "heroFadeUp 0.7s ease both, gradientShift 6s ease infinite",
-                animationDelay:          "0.12s, 0s",
+                fontFamily:           "'Instrument Serif', serif",
+                fontStyle:            "italic",
+                fontWeight:           400,
+                fontSize:             "clamp(3rem, 6vw, 5rem)",
+                lineHeight:           1.05,
+                background:           "linear-gradient(90deg, #A3B535, #ffffff, #A3B535)",
+                backgroundSize:       "300% auto",
+                WebkitBackgroundClip: "text",
+                WebkitTextFillColor:  "transparent",
+                backgroundClip:       "text",
+                animation:            "heroFadeUp 0.7s ease 0.12s both, gradientShift 6s ease infinite",
               }}
             >
               {firstName}
             </span>
           </div>
 
-          {/* Subtitle */}
           <p
             className="text-sm mt-3"
-            style={{
-              color:          "rgba(255,255,255,0.55)",
-              animation:      "heroFadeUp 0.7s ease both",
-              animationDelay: "0.2s",
-            }}
+            style={{ color: "rgba(255,255,255,0.50)", animation: "heroFadeUp 0.7s ease 0.2s both" }}
           >
             Panel de administración · {nombreEmpresa}
           </p>
@@ -202,522 +226,180 @@ export default function AdminEmpresa() {
       </div>
 
       {/* ══════════════════════════════════════════
-          CONTENT AREA
+          CONTENT
       ══════════════════════════════════════════ */}
-      <div className="px-10 lg:px-16 pt-14 pb-16 flex flex-col gap-16">
+      <div className="px-10 lg:px-16 pt-12 pb-16 flex flex-col gap-12">
 
-        {/* ── SECCIÓN 1: MÉTRICAS ── */}
+        {/* ── MÉTRICAS ── */}
         <section>
-          <TituloSeccion>Resumen</TituloSeccion>
+          <TituloSeccion>Resumen del equipo</TituloSeccion>
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
 
-            {/* Empleados activos */}
-            <button
-              onClick={() => router.push("/dashboard/admin?tab=empleados")}
-              className="text-left rounded-2xl px-6 py-5 transition-all group"
-              style={{
-                background:   "var(--blanco)",
-                border:       "1px solid var(--gris-borde)",
-                position:     "relative",
-                overflow:     "hidden",
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.boxShadow  = "0 6px 24px rgba(0,0,0,0.08)";
-                e.currentTarget.style.transform  = "translateY(-2px)";
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.boxShadow  = "none";
-                e.currentTarget.style.transform  = "translateY(0)";
-              }}
-            >
-              {/* Top accent strip */}
+            {[
+              { valor: activos,            label: "Empleados activos",  sub: totalEmpleados > 0 ? `${Math.round((activos/totalEmpleados)*100)}% del total` : null, href: "/dashboard/admin?tab=empleados",    color: "var(--azul-egm)" },
+              { valor: inactivos,          label: "Sin acceso activo",  sub: inactivos > 0 ? "Gestionar →" : null,                                                 href: "/dashboard/admin?tab=empleados",    color: "var(--texto-muted)" },
+              { valor: `${progresoMedio}%`, label: "Progreso medio",   sub: null,                                                                                   href: null,                               color: "var(--verde-oliva)", barra: true },
+              { valor: modulosTotal,       label: "Módulos publicados", sub: "Ver formaciones →",                                                                   href: "/dashboard/admin?tab=formaciones",  color: "var(--texto-primario)" },
+            ].map((stat, i) => (
               <div
-                style={{
-                  position:   "absolute",
-                  top:        0,
-                  left:       0,
-                  right:      0,
-                  height:     "3px",
-                  background: "var(--azul-egm)",
-                }}
-              />
-              <p
-                className="text-4xl font-bold mt-1"
-                style={{ color: "var(--azul-egm)" }}
+                key={i}
+                onClick={() => stat.href && router.push(stat.href)}
+                className="rounded-2xl px-5 py-5 transition-colors"
+                style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", cursor: stat.href ? "pointer" : "default" }}
+                onMouseEnter={(e) => { if (stat.href) (e.currentTarget as HTMLDivElement).style.background = "var(--gris-pagina)"; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "var(--blanco)"; }}
               >
-                {resumen?.usuariosActivos ?? "—"}
-              </p>
-              <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
-                Empleados activos
-              </p>
-            </button>
+                <p className="text-2xl font-semibold" style={{ color: stat.color }}>{stat.valor}</p>
+                <p className="text-xs mt-1" style={{ color: "var(--texto-muted)" }}>{stat.label}</p>
+                {(stat as any).barra && (
+                  <div className="w-full rounded-full overflow-hidden mt-3" style={{ height: "4px", background: "var(--gris-superficie)" }}>
+                    <div style={{ width: `${progresoMedio}%`, height: "100%", background: "var(--verde-oliva)", borderRadius: "9999px" }} />
+                  </div>
+                )}
+                {stat.sub && !((stat as any).barra) && (
+                  <p className="text-xs mt-2" style={{ color: stat.href ? "var(--azul-egm)" : "var(--texto-muted)" }}>{stat.sub}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
 
-            {/* Empleados inactivos */}
-            <button
-              onClick={() => router.push("/dashboard/admin?tab=empleados")}
-              className="text-left rounded-2xl px-6 py-5 transition-all"
-              style={{
-                background: "var(--blanco)",
-                border:     "1px solid var(--gris-borde)",
-                position:   "relative",
-                overflow:   "hidden",
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.boxShadow = "0 6px 24px rgba(0,0,0,0.08)";
-                e.currentTarget.style.transform = "translateY(-2px)";
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.boxShadow = "none";
-                e.currentTarget.style.transform = "translateY(0)";
-              }}
-            >
-              <div
-                style={{
-                  position:   "absolute",
-                  top:        0,
-                  left:       0,
-                  right:      0,
-                  height:     "3px",
-                  background: "var(--texto-muted)",
-                  opacity:    0.4,
-                }}
-              />
-              <p
-                className="text-4xl font-bold mt-1"
-                style={{ color: "var(--texto-muted)" }}
-              >
-                {resumen?.usuariosInactivos ?? "—"}
-              </p>
-              <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
-                Empleados inactivos
-              </p>
-            </button>
+        {/* ── FORMACIÓN + ACTIVIDAD ── */}
+        <section>
+          <div className="grid grid-cols-1 lg:grid-cols-5 gap-8">
 
-            {/* Progreso medio */}
-            <div
-              className="rounded-2xl px-6 py-5"
-              style={{
-                background: "var(--blanco)",
-                border:     "1px solid var(--gris-borde)",
-                position:   "relative",
-                overflow:   "hidden",
-              }}
-            >
-              <div
-                style={{
-                  position:   "absolute",
-                  top:        0,
-                  left:       0,
-                  right:      0,
-                  height:     "3px",
-                  background: "var(--verde-oliva)",
-                }}
-              />
-              <p
-                className="text-4xl font-bold mt-1"
-                style={{ color: "var(--verde-oliva)" }}
-              >
-                —
-              </p>
-              <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
-                Progreso medio
-              </p>
-              <span
-                className="inline-block text-xs px-2 py-0.5 rounded-full mt-2"
-                style={{
-                  background: "var(--verde-oliva-light)",
-                  color:      "var(--verde-oliva)",
-                  fontWeight: 500,
-                }}
-              >
-                Próximamente
-              </span>
+            {/* Estado de formación */}
+            <div className="lg:col-span-3">
+              <div className="flex items-center justify-between mb-5">
+                <TituloSeccion noMargin>Estado de formación</TituloSeccion>
+                <button onClick={() => router.push("/dashboard/admin?tab=formaciones")} className="text-xs font-medium hover:underline shrink-0" style={{ color: "var(--azul-egm)" }}>
+                  Ver módulos →
+                </button>
+              </div>
+              <div className="flex flex-col gap-3">
+                {MOCK_MODULOS.map((mod) => {
+                  const pctC = Math.round((mod.completados / mod.total) * 100);
+                  const pctP = Math.round((mod.enProgreso  / mod.total) * 100);
+                  return (
+                    <div key={mod.id} className="rounded-xl px-5 py-4" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                      <div className="flex items-center justify-between mb-2">
+                        <p className="text-sm" style={{ color: "var(--texto-primario)" }}>{mod.nombre}</p>
+                        <span className="text-xs font-semibold ml-3 shrink-0" style={{ color: "var(--verde-oliva)" }}>{pctC}%</span>
+                      </div>
+                      <div className="w-full flex rounded-full overflow-hidden" style={{ height: "5px", background: "var(--gris-superficie)" }}>
+                        <div style={{ width: `${pctC}%`, background: "var(--verde-oliva)" }} />
+                        <div style={{ width: `${pctP}%`, background: "#f59e0b" }} />
+                      </div>
+                      <div className="flex gap-4 mt-2">
+                        {[
+                          { n: mod.completados, label: "completados", color: "var(--verde-oliva)" },
+                          { n: mod.enProgreso,  label: "en progreso", color: "#f59e0b" },
+                          { n: mod.pendientes,  label: "pendientes",  color: "var(--gris-borde)" },
+                        ].map((s) => (
+                          <span key={s.label} className="text-xs flex items-center gap-1" style={{ color: "var(--texto-muted)" }}>
+                            <span style={{ width: "7px", height: "7px", borderRadius: "50%", background: s.color, display: "inline-block", flexShrink: 0 }} />
+                            {s.n} {s.label}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
             </div>
 
-            {/* Módulos activos */}
-            <div
-              className="rounded-2xl px-6 py-5"
-              style={{
-                background: "var(--blanco)",
-                border:     "1px solid var(--gris-borde)",
-                position:   "relative",
-                overflow:   "hidden",
-              }}
-            >
-              <div
-                style={{
-                  position:   "absolute",
-                  top:        0,
-                  left:       0,
-                  right:      0,
-                  height:     "3px",
-                  background: "var(--advertencia)",
-                }}
-              />
-              <p
-                className="text-4xl font-bold mt-1"
-                style={{ color: "var(--advertencia)" }}
-              >
-                —
-              </p>
-              <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
-                Módulos activos
-              </p>
-              <span
-                className="inline-block text-xs px-2 py-0.5 rounded-full mt-2"
-                style={{
-                  background: "var(--advertencia-light)",
-                  color:      "var(--advertencia)",
-                  fontWeight: 500,
-                }}
-              >
-                Próximamente
-              </span>
+            {/* Actividad reciente */}
+            <div className="lg:col-span-2">
+              <TituloSeccion>Actividad reciente</TituloSeccion>
+              <div className="rounded-2xl overflow-hidden" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                {MOCK_ACTIVIDAD.map((item, i) => (
+                  <div key={i} className="flex items-start gap-3 px-4 py-3.5" style={{ borderBottom: i < MOCK_ACTIVIDAD.length - 1 ? "1px solid var(--gris-borde)" : "none" }}>
+                    <ActividadIcon tipo={item.tipo} />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs leading-snug" style={{ color: "var(--texto-primario)" }}>{item.texto}</p>
+                      <p className="text-xs mt-1" style={{ color: "var(--texto-muted)" }}>{item.hora}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
 
           </div>
         </section>
 
-        {/* ── SECCIÓN 2: ACCIONES + ANUNCIOS ── */}
+        {/* ── ACCIONES + ANUNCIOS ── */}
         <section>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
 
-            {/* LEFT: Acciones rápidas */}
+            {/* Acciones rápidas */}
             <div className="lg:col-span-1">
               <TituloSeccion>Acciones rápidas</TituloSeccion>
-              <div className="flex flex-col gap-3">
-
-                {/* Añadir empleado */}
-                <button
-                  onClick={() => router.push("/dashboard/admin?tab=empleados")}
-                  className="flex items-center gap-4 rounded-2xl px-5 py-4 text-left w-full transition-all"
-                  style={{
-                    background: "var(--blanco)",
-                    border:     "1px solid var(--gris-borde)",
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.boxShadow = "0 4px 16px rgba(0,0,0,0.08)";
-                    e.currentTarget.style.transform = "translateY(-1px)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.boxShadow = "none";
-                    e.currentTarget.style.transform = "translateY(0)";
-                  }}
-                >
-                  <div
-                    className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
-                    style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}
+              <div className="flex flex-col gap-2">
+                {[
+                  { label: "Añadir empleado",  desc: "Registra un nuevo miembro del equipo",   href: "/dashboard/admin?tab=empleados",   bg: "var(--azul-egm-light)",   color: "var(--azul-egm)",  icon: "M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" },
+                  { label: "Nuevo módulo",     desc: "Crea contenido formativo para tu equipo", href: "/dashboard/admin/modulos/crear",    bg: "var(--verde-oliva-light)", color: "var(--verde-oliva)", icon: "M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" },
+                  { label: "Publicar anuncio", desc: "Comunica algo importante a tu equipo",   href: "/dashboard/admin?tab=anuncios",    bg: "#fef3c7",                 color: "#b45309",           icon: "M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" },
+                ].map((a) => (
+                  <button
+                    key={a.label}
+                    onClick={() => router.push(a.href)}
+                    className="flex items-center gap-3 rounded-xl px-4 py-3.5 text-left w-full transition-colors"
+                    style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}
+                    onMouseEnter={(e) => { e.currentTarget.style.background = "var(--gris-pagina)"; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.background = "var(--blanco)"; }}
                   >
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+                    <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0" style={{ background: a.bg, color: a.color }}>
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d={a.icon} />
+                      </svg>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium" style={{ color: "var(--texto-primario)" }}>{a.label}</p>
+                      <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>{a.desc}</p>
+                    </div>
+                    <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} style={{ color: "var(--gris-borde)" }}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                     </svg>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
-                      Añadir empleado
-                    </p>
-                    <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>
-                      Registra un nuevo miembro del equipo
-                    </p>
-                  </div>
-                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
-                    style={{ color: "var(--texto-muted)" }}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                  </svg>
-                </button>
-
-                {/* Nuevo módulo */}
-                <button
-                  onClick={() => router.push("/dashboard/admin/modulos/crear")}
-                  className="flex items-center gap-4 rounded-2xl px-5 py-4 text-left w-full transition-all"
-                  style={{
-                    background: "var(--blanco)",
-                    border:     "1px solid var(--gris-borde)",
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.boxShadow = "0 4px 16px rgba(0,0,0,0.08)";
-                    e.currentTarget.style.transform = "translateY(-1px)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.boxShadow = "none";
-                    e.currentTarget.style.transform = "translateY(0)";
-                  }}
-                >
-                  <div
-                    className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
-                    style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}
-                  >
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                    </svg>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
-                      Nuevo módulo
-                    </p>
-                    <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>
-                      Crea contenido formativo para tu equipo
-                    </p>
-                  </div>
-                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
-                    style={{ color: "var(--texto-muted)" }}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                  </svg>
-                </button>
-
-                {/* Publicar anuncio */}
-                <button
-                  onClick={() => router.push("/dashboard/admin?tab=anuncios")}
-                  className="flex items-center gap-4 rounded-2xl px-5 py-4 text-left w-full transition-all"
-                  style={{
-                    background: "var(--blanco)",
-                    border:     "1px solid var(--gris-borde)",
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.boxShadow = "0 4px 16px rgba(0,0,0,0.08)";
-                    e.currentTarget.style.transform = "translateY(-1px)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.boxShadow = "none";
-                    e.currentTarget.style.transform = "translateY(0)";
-                  }}
-                >
-                  <div
-                    className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
-                    style={{ background: "var(--advertencia-light)", color: "var(--advertencia)" }}
-                  >
-                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
-                    </svg>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
-                      Publicar anuncio
-                    </p>
-                    <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>
-                      Comunica algo importante a tu equipo
-                    </p>
-                  </div>
-                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
-                    style={{ color: "var(--texto-muted)" }}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-                  </svg>
-                </button>
-
+                  </button>
+                ))}
               </div>
             </div>
 
-            {/* RIGHT: Últimos comunicados */}
+            {/* Últimos comunicados */}
             <div className="lg:col-span-2">
               <div className="flex items-center justify-between mb-6">
                 <TituloSeccion noMargin>Últimos comunicados</TituloSeccion>
-                <button
-                  onClick={() => router.push("/dashboard/admin?tab=anuncios")}
-                  className="text-sm font-medium hover:underline shrink-0"
-                  style={{ color: "var(--azul-egm)" }}
-                >
+                <button onClick={() => router.push("/dashboard/admin?tab=anuncios")} className="text-xs font-medium hover:underline shrink-0" style={{ color: "var(--azul-egm)" }}>
                   Ver todos →
                 </button>
               </div>
 
               {anuncios.length === 0 ? (
-                <div
-                  className="flex flex-col items-center justify-center py-12 text-center rounded-2xl"
-                  style={{
-                    background: "var(--gris-pagina)",
-                    border:     "1px dashed var(--gris-borde)",
-                  }}
-                >
-                  <div
-                    className="w-12 h-12 rounded-xl flex items-center justify-center mb-4"
-                    style={{ background: "var(--azul-egm-light)" }}
-                  >
-                    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}
-                      style={{ color: "var(--azul-egm)" }}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
-                    </svg>
-                  </div>
-                  <p className="text-sm font-semibold mb-1" style={{ color: "var(--texto-primario)" }}>
-                    Sin comunicados publicados
-                  </p>
-                  <p className="text-xs mb-4" style={{ color: "var(--texto-muted)" }}>
-                    Comunica novedades importantes a tu equipo
-                  </p>
-                  <button
-                    onClick={() => router.push("/dashboard/admin?tab=anuncios")}
-                    className="text-xs font-semibold px-4 py-2 rounded-lg transition-opacity"
-                    style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
-                    onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.85")}
-                    onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
-                  >
-                    Crear primer comunicado
+                <div className="flex flex-col items-center justify-center py-10 text-center rounded-2xl" style={{ background: "var(--gris-pagina)", border: "1px dashed var(--gris-borde)" }}>
+                  <p className="text-sm mb-1" style={{ color: "var(--texto-primario)" }}>Sin comunicados publicados</p>
+                  <p className="text-xs mb-4" style={{ color: "var(--texto-muted)" }}>Comunica novedades importantes a tu equipo</p>
+                  <button onClick={() => router.push("/dashboard/admin?tab=anuncios")} className="text-xs font-semibold px-4 py-2 rounded-lg" style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}>
+                    Crear comunicado
                   </button>
                 </div>
               ) : (
-                <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-2">
                   {anuncios.map((a) => (
-                    <div
-                      key={a.anuncioId}
-                      className="flex items-start justify-between rounded-xl px-4 py-3"
-                      style={{
-                        background:  "var(--blanco)",
-                        border:      "1px solid var(--gris-borde)",
-                        borderLeft:  "3px solid var(--azul-egm)",
-                      }}
-                    >
+                    <div key={a.anuncioId} className="flex items-start gap-3 rounded-xl px-4 py-3.5" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", borderLeft: "3px solid var(--azul-egm)" }}>
                       <div className="flex-1 min-w-0">
-                        <p
-                          className="text-sm font-semibold truncate"
-                          style={{ color: "var(--texto-primario)" }}
-                        >
-                          {a.titulo}
-                        </p>
-                        <p
-                          className="text-xs mt-0.5 line-clamp-2"
-                          style={{ color: "var(--texto-muted)" }}
-                        >
-                          {a.contenido}
-                        </p>
+                        <div className="flex items-start justify-between gap-2">
+                          <p className="text-sm font-medium" style={{ color: "var(--texto-primario)" }}>{a.titulo}</p>
+                          <span className="text-xs shrink-0 mt-0.5" style={{ color: "var(--texto-muted)" }}>{formatFecha(a.creadoEn)}</span>
+                        </div>
+                        <p className="text-xs mt-1 line-clamp-1" style={{ color: "var(--texto-muted)" }}>{a.contenido}</p>
                       </div>
-                      <span
-                        className="text-xs ml-4 shrink-0 mt-0.5"
-                        style={{ color: "var(--texto-muted)" }}
-                      >
-                        {formatFecha(a.creadoEn)}
+                      <span className="text-xs px-2 py-0.5 rounded-full font-medium shrink-0 mt-0.5" style={{ background: a.esGlobal ? "#dbeafe" : "var(--verde-oliva-light)", color: a.esGlobal ? "#1d4ed8" : "var(--verde-oliva)" }}>
+                        {a.esGlobal ? "Global" : "Empresa"}
                       </span>
                     </div>
                   ))}
                 </div>
               )}
-            </div>
-
-          </div>
-        </section>
-
-        {/* ── SECCIÓN 3: ESTADO DEL EQUIPO ── */}
-        <section>
-          <TituloSeccion>Estado del equipo</TituloSeccion>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-
-            {/* Empleados activos */}
-            <div
-              className="rounded-2xl px-5 py-5"
-              style={{
-                background: "var(--blanco)",
-                border:     "1px solid var(--gris-borde)",
-                position:   "relative",
-                overflow:   "hidden",
-              }}
-            >
-              <div
-                style={{
-                  position:   "absolute",
-                  bottom:     0,
-                  left:       0,
-                  right:      0,
-                  height:     "2px",
-                  background: "linear-gradient(90deg, var(--azul-egm), var(--azul-egm-light))",
-                }}
-              />
-              <div
-                className="w-10 h-10 rounded-xl flex items-center justify-center mb-3"
-                style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-              </div>
-              <p className="text-xs mb-1" style={{ color: "var(--texto-muted)" }}>
-                Empleados activos
-              </p>
-              <p
-                className="text-3xl font-bold"
-                style={{ color: "var(--azul-egm)" }}
-              >
-                {resumen?.usuariosActivos ?? "—"}
-              </p>
-            </div>
-
-            {/* Módulos de formación */}
-            <div
-              className="rounded-2xl px-5 py-5"
-              style={{
-                background: "var(--blanco)",
-                border:     "1px solid var(--gris-borde)",
-                position:   "relative",
-                overflow:   "hidden",
-              }}
-            >
-              <div
-                style={{
-                  position:   "absolute",
-                  bottom:     0,
-                  left:       0,
-                  right:      0,
-                  height:     "2px",
-                  background: "linear-gradient(90deg, var(--verde-oliva), var(--verde-oliva-light))",
-                }}
-              />
-              <div
-                className="w-10 h-10 rounded-xl flex items-center justify-center mb-3"
-                style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                </svg>
-              </div>
-              <p className="text-xs mb-2" style={{ color: "var(--texto-muted)" }}>
-                Módulos de formación
-              </p>
-              <button
-                onClick={() => router.push("/dashboard/admin?tab=formaciones")}
-                className="text-xs font-semibold transition-opacity"
-                style={{ color: "var(--verde-oliva)" }}
-                onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.7")}
-                onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
-              >
-                Gestionar módulos →
-              </button>
-            </div>
-
-            {/* Empleados inactivos */}
-            <div
-              className="rounded-2xl px-5 py-5"
-              style={{
-                background: "var(--blanco)",
-                border:     "1px solid var(--gris-borde)",
-                position:   "relative",
-                overflow:   "hidden",
-              }}
-            >
-              <div
-                style={{
-                  position:   "absolute",
-                  bottom:     0,
-                  left:       0,
-                  right:      0,
-                  height:     "2px",
-                  background: "linear-gradient(90deg, var(--texto-muted), var(--gris-superficie))",
-                  opacity:    0.5,
-                }}
-              />
-              <div
-                className="w-10 h-10 rounded-xl flex items-center justify-center mb-3"
-                style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)" }}
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
-                </svg>
-              </div>
-              <p className="text-xs mb-1" style={{ color: "var(--texto-muted)" }}>
-                Empleados inactivos
-              </p>
-              <p
-                className="text-3xl font-bold"
-                style={{ color: "var(--texto-muted)" }}
-              >
-                {resumen?.usuariosInactivos ?? "—"}
-              </p>
             </div>
 
           </div>

--- a/components/pages/Empleado.tsx
+++ b/components/pages/Empleado.tsx
@@ -531,72 +531,149 @@ export default function Empleado() {
 
         {/* ── FILA 3: COMUNIDAD ── */}
         <section>
-          <TituloSeccion>Comunidad</TituloSeccion>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {[
-              {
-                label: "Eventos empresariales",
-                desc:  "Actividades y networking entre las empresas del parque",
-                icono: (
-                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
-                ),
-              },
-              {
-                label: "Team building",
-                desc:  "Iniciativas colectivas e integración entre equipos",
-                icono: (
-                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
-                  </svg>
-                ),
-              },
-              {
-                label: "En Femenino",
-                desc:  "Liderazgo e igualdad en el entorno empresarial",
-                icono: (
-                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-                  </svg>
-                ),
-              },
-            ].map((item) => (
-              <div key={item.label}
-                className="flex flex-col gap-4 px-5 py-5 rounded-2xl relative overflow-hidden"
-                style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+          <div className="flex items-end justify-between mb-6">
+            <TituloSeccion noMargin>Comunidad</TituloSeccion>
+            <span className="text-xs px-3 py-1 rounded-full font-semibold" style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}>
+              Parque empresarial EGM
+            </span>
+          </div>
 
-                {/* Glow corner */}
-                <div className="absolute top-0 right-0 w-24 h-24 pointer-events-none"
-                  style={{ background: "radial-gradient(circle at top right, rgba(139,154,45,0.08) 0%, transparent 70%)" }} />
+          {/* Evento destacado + iniciativas */}
+          <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-4">
 
-                {/* Icono */}
-                <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
-                  style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}>
-                  {item.icono}
+            {/* Evento destacado (3/5) */}
+            <div
+              className="lg:col-span-3 rounded-2xl overflow-hidden relative"
+              style={{ background: "var(--marino)", minHeight: "200px" }}
+            >
+              {/* Fondo decorativo */}
+              <div style={{ position: "absolute", inset: 0, background: "radial-gradient(ellipse at 80% 20%, rgba(163,181,53,0.18) 0%, transparent 60%)" }} />
+              <div style={{ position: "absolute", top: "-40px", right: "-40px", width: "200px", height: "200px", borderRadius: "50%", background: "rgba(255,255,255,0.03)" }} />
+
+              <div className="relative z-10 p-6 flex flex-col h-full" style={{ minHeight: "200px" }}>
+                <div className="flex items-start justify-between mb-auto">
+                  <span className="text-xs font-bold uppercase tracking-widest px-2.5 py-1 rounded-full" style={{ background: "rgba(163,181,53,0.2)", color: "#A3B535" }}>
+                    Próximo evento
+                  </span>
+                  <div className="text-right">
+                    <p className="text-2xl font-bold text-white leading-none">24</p>
+                    <p className="text-xs" style={{ color: "rgba(255,255,255,0.5)" }}>May</p>
+                  </div>
                 </div>
 
-                {/* Texto */}
-                <div className="flex-1">
-                  <p className="text-sm font-semibold mb-1" style={{ color: "var(--texto-primario)" }}>
-                    {item.label}
+                <div className="mt-6">
+                  <h3 className="text-lg font-semibold text-white mb-1" style={{ fontFamily: "'Instrument Serif', serif", fontStyle: "italic" }}>
+                    Jornada de Networking EGM
+                  </h3>
+                  <p className="text-sm mb-4" style={{ color: "rgba(255,255,255,0.55)" }}>
+                    Conecta con profesionales del parque empresarial. Ponencias, mesas redondas y espacio de networking libre.
                   </p>
-                  <p className="text-xs leading-relaxed" style={{ color: "var(--texto-muted)" }}>
-                    {item.desc}
-                  </p>
+                  <div className="flex flex-wrap gap-4">
+                    {[
+                      { icon: "M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z", text: "Sala Polivalente A" },
+                      { icon: "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z", text: "10:00 – 14:00 h" },
+                      { icon: "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z", text: "42 inscritos" },
+                    ].map((d) => (
+                      <span key={d.text} className="flex items-center gap-1.5 text-xs" style={{ color: "rgba(255,255,255,0.5)" }}>
+                        <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d={d.icon} />
+                        </svg>
+                        {d.text}
+                      </span>
+                    ))}
+                  </div>
                 </div>
 
-                {/* Badge */}
-                <span className="text-[10px] font-semibold self-start px-2.5 py-1 rounded-full"
-                  style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)", border: "1px solid rgba(139,154,45,0.2)" }}>
-                  Próximamente
-                </span>
-
-                {/* Línea inferior */}
-                <div className="absolute bottom-0 left-0 right-0 h-[2px]"
-                  style={{ background: "linear-gradient(to right, var(--verde-oliva), transparent 70%)" }} />
+                <button
+                  className="mt-5 self-start text-xs font-semibold px-4 py-2 rounded-xl transition-opacity hover:opacity-80"
+                  style={{ background: "#A3B535", color: "#fff" }}
+                >
+                  Ver detalles e inscribirme
+                </button>
               </div>
-            ))}
+            </div>
+
+            {/* Iniciativas (2/5) */}
+            <div className="lg:col-span-2 flex flex-col gap-3">
+              {[
+                {
+                  label: "Team building",
+                  desc:  "Integración y trabajo en equipo entre empresas del parque",
+                  fecha: "Jun 2025",
+                  inscritos: 18,
+                  color: "#7c3aed",
+                  bg:    "#ede9fe",
+                  icon:  "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z",
+                },
+                {
+                  label: "En Femenino",
+                  desc:  "Liderazgo, igualdad e inspiración en el entorno empresarial",
+                  fecha: "Jul 2025",
+                  inscritos: 31,
+                  color: "#be185d",
+                  bg:    "#fce7f3",
+                  icon:  "M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z",
+                },
+                {
+                  label: "Eventos empresariales",
+                  desc:  "Actividades de networking entre las empresas del parque",
+                  fecha: "Mensual",
+                  inscritos: 60,
+                  color: "var(--azul-egm)",
+                  bg:    "var(--azul-egm-light)",
+                  icon:  "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z",
+                },
+              ].map((ini) => (
+                <div
+                  key={ini.label}
+                  className="flex items-center gap-3 rounded-xl px-4 py-3.5 transition-colors"
+                  style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", cursor: "pointer" }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = "var(--gris-pagina)"; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "var(--blanco)"; }}
+                >
+                  <div className="w-9 h-9 rounded-xl flex items-center justify-center shrink-0" style={{ background: ini.bg, color: ini.color }}>
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d={ini.icon} />
+                    </svg>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>{ini.label}</p>
+                    <p className="text-xs mt-0.5 line-clamp-1" style={{ color: "var(--texto-muted)" }}>{ini.desc}</p>
+                  </div>
+                  <div className="text-right shrink-0">
+                    <p className="text-xs font-semibold" style={{ color: ini.color }}>{ini.fecha}</p>
+                    <p className="text-[10px] mt-0.5" style={{ color: "var(--texto-muted)" }}>{ini.inscritos} inscritos</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Tablón de la comunidad */}
+          <div
+            className="rounded-2xl overflow-hidden"
+            style={{ border: "1px solid var(--gris-borde)", background: "var(--blanco)" }}
+          >
+            <div
+              className="px-5 py-3.5 flex items-center justify-between"
+              style={{ borderBottom: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}
+            >
+              <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>Tablón de la comunidad</p>
+              <span className="text-xs px-2 py-0.5 rounded-full font-medium" style={{ background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }}>Próximamente</span>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 divide-x" style={{ borderColor: "var(--gris-borde)" }}>
+              {[
+                { emoji: "💬", titulo: "Foro del parque",         desc: "Comparte ideas y preguntas con el resto de empresas y empleados." },
+                { emoji: "📌", titulo: "Anuncios de comunidad",   desc: "Comunicados transversales del parque empresarial EGM." },
+                { emoji: "🤝", titulo: "Directorio de empresas",  desc: "Conoce las empresas y equipos que comparten espacio contigo." },
+              ].map((item, i) => (
+                <div key={i} className="px-5 py-4 flex flex-col gap-2">
+                  <span className="text-2xl leading-none">{item.emoji}</span>
+                  <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>{item.titulo}</p>
+                  <p className="text-xs leading-relaxed" style={{ color: "var(--texto-muted)" }}>{item.desc}</p>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
 

--- a/components/ui/ChatbotIA.tsx
+++ b/components/ui/ChatbotIA.tsx
@@ -31,29 +31,59 @@ const SUGGESTIONS = [
 
 const RESPUESTAS: Array<{ keywords: string[]; response: string }> = [
   {
-    keywords: ["formacion", "pendiente", "formación"],
+    keywords: ["formacion", "pendiente", "formación", "mis formaciones", "que tengo"],
     response:
-      "Tienes **3 formaciones pendientes**: *Comunicación Efectiva*, *Herramientas Digitales* y *Ciberseguridad*. Te recomiendo empezar por Comunicación Efectiva, ya que es la base para el resto. ¿Quieres que te explique cómo acceder?",
+      "Tienes **3 formaciones pendientes**: *Comunicación Efectiva*, *Herramientas Digitales* y *Ciberseguridad y Protección de Datos*. Te recomiendo empezar por **Comunicación Efectiva**, ya que es la base para el resto. ¿Quieres acceder directamente?",
   },
   {
-    keywords: ["comunicado", "noticia"],
+    keywords: ["progreso", "avance", "completado", "cuanto llevo", "cuánto llevo"],
     response:
-      "El último comunicado es del 14 de abril: *'Actualización del protocolo de acceso al parking'*. En resumen: a partir del 1 de mayo se requerirá tarjeta de empresa para acceder. ¿Quieres más detalles?",
+      "Tu progreso actual: ✅ *Incorporación y Bienvenida* — **100% completado** 🔄 *Negociación y Habilidades Directivas* — **60% en progreso** ⏳ *Comunicación Efectiva* — **pendiente**. ¡Vas por buen camino! Tienes 1 módulo completado esta semana.",
   },
   {
-    keywords: ["prl", "riesgo", "seguridad"],
+    keywords: ["comunicado", "noticia", "anuncio"],
     response:
-      "Las normas básicas de PRL incluyen: ✅ Uso de EPI en zonas señalizadas ✅ Comunicar cualquier incidente al responsable ✅ No manipular equipos sin formación específica ✅ Mantener las salidas de emergencia despejadas. ¿Necesitas información sobre alguna norma específica?",
+      "El último comunicado es del 14 de abril: *'Actualización del protocolo de acceso al parking'*. A partir del 1 de mayo se requerirá tarjeta de empresa para acceder. También hay un anuncio sobre la **Jornada de Networking del 24 de mayo**. ¿Quieres más detalles de alguno?",
   },
   {
-    keywords: ["modulo", "completar", "módulo"],
+    keywords: ["prl", "riesgo", "seguridad", "prevencion", "prevención"],
     response:
-      "Para completar un módulo: 1️⃣ Accede a *Formación* en el menú 2️⃣ Selecciona el módulo que quieres hacer 3️⃣ Ve completando cada sección en orden 4️⃣ Responde el quiz final con al menos 2/3 aciertos. ¡El progreso se guarda automáticamente!",
+      "Las normas básicas de PRL en el parque empresarial EGM: ✅ Uso de EPI en zonas señalizadas ✅ Comunicar cualquier incidente al responsable ✅ No manipular equipos sin formación específica ✅ Mantener las salidas de emergencia despejadas ✅ Velocidad máxima en el parking: 10 km/h. ¿Necesitas información sobre alguna norma específica?",
+  },
+  {
+    keywords: ["modulo", "completar", "módulo", "como funciona", "cómo funciona"],
+    response:
+      "Para completar un módulo: 1️⃣ Accede a **Formación** en el menú lateral 2️⃣ Selecciona el módulo que quieres realizar 3️⃣ Completa cada sección en orden 4️⃣ Responde el cuestionario final (mínimo 2/3 aciertos). ¡El progreso se guarda automáticamente y puedes continuar donde lo dejaste!",
+  },
+  {
+    keywords: ["certificado", "diploma", "logro"],
+    response:
+      "Al completar cada módulo recibirás un **certificado digital** con tu nombre y la fecha de finalización. Los certificados de los módulos de PRL y Protección de Datos tienen validez oficial. Puedes descargarlos desde tu perfil. 🏆",
+  },
+  {
+    keywords: ["evento", "actividad", "networking", "comunidad"],
+    response:
+      "Próximos eventos en el parque EGM: 📅 **24 de mayo** — Jornada de Networking (42 inscritos) 📅 **Junio** — Team Building entre empresas 📅 **Julio** — Jornada 'En Femenino'. ¿Te apunto a alguno?",
+  },
+  {
+    keywords: ["equipo", "compañero", "empresa"],
+    response:
+      "Tu empresa tiene actualmente **28 empleados activos**. El progreso medio del equipo en formación es del **67%**. Los módulos con mayor participación son *Onboarding Corporativo* (89%) y *Protección de Datos* (78%). ¿Quieres ver el detalle de algún módulo?",
+  },
+  {
+    keywords: ["hola", "buenas", "buenos días", "buenas tardes"],
+    response:
+      "¡Hola! 👋 Estoy aquí para ayudarte. Puedo informarte sobre tus **formaciones pendientes**, el **progreso del equipo**, **comunicados** del parque, normas de **PRL** o cómo usar la plataforma. ¿Por dónde empezamos?",
+  },
+  {
+    keywords: ["gracias", "perfecto", "genial", "ok"],
+    response:
+      "¡De nada! 😊 Si necesitas cualquier otra cosa, aquí estaré. ¡Mucho ánimo con la formación!",
   },
 ]
 
 const DEFAULT_RESPONSE =
-  "Entendido. Estoy procesando tu consulta... En breve tendré una respuesta para ti. Mientras tanto, puedes explorar la sección de **Formación** o revisar los **Comunicados** más recientes. 💡"
+  "Entendido. Déjame revisar eso por ti... Mientras tanto, puedes explorar la sección de **Formación** o consultar los **Comunicados** más recientes. Si necesitas algo concreto, intenta preguntarme sobre tu progreso, PRL, comunicados o próximos eventos. 💡"
 
 function normalize(text: string): string {
   return text


### PR DESCRIPTION
- AdminEmpresa: hero restaurado, contenido más ligero sin strips de color, métricas compactas, sección Comunidad rediseñada con evento destacado + iniciativas + tablón
- Admin tabs: títulos en Instrument Serif, drawer empleados con progreso formación mockeado, tabla seguimiento equipo en tab módulos, cards anuncios mejoradas, chevron en tabla en vez de botón desactivar
- Crear módulo: hero con imagen de fondo, stepper mejorado, layout más premium, banner éxito con botón "Crear otro"
- Formación: duraciones reales por tipo de módulo, título en Instrument Serif
- ChatbotIA: 10 respuestas vs 4 anteriores (progreso, certificados, eventos, equipo, saludos)
- DashboardHero y Empleado: fix texto invisible por GSAP, gradiente oliva→blanco→oliva