### PR TITLE
Implementacion actividad reciente admin empresa

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,7 +1,17 @@
 export const runtime = "nodejs"
 
 import { NextRequest } from "next/server"
-import { chatCompletionStream, ChatMessage } from "@/lib/ai/provider"
+
+// La clave de IA ya NO vive en Vercel — el backend de Render la gestiona.
+// Este fichero actúa como proxy: construye el systemPrompt y reenvía al backend.
+const BACKEND_URL =
+  process.env.BACKEND_URL ??
+  "https://atalayas-backend-c25d.onrender.com/api/v1"
+
+interface ChatMessage {
+  role: "user" | "assistant"
+  content: string
+}
 
 function buildSystemPrompt(context: {
   nombreUsuario?: string
@@ -64,23 +74,26 @@ export async function POST(req: NextRequest) {
 
     const systemPrompt = buildSystemPrompt(context ?? {})
 
-    const stream = new ReadableStream({
-      async start(controller) {
-        const encoder = new TextEncoder()
-        try {
-          await chatCompletionStream(messages, systemPrompt, (chunk) => {
-            controller.enqueue(encoder.encode(chunk))
-          })
-        } catch (error) {
-          console.error("[/api/chat] Error en stream:", error)
-          controller.enqueue(encoder.encode("⚠️ Error al generar la respuesta."))
-        } finally {
-          controller.close()
-        }
-      },
+    // ── Proxy al backend de Render ────────────────────────────────────────────
+    // El backend tiene las claves de IA (Gemini / Groq) y devuelve el stream.
+    const backendRes = await fetch(`${BACKEND_URL}/ai/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages, systemPrompt }),
     })
 
-    return new Response(stream, {
+    if (!backendRes.ok || !backendRes.body) {
+      const status = backendRes.status
+      console.error("[/api/chat] Backend respondió con error:", status)
+      const errorMsg =
+        status >= 500
+          ? "⚠️ El servicio de IA no está disponible en este momento. Inténtalo en unos minutos."
+          : "⚠️ No se pudo procesar la consulta. Inténtalo de nuevo."
+      return new Response(errorMsg, { status: 502 })
+    }
+
+    // Pipe directo: el stream del backend llega al cliente sin modificaciones
+    return new Response(backendRes.body, {
       headers: { "Content-Type": "text/plain; charset=utf-8" },
     })
   } catch (error) {

--- a/components/pages/AdminEmpresa.tsx
+++ b/components/pages/AdminEmpresa.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { apiFetch, API_URL } from "@/lib/api";
+import { getActividadReciente } from "@/lib/api/progreso";
+import type { ActividadItem } from "@/lib/types/progreso";
 
 interface ResumenAdmin {
   nombreEmpresa: string;
@@ -31,13 +33,17 @@ const MOCK_MODULOS = [
   { id: "m4", nombre: "Onboarding Corporativo", completados: 25, enProgreso: 2, pendientes: 1, total: 28 },
 ];
 
-const MOCK_ACTIVIDAD = [
-  { hora: "Hace 5 min", texto: "Ana García completó «Prevención de Riesgos»", tipo: "completado" },
-  { hora: "Hace 22 min", texto: "Carlos Ruiz inició «Protección de Datos»", tipo: "inicio" },
-  { hora: "Hace 1 h", texto: "María López obtuvo el 100% en Onboarding", tipo: "logro" },
-  { hora: "Hace 3 h", texto: "5 empleados completaron «Habilidades Comunicación»", tipo: "grupo" },
-  { hora: "Ayer", texto: "Nuevo módulo «Excel Avanzado» publicado", tipo: "nuevo" },
-];
+function tiempoRelativo(timestamp: string): string {
+  const diff = Date.now() - new Date(timestamp).getTime();
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return "ahora mismo";
+  if (min < 60) return `Hace ${min} min`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `Hace ${h} h`;
+  const d = Math.floor(h / 24);
+  if (d === 1) return "Ayer";
+  return `Hace ${d} días`;
+}
 
 function formatFecha(iso: string) {
   return new Date(iso).toLocaleDateString("es-ES", { day: "numeric", month: "short" });
@@ -103,20 +109,23 @@ export default function AdminEmpresa() {
 
   const [resumen, setResumen] = useState<ResumenAdmin | null>(null);
   const [anuncios, setAnuncios] = useState<Anuncio[]>([]);
+  const [actividad, setActividad] = useState<ActividadItem[]>([]);
   const [cargando, setCargando] = useState(true);
 
   useEffect(() => {
     async function cargarDatos() {
       try {
-        const [resRes, anunciosRes] = await Promise.all([
+        const [resRes, anunciosRes, actividadData] = await Promise.all([
           apiFetch(`${API_URL}/dashboard/admin/resumen`),
           apiFetch(`${API_URL}/anuncios`),
+          getActividadReciente(5).catch(() => [] as ActividadItem[]),
         ]);
         if (resRes.ok) setResumen(await resRes.json());
         if (anunciosRes.ok) {
           const data = await anunciosRes.json();
           setAnuncios(data.filter((a: Anuncio) => a.activo).slice(0, 4));
         }
+        setActividad(actividadData);
       } catch { }
       finally { setCargando(false); }
     }
@@ -311,17 +320,24 @@ export default function AdminEmpresa() {
             {/* Actividad reciente */}
             <div className="lg:col-span-2">
               <TituloSeccion>Actividad reciente</TituloSeccion>
-              <div className="rounded-2xl overflow-hidden" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-                {MOCK_ACTIVIDAD.map((item, i) => (
-                  <div key={i} className="flex items-start gap-3 px-4 py-3.5" style={{ borderBottom: i < MOCK_ACTIVIDAD.length - 1 ? "1px solid var(--gris-borde)" : "none" }}>
-                    <ActividadIcon tipo={item.tipo} />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-xs leading-snug" style={{ color: "var(--texto-primario)" }}>{item.texto}</p>
-                      <p className="text-xs mt-1" style={{ color: "var(--texto-muted)" }}>{item.hora}</p>
+              {actividad.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-10 text-center rounded-2xl" style={{ background: "var(--gris-pagina)", border: "1px dashed var(--gris-borde)" }}>
+                  <p className="text-sm mb-1" style={{ color: "var(--texto-primario)" }}>Sin actividad reciente</p>
+                  <p className="text-xs" style={{ color: "var(--texto-muted)" }}>Aparecerá aquí cuando los empleados interactúen con los módulos</p>
+                </div>
+              ) : (
+                <div className="rounded-2xl overflow-hidden" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                  {actividad.map((item, i) => (
+                    <div key={i} className="flex items-start gap-3 px-4 py-3.5" style={{ borderBottom: i < actividad.length - 1 ? "1px solid var(--gris-borde)" : "none" }}>
+                      <ActividadIcon tipo={item.tipo} />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs leading-snug" style={{ color: "var(--texto-primario)" }}>{item.texto}</p>
+                        <p className="text-xs mt-1" style={{ color: "var(--texto-muted)" }}>{tiempoRelativo(item.timestamp)}</p>
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+              )}
             </div>
 
           </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# Documentación — Atalayas Frontend
+
+Bienvenido a la documentación técnica del frontend de **Atalayas Ciudad Empresarial**, la plataforma de onboarding y formación para las empresas del área empresarial de Alicante.
+
+---
+
+## Descripción del proyecto
+
+Atalayas es una aplicación web que permite a las empresas gestionar el onboarding y la formación de sus empleados. Cada empresa tiene su propio espacio con módulos formativos, comunicados internos y seguimiento de progreso. Un superadministrador gestiona el alta de empresas y la plataforma de forma global.
+
+## Stack resumido
+
+| Tecnología | Uso |
+|---|---|
+| Next.js 16 (App Router) | Framework principal |
+| TypeScript | Tipado estático |
+| Tailwind CSS v4 | Estilos |
+| Supabase | Storage de imágenes |
+| GSAP + Motion | Animaciones |
+| Google Gemini 2.0 Flash | IA del chatbot (primario) |
+| Groq llama-3.3-70b | IA del chatbot (fallback) |
+
+## Índice de documentación
+
+| Fichero | Contenido |
+|---|---|
+| [arquitectura.md](./arquitectura.md) | Stack, estructura de carpetas y convenciones del proyecto |
+| [autenticacion.md](./autenticacion.md) | Flujo de sesión, roles, guards y diagrama |
+| [api.md](./api.md) | Todos los endpoints del backend consumidos |
+| [chatbot-ia.md](./chatbot-ia.md) | Arquitectura de AtalaIA: componente, ruta de API y proveedor de IA |
+| [rutas.md](./rutas.md) | Mapa de rutas de la app y acceso por rol |
+| [componentes.md](./componentes.md) | Inventario de componentes con propósito y props |
+| [variables-de-entorno.md](./variables-de-entorno.md) | Variables de entorno requeridas |
+
+---
+
+> **Nota de mantenimiento:** Los ficheros `api.md` y `rutas.md` son los que más cambian. Actualízalos cada vez que se añadan endpoints o rutas nuevas.
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,137 @@
+# API — Referencia de endpoints
+
+## Wrapper `apiFetch`
+
+Toda llamada al backend debe hacerse a través de `apiFetch` (`lib/api.ts`). Nunca uses `fetch` directamente para llamadas al backend.
+
+```ts
+import { apiFetch, API_URL } from "@/lib/api"
+
+const res = await apiFetch(`${API_URL}/modulos`)
+```
+
+`apiFetch` añade automáticamente:
+- `credentials: "include"` → envía la cookie de sesión.
+- `Authorization: Bearer <token>` → si existe `accessToken` en `localStorage`.
+- `Content-Type: application/json` → en todas las peticiones.
+
+### URL base
+
+```ts
+// lib/api.ts
+export const API_URL =
+  process.env.NEXT_PUBLIC_API_URL ??
+  "https://atalayas-backend-c25d.onrender.com/api/v1"
+```
+
+En producción se puede sobreescribir con la variable de entorno `NEXT_PUBLIC_API_URL`.
+
+---
+
+## Autenticación (`/auth`)
+
+| Método | Endpoint | Descripción | Función |
+|---|---|---|---|
+| `GET` | `/auth/me` | Devuelve los datos del usuario autenticado a partir de la cookie/token. Devuelve 401 si no hay sesión. | `AuthContext` (directo) |
+| `POST` | `/auth/logout` | Cierra la sesión en el servidor e invalida la cookie. | `AuthContext.logout()` |
+
+---
+
+## Módulos de formación (`/modulos`)
+
+Definidas en `lib/api/modulos.ts`.
+
+| Método | Endpoint | Descripción | Función |
+|---|---|---|---|
+| `GET` | `/modulos` | Lista los módulos visibles para el usuario autenticado. El backend filtra por empresa y rol automáticamente. | `getModulos()` |
+
+### Función combinada: `getModulosConProgreso()`
+
+No es un endpoint en sí, sino una función que llama en paralelo a `/modulos` y `/progreso/me` y combina los resultados para añadir el campo `status` (`"completado"`, `"en progreso"`, `"pendiente"`) a cada módulo.
+
+---
+
+## Progreso (`/progreso`)
+
+Definidas en `lib/api/modulos.ts` y `lib/api/progreso.ts`.
+
+| Método | Endpoint | Descripción | Función |
+|---|---|---|---|
+| `GET` | `/progreso/me` | Devuelve todos los registros de progreso del usuario autenticado. | `getMiProgreso()` |
+| `POST` | `/progreso` | Crea o actualiza el progreso de un contenido. Se llama al abrir o completar un módulo. | `registrarProgreso(payload)` |
+| `GET` | `/progreso/empresa/:empresaId` | Devuelve el progreso de todos los empleados de una empresa. Solo visible para admins. | `getProgresoEmpresa(empresaId)` |
+
+### Payload de `registrarProgreso`
+
+```ts
+{
+  usuarioId:       string   // ID del usuario
+  contenidoId:     string   // ID del contenido dentro del módulo
+  empresaId:       string   // ID de la empresa
+  tiempoSegundos:  number   // Tiempo que lleva el usuario en el contenido
+  completado:      boolean  // true si ha completado el contenido
+}
+```
+
+---
+
+## Anuncios / Noticias (`/anuncios`)
+
+Definidas en `lib/api/noticias.ts`.
+
+| Método | Endpoint | Descripción | Función |
+|---|---|---|---|
+| `GET` | `/anuncios` | Lista todos los anuncios. Se puede filtrar por empresa con `?empresaId=`. | `getNoticias(empresaId?)` |
+| `POST` | `/anuncios` | Crea un nuevo anuncio. | `crearNoticia(data)` |
+| `PUT` | `/anuncios/:id` | Edita un anuncio existente. | `editarNoticia(id, data)` |
+| `PATCH` | `/anuncios/:id/desactivar` | Desactiva un anuncio (no lo elimina). | `desactivarNoticia(id)` |
+
+### Tipo `NoticiaInput` (payload de creación/edición)
+
+```ts
+{
+  titulo:     string
+  contenido:  string
+  esGlobal:   boolean         // true = visible para todas las empresas
+  empresaId?: string | null   // null si es global
+}
+```
+
+---
+
+## Empresas (`/empresas`)
+
+Definidas en `lib/api/empresas.ts`. Solo accesibles para el superadmin.
+
+| Método | Endpoint | Descripción | Función |
+|---|---|---|---|
+| `GET` | `/empresas` | Lista todas las empresas registradas. | `getEmpresas()` |
+| `PATCH` | `/empresas/:id/estado` | Cambia el estado de solicitud de una empresa (`PENDIENTE`, `APROBADA`, `RECHAZADA`). | `actualizarEstadoEmpresa(id, estado)` |
+| `PATCH` | `/empresas/:id/solicitud` | Rechaza una solicitud de empresa pendiente. | `rechazarSolicitudEmpresa(id)` |
+| `PATCH` | `/empresas/:id/activacion` | Activa o desactiva una empresa ya aprobada (toggle). | `toggleActivacionEmpresa(id)` |
+
+---
+
+## Notificaciones (`/notificaciones`)
+
+Llamadas realizadas directamente desde `Header.tsx`, sin función auxiliar en `lib/api/`.
+
+| Método | Endpoint | Descripción |
+|---|---|---|
+| `GET` | `/notificaciones/me/contador` | Devuelve `{ noLeidas: number }`. Se consulta cada 30 segundos mediante polling. |
+| `PATCH` | `/notificaciones/me/leer-todas` | Marca todas las notificaciones del usuario como leídas. |
+
+---
+
+## Gestión de errores
+
+Todas las funciones de `lib/api/` siguen el mismo patrón:
+
+```ts
+const res = await apiFetch(`${API_URL}/endpoint`)
+if (!res.ok) throw new Error("Mensaje de error descriptivo")
+return res.json()
+```
+
+Los componentes que llaman a estas funciones deben capturar el error con `try/catch` y mostrar feedback al usuario.
+

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -1,0 +1,112 @@
+# Arquitectura del proyecto
+
+## Stack tecnológico
+
+| Tecnología | Versión | Para qué se usa |
+|---|---|---|
+| **Next.js** | 16 (App Router) | Framework React con enrutado por carpetas, layouts anidados y rutas de API en el servidor |
+| **TypeScript** | 5 | Tipado estático en todo el proyecto |
+| **Tailwind CSS** | 4 | Clases de utilidad para los estilos. Se usa junto con estilos en línea para componentes complejos |
+| **Supabase** | 2 | Se usa exclusivamente como **Storage** para subir imágenes de portada de módulos |
+| **GSAP** | 3 | Animaciones de entrada en menús y componentes UI (NotifMenu, UserMenu) |
+| **Motion** | 12 | Animaciones declarativas en componentes de página |
+| **Google Gemini 2.0 Flash** | — | Modelo de IA principal del chatbot AtalaIA |
+| **Groq llama-3.3-70b** | — | Modelo de IA de respaldo si Gemini falla |
+| **jsPDF** | 4 | Generación de PDFs en el cliente |
+| **Recharts** | 3 | Gráficas en el área de estadísticas del superadmin |
+| **HLS.js** | 1 | Reproducción de vídeo en streaming en módulos formativos |
+| **Lucide React** | 1 | Librería de iconos |
+
+---
+
+## Estructura de carpetas
+
+```
+atalayas-frontend/
+├── app/                        # Rutas de la aplicación (Next.js App Router)
+│   ├── layout.tsx              # Layout raíz: fuentes, AuthProvider
+│   ├── globals.css             # Variables CSS globales (colores, tipografías)
+│   ├── (public)/               # Grupo de rutas públicas (no requieren sesión)
+│   │   ├── layout.tsx
+│   │   ├── page.tsx            # Landing pública
+│   │   ├── login/
+│   │   └── register-empresa/
+│   ├── api/
+│   │   └── chat/
+│   │       └── route.ts        # Ruta de API del chatbot AtalaIA (servidor)
+│   ├── dashboard/              # Área de empleados y admins de empresa
+│   │   ├── layout.tsx          # Guard de sesión + Header + ChatbotIA
+│   │   ├── page.tsx
+│   │   ├── formacion/
+│   │   ├── comunicacion/
+│   │   ├── admin/
+│   │   ├── configuracion/
+│   │   ├── noticias/
+│   │   ├── onboarding/
+│   │   └── perfil/
+│   ├── superadmin/             # Área exclusiva del superadministrador
+│   │   ├── layout.tsx
+│   │   ├── page.tsx
+│   │   ├── empresas/
+│   │   ├── solicitudes/
+│   │   ├── estadisticas/
+│   │   ├── comunicados/
+│   │   └── configuracion/
+│   └── reset-password/
+├── components/                 # Componentes React reutilizables
+│   ├── Header.tsx              # Cabecera global (adaptativa por rol)
+│   ├── ModuloForm.tsx          # Formulario de creación/edición de módulos
+│   ├── auth/
+│   │   └── SuperAdminRoute.tsx # Guard de rol superadmin
+│   ├── pages/                  # Componentes de página completos
+│   └── ui/                     # Componentes de interfaz reutilizables
+├── context/
+│   └── AuthContext.tsx         # Estado global de sesión del usuario
+├── lib/                        # Lógica de negocio y utilidades
+│   ├── api.ts                  # apiFetch + API_URL base
+│   ├── routes.ts               # Definición de rutas por rol
+│   ├── supabase.ts             # Cliente Supabase + función de subida de imágenes
+│   ├── ai/
+│   │   └── provider.ts         # Proveedor de IA: Gemini y Groq
+│   ├── api/                    # Funciones de llamada a la API por dominio
+│   │   ├── modulos.ts
+│   │   ├── noticias.ts
+│   │   ├── progreso.ts
+│   │   └── empresas.ts
+│   └── types/                  # Tipos TypeScript compartidos
+│       ├── modulos.ts
+│       ├── noticias.ts
+│       └── progreso.ts
+└── public/                     # Imágenes estáticas, logos y fondos
+```
+
+---
+
+## Convenciones del proyecto
+
+### Nombrado de ficheros
+- Componentes React → `PascalCase.tsx` (ej: `ChatbotIA.tsx`)
+- Utilidades y tipos → `camelCase.ts` (ej: `api.ts`, `modulos.ts`)
+- Rutas de Next.js → carpeta con `page.tsx` o `route.ts`
+
+### Directiva `"use client"` / `"use server"`
+- Los componentes con hooks de React, acceso al DOM o `localStorage` llevan `"use client"` en la primera línea.
+- Las rutas de API (`app/api/`) y el proveedor de IA (`lib/ai/provider.ts`) son de servidor por defecto. `provider.ts` usa `import "server-only"` explícitamente para evitar importarlo accidentalmente en el cliente.
+
+### Estilos
+- **Tailwind** se usa para layout, espaciado, tipografía y responsive.
+- **Variables CSS globales** (definidas en `globals.css`) para colores corporativos: `--azul-egm`, `--verde-oliva`, `--marino`, etc. Se aplican con `style={{ color: "var(--azul-egm)" }}`.
+- Los componentes UI más complejos (ChatbotIA, NotifMenu) usan estilos en línea para control total de las animaciones.
+
+### Gestión de datos
+- No hay librería de estado global (Redux, Zustand, etc.). El estado se gestiona con React State + Context.
+- Las llamadas a la API siempre pasan por el wrapper `apiFetch` de `lib/api.ts`. Nunca se usa `fetch` directamente para llamadas al backend.
+- Los tipos de respuesta de la API se definen en `lib/types/` y los importan tanto los componentes como las funciones de `lib/api/`.
+
+### Alias de importación
+El alias `@/` apunta a la raíz del proyecto (configurado en `tsconfig.json`):
+```ts
+import { apiFetch } from "@/lib/api"
+import { useAuth } from "@/context/AuthContext"
+```
+

--- a/docs/autenticacion.md
+++ b/docs/autenticacion.md
@@ -1,0 +1,129 @@
+# Autenticación y roles
+
+## Cómo funciona la sesión
+
+La autenticación se basa en **JWT (JSON Web Token)**. El backend devuelve un token de acceso que el frontend almacena en `localStorage` bajo la clave `accessToken`. Además, el backend establece una **cookie HttpOnly** para mayor seguridad en entornos del mismo dominio.
+
+Todas las peticiones al backend pasan por el wrapper `apiFetch` (definido en `lib/api.ts`), que inyecta automáticamente:
+- La cookie de sesión mediante `credentials: "include"`.
+- El token `Bearer` desde `localStorage`, necesario cuando el frontend (Vercel) y el backend (Render) están en dominios distintos y las cookies entre dominios no se envían.
+
+---
+
+## Diagrama de flujo de sesión
+
+```mermaid
+flowchart TD
+    A([Usuario abre la app]) --> B{¿Existe 'guest'\nen localStorage?}
+
+    B -- Sí --> C[loginInvitado\ncodigoRol = INVITADO]
+    B -- No --> D[GET /auth/me]
+
+    D -- Error o 401 --> E[setUsuario null]
+    D -- OK --> F{¿usuario.activo?}
+
+    F -- No --> G[logout\nredirige a /login]
+    F -- Sí --> H[setUsuario con datos del backend]
+
+    C --> I{Ruta solicitada}
+    E --> J[Redirige a /login]
+    H --> I
+
+    I -- /dashboard/* --> K{¿codigoRol = INVITADO?}
+    K -- Sí --> L[Redirige a /]
+    K -- No --> M[Acceso permitido]
+
+    I -- /superadmin/* --> N{¿codigoRol = ROLE_ADMIN?}
+    N -- No --> O[Redirige a /dashboard]
+    N -- Sí --> P[Acceso permitido]
+
+    I -- Ruta pública --> Q[Acceso libre]
+```
+
+---
+
+## AuthContext
+
+El estado de sesión se gestiona en `context/AuthContext.tsx` mediante un **React Context** que envuelve toda la aplicación desde `app/layout.tsx`.
+
+### Qué expone el contexto
+
+```ts
+interface AuthContextType {
+  usuario: Usuario | null       // datos del usuario autenticado (o null si no hay sesión)
+  setUsuario: (u: Usuario | null) => void
+  logout: () => Promise<void>   // llama a POST /auth/logout y limpia el estado
+  loginInvitado: () => void     // activa la sesión de invitado sin llamar al backend
+}
+```
+
+### Tipo `Usuario`
+
+```ts
+interface Usuario {
+  nombre: string
+  apellidos?: string
+  codigoRol: string           // ver tabla de roles más abajo
+  nombreEmpresa?: string
+  logoEmpresaUrl?: string
+  activo?: boolean
+  empresaId?: string
+  usuarioId?: string
+  email?: string
+  avatarUrl?: string
+  bannerUrl?: string
+  nombreRol?: string
+  invitado?: boolean          // true solo en modo invitado
+}
+```
+
+### Ciclo de vida de la sesión
+
+1. Al montar `AuthProvider`, se comprueba `localStorage` para detectar el modo invitado.
+2. Si no hay invitado, se llama a `GET /auth/me` para restaurar la sesión.
+3. Si el backend devuelve un usuario inactivo (`activo: false`), se ejecuta `logout()`.
+4. En `logout()` se llaman a `DELETE /auth/logout`, se borra `accessToken` y `guest` de `localStorage` y se pone `usuario` a `null`.
+
+---
+
+## Tabla de roles
+
+| `codigoRol` | Nombre | Acceso |
+|---|---|---|
+| `INVITADO` | Invitado | Solo la landing pública (`/`). No puede acceder al dashboard. |
+| `ROLE_EMPLEADO` | Empleado | Dashboard: Inicio, Formación, Comunicación. |
+| `ROLE_ADMIN_EMPRESA` | Administrador de empresa | Dashboard completo: incluye la sección Administración (gestión de módulos y empleados). |
+| `ROLE_ADMIN` | Superadministrador | Área `/superadmin`: gestión global de empresas, solicitudes, estadísticas y comunicados. |
+
+---
+
+## Guards de layout
+
+### Dashboard (`app/dashboard/layout.tsx`)
+
+El layout del dashboard protege **todas** las rutas bajo `/dashboard`:
+
+1. Si no hay usuario en el contexto, llama a `GET /auth/me` para comprobar si hay sesión activa.
+2. Si no hay sesión válida → redirige a `/login`.
+3. Si el usuario es `INVITADO` → redirige a `/` (la landing).
+4. Mientras se verifica la sesión, muestra un spinner de carga.
+
+### Superadmin (`components/auth/SuperAdminRoute.tsx`)
+
+Componente de alto orden que envuelve el contenido de las páginas del superadmin:
+
+- Si no hay usuario → redirige a `/login`.
+- Si el `codigoRol` no es `ROLE_ADMIN` → redirige a `/dashboard`.
+- Si pasa los dos checks → renderiza el contenido.
+
+---
+
+## Modo invitado
+
+El modo invitado permite acceder a la landing pública sin necesidad de registrarse. Se activa llamando a `loginInvitado()` del contexto, que:
+
+1. Crea un objeto `Usuario` local con `codigoRol: "INVITADO"` e `invitado: true`.
+2. Guarda `"true"` en `localStorage` bajo la clave `guest`.
+
+Este modo no hace ninguna llamada al backend. Al cerrar sesión se elimina la clave `guest` de `localStorage`.
+

--- a/docs/chatbot-ia.md
+++ b/docs/chatbot-ia.md
@@ -1,0 +1,143 @@
+# AtalaIA — Chatbot de inteligencia artificial
+
+AtalaIA es el asistente IA integrado en la plataforma. Aparece como un botón flotante (FAB) en el dashboard y responde preguntas sobre formación, onboarding, comunicados y el uso de la plataforma.
+
+---
+
+## Arquitectura general
+
+```
+Usuario escribe mensaje
+        │
+        ▼
+[ChatbotIA.tsx]  ←→  localStorage (historial de mensajes)
+  (cliente)
+        │  POST /api/chat
+        │  { messages, context }
+        ▼
+[app/api/chat/route.ts]          ← Vercel / Next.js servidor
+  buildSystemPrompt(context)
+        │  POST /ai/chat
+        │  { messages, systemPrompt }
+        ▼
+[Backend Render]                 ← aquí viven GEMINI_API_KEY y GROQ_API_KEY
+        │
+        ├──► Google Gemini 2.0 Flash  ──► streaming de tokens
+        │         (falla)
+        └──► Groq llama-3.3-70b      ──► streaming de tokens
+                                              │
+                                   pipe del stream sin modificar
+                                              │
+                                              ▼
+                                    ChatbotIA actualiza el mensaje
+                                    token a token en pantalla
+```
+
+> **Diseño proxy:** `route.ts` construye el `systemPrompt` con el contexto del usuario (nombre, empresa, módulos) y lo reenvía al backend. El backend no necesita conocer al usuario — solo recibe los mensajes y el prompt ya construido.
+
+---
+
+## Componente `ChatbotIA` (`components/ui/ChatbotIA.tsx`)
+
+Es el componente de interfaz del chatbot. Se renderiza en el layout de `/dashboard` y está disponible en toda la sección autenticada.
+
+### Características principales
+
+- **FAB arrastrable**: En escritorio, el botón flotante se puede arrastrar a cualquier posición. La posición se guarda en `localStorage` (`atalaIA-fab-pos`) y se restaura en la siguiente visita.
+- **Panel adaptativo**: En móvil, el panel ocupa casi toda la pantalla deslizando desde abajo. En escritorio, flota al lado del FAB.
+- **Historial persistente**: Los mensajes se guardan en `localStorage` (`atalaIA-messages`) y se restauran al reabrir el chat.
+- **Streaming visible**: Los tokens llegan del servidor y se van añadiendo al texto del mensaje en tiempo real, con un cursor parpadeante.
+- **Sugerencias contextuales**: Al abrir el chat por primera vez se muestran 4 sugerencias personalizadas según el rol del usuario y el estado de sus módulos.
+- **Rate limiting en cliente**: Máximo 4 mensajes en 10 segundos. Si se supera, se bloquea el envío 5 segundos con un aviso.
+- **Punto rojo de actividad**: El FAB muestra un indicador rojo si el usuario tiene módulos pendientes o en progreso.
+
+### Contexto que envía al servidor
+
+Cada mensaje incluye el contexto del usuario para que la IA pueda personalizar las respuestas:
+
+```ts
+{
+  messages: últimos 10 mensajes del historial,
+  context: {
+    nombreUsuario:      "Nombre Apellidos",
+    empresa:            "Nombre de la empresa",
+    rol:                "ROLE_EMPLEADO",
+    modulosPendientes:  ["Módulo A", "Módulo B (en progreso)"],
+    modulosCompletados: ["Módulo C"],
+  }
+}
+```
+
+---
+
+## Ruta de API (`app/api/chat/route.ts`)
+
+Es una **ruta de servidor de Next.js** que actúa como **proxy** entre el cliente y el backend de Render.
+
+- **Runtime**: `nodejs`
+- **Método**: solo acepta `POST`
+- **Entrada**: `{ messages: ChatMessage[], context?: {...} }`
+- **Proceso**:
+  1. Construye el `systemPrompt` personalizado con `buildSystemPrompt(context)`.
+  2. Hace `POST` a `${BACKEND_URL}/ai/chat` con `{ messages, systemPrompt }`.
+  3. Devuelve el `body` del backend directamente al cliente como pipe, sin bufferizar.
+- **Salida**: `ReadableStream` de texto plano (`text/plain; charset=utf-8`).
+
+La variable `BACKEND_URL` (solo servidor) apunta al backend de Render. Fallback automático a la URL de producción si no está definida.
+
+### `buildSystemPrompt(context)`
+
+Función que construye el prompt de sistema personalizado para cada conversación. Define:
+- La identidad del asistente (AtalaIA, plataforma Atalayas).
+- El contexto del usuario (nombre, empresa, rol, módulos).
+- Las reglas de formato de respuesta (negrita, listas, emojis moderados).
+- Las instrucciones de comportamiento (no inventar datos, no pedir que inicien sesión, responder en español).
+
+---
+
+## Proveedor de IA — backend de Render
+
+La lógica de conexión con Gemini y Groq **vive en el backend**. El frontend ya no depende de las SDKs `@google/generative-ai` ni `groq-sdk` para el chatbot.
+
+El fichero `lib/ai/provider.ts` queda en el repositorio como referencia histórica pero **ya no se importa desde ningún sitio**. Se puede eliminar junto con sus dependencias del `package.json` una vez el backend tenga el endpoint `/ai/chat` funcionando.
+
+### Contrato del endpoint del backend
+
+```
+POST /api/v1/ai/chat
+Content-Type: application/json
+
+Body:
+{
+  "messages":     [{ "role": "user" | "assistant", "content": string }],
+  "systemPrompt": string
+}
+
+Response:
+  Content-Type: text/plain; charset=utf-8
+  Body: stream de tokens de texto plano
+```
+
+---
+
+## Sugerencias contextuales
+
+Al abrir el chat por primera vez (sin historial previo), el componente muestra 4 sugerencias de preguntas. Las sugerencias se seleccionan aleatoriamente de dos pools:
+
+- **Admins** (`ROLE_ADMIN` / `ROLE_ADMIN_EMPRESA`): preguntas sobre gestión de módulos, progreso de empleados, comunicados...
+- **Empleados**: preguntas sobre completar módulos, PRL, comunicados, onboarding...
+
+Si el usuario tiene módulos en progreso o pendientes, se priorizan sugerencias relacionadas con esos módulos concretos.
+
+---
+
+## Variables de entorno necesarias
+
+| Variable | Dónde se configura | Descripción |
+|---|---|---|
+| `BACKEND_URL` | **Vercel** (solo servidor) | URL base del backend de Render. Sin ella se usa el fallback de producción. |
+| `GOOGLE_GEMINI_API_KEY` | **Render** (backend) | Clave para Gemini 2.0 Flash. |
+| `GROQ_API_KEY` | **Render** (backend) | Clave para llama-3.3-70b (fallback). |
+
+Ver [variables-de-entorno.md](./variables-de-entorno.md) para la guía completa.
+

--- a/docs/componentes.md
+++ b/docs/componentes.md
@@ -1,0 +1,200 @@
+# Componentes
+
+Inventario de todos los componentes del proyecto, agrupados por carpeta. Para cada uno se indica su propósito, las props que acepta y notas de uso relevantes.
+
+---
+
+## `components/` (raíz)
+
+### `Header.tsx`
+
+Cabecera global de la aplicación, presente en el dashboard y en el área del superadmin.
+
+**Comportamiento:**
+- Detecta si el usuario es superadmin (`codigoRol === "ROLE_ADMIN"`) y cambia los enlaces de navegación en consecuencia.
+- En escritorio muestra los enlaces horizontalmente. En móvil, los oculta tras un menú hamburguesa.
+- Muestra el contador de notificaciones no leídas con polling cada 30 segundos.
+- El logo, el enlace de perfil y la campana de notificaciones apuntan a rutas distintas según el rol.
+
+| Prop | Tipo | Descripción |
+|---|---|---|
+| `logoEmpresa?` | `string` | URL del logo de la empresa para mostrar en el avatar. Opcional. |
+
+**Incluye internamente:** `NavButton` (botón de navegación con animación de subrayado), `UserMenu`, `NotifMenu`.
+
+---
+
+### `ModuloForm.tsx`
+
+Formulario para **crear o editar** un módulo formativo. Lo usa el admin de empresa desde la sección de administración.
+
+| Prop | Tipo | Descripción |
+|---|---|---|
+| `editando?` | `{ moduloId, nombre, descripcion, tipoModulo } \| null` | Si se pasa, el formulario se pre-rellena para edición. Si es `null` o `undefined`, es un formulario de creación. |
+| `empresaId` | `string \| undefined` | ID de la empresa a la que pertenece el módulo. |
+| `onSave` | `() => void` | Callback que se llama al guardar correctamente. |
+| `onCancel` | `() => void` | Callback que se llama al cancelar. |
+
+**Tipos de módulo disponibles:** `IDENTIDAD`, `BASICA`, `ESPECIFICA`, `DESARROLLO`, `RECOMPENSAS`, `COMUNIDAD`. Ver `lib/types/modulos.ts`.
+
+---
+
+## `components/auth/`
+
+### `SuperAdminRoute.tsx`
+
+Componente de **guard de rol** para el área del superadmin. Envuelve el contenido de las páginas que solo debe ver `ROLE_ADMIN`.
+
+- Si no hay usuario → redirige a `/login`.
+- Si el rol no es `ROLE_ADMIN` → redirige a `/dashboard`.
+- Si el usuario tiene el rol correcto → renderiza `children`.
+
+| Prop | Tipo | Descripción |
+|---|---|---|
+| `children` | `ReactNode` | Contenido a proteger. |
+
+---
+
+## `components/ui/`
+
+### `ChatbotIA.tsx`
+
+El asistente IA AtalaIA. Componente flotante disponible en todo el dashboard. Ver [chatbot-ia.md](./chatbot-ia.md) para la documentación completa.
+
+**No tiene props externas.** Lee el usuario del `AuthContext` y los módulos directamente desde la API.
+
+---
+
+### `Header.tsx` → ver sección de raíz arriba.
+
+---
+
+### `UserMenu.tsx`
+
+Menú desplegable del usuario en la esquina superior derecha del header. Muestra el nombre, empresa y opciones de navegación.
+
+| Prop | Tipo | Descripción |
+|---|---|---|
+| `nombreMostrado` | `string` | Nombre del usuario a mostrar. |
+| `empresaNombre?` | `string` | Nombre de la empresa. |
+| `initials` | `string` | Iniciales del usuario (para el avatar). |
+| `logoEmpresa?` | `string` | URL del logo de empresa. |
+| `avatarUrl?` | `string` | URL de la foto de perfil del usuario. |
+| `onPerfil` | `() => void` | Navega al perfil. |
+| `onConfiguracion` | `() => void` | Navega a configuración. |
+| `onCerrarSesion` | `() => void` | Cierra la sesión. |
+
+**Animaciones:** usa GSAP para la animación de entrada/salida del dropdown.
+
+---
+
+### `NotifMenu.tsx`
+
+Campana de notificaciones en el header. Muestra el contador de notificaciones no leídas y permite marcarlas todas como leídas.
+
+| Prop | Tipo | Descripción |
+|---|---|---|
+| `noLeidas` | `number` | Número de notificaciones no leídas. |
+| `onVerTodas` | `() => void` | Navega a la sección de notificaciones/comunicación. |
+| `onMarcarLeidas` | `() => void` | Marca todas como leídas. |
+
+**Animaciones:** usa GSAP para la animación de entrada del dropdown y de las tarjetas internas.
+
+---
+
+### `DashboardHero.tsx`
+
+Banner hero reutilizable para las páginas del dashboard. Muestra una imagen de fondo con degradado oscuro y un título tipográfico.
+
+| Prop | Tipo | Descripción |
+|---|---|---|
+| `prefijo?` | `string` | Texto en Poppins bold, antes del título principal. Ej: `"Centro de "` |
+| `titulo` | `string` | Texto principal en Instrument Serif italic. Ej: `"Formación."` |
+| `imagenFondo?` | `string` | Ruta relativa a `/public`. Por defecto: `/background-dashboard.jpg`. |
+
+Muestra el nombre del usuario autenticado (obtenido del `AuthContext`).
+
+---
+
+### `Button.tsx`
+
+Botón genérico reutilizable con variantes de estilo.
+
+---
+
+### `ComunicadosCarousel.tsx`
+
+Carrusel de comunicados/anuncios. Se usa en la sección de comunicación del empleado.
+
+---
+
+### `FooterCTA.tsx`
+
+Sección de llamada a la acción para el pie de las páginas públicas.
+
+---
+
+### `GradientText.tsx`
+
+Componente de texto con gradiente de color. Se usa en títulos de la landing y páginas de presentación.
+
+---
+
+### `Grainient.tsx`
+
+Fondo animado con gradiente + efecto de grano (noise). Se usa en el header del chatbot. Renderiza un canvas WebGL usando la librería OGL.
+
+| Prop | Tipo | Descripción |
+|---|---|---|
+| `color1`, `color2`, `color3` | `string` | Colores en hexadecimal del gradiente animado. |
+| `timeSpeed` | `number` | Velocidad de animación temporal. |
+| `warpSpeed` | `number` | Velocidad del efecto de distorsión (warp). |
+| `warpStrength` | `number` | Intensidad de la distorsión. |
+| `contrast` | `number` | Contraste del gradiente. |
+| `saturation` | `number` | Saturación del gradiente. |
+| `grainAmount` | `number` | Cantidad de grano (0 = sin grano, 1 = máximo). |
+| `style?` | `CSSProperties` | Estilos en línea del contenedor canvas. |
+
+---
+
+### `LineWaves.tsx`
+
+Animación de ondas de líneas. Usada como elemento decorativo en fondos de sección.
+
+---
+
+### `LogoLoop.tsx`
+
+Carrusel infinito de logos de empresa. Se usa en la landing para mostrar las empresas del área empresarial.
+
+---
+
+### `SplitText.tsx`
+
+Componente que divide un texto en letras/palabras para animar su entrada de forma escalonada.
+
+---
+
+### `WaveDivider.tsx`
+
+Separador decorativo en forma de ola entre secciones de página.
+
+---
+
+## `components/pages/`
+
+Componentes de "página completa" que encapsulan la lógica y presentación de una sección entera. Son importados directamente por los `page.tsx` de Next.js.
+
+| Componente | Sección | Descripción |
+|---|---|---|
+| `AdminEmpresa.tsx` | `/dashboard/admin` | Panel del admin de empresa: resumen de usuarios, anuncios y progreso de módulos. |
+| `AdminGeneral.tsx` | Superadmin | Vista general de administración global. |
+| `Empleado.tsx` | Dashboard empleado | Vista principal del empleado con sus módulos y progreso. |
+| `GestionEmpresas.tsx` | `/superadmin/empresas` | Tabla de gestión de empresas con acciones de aprobar, rechazar y activar/desactivar. |
+| `Invitado.tsx` | Landing invitado | Vista reducida de la plataforma para usuarios no registrados. |
+| `Landing.tsx` | `/` | Landing pública completa con presentación de la plataforma. |
+| `Login.tsx` | `/login` | Formulario de login con validación. |
+| `Noticias.tsx` | `/dashboard/noticias` | Lista de anuncios con opción de creación/edición para admins. |
+| `RegisterEmpresa.tsx` | `/register-empresa` | Formulario de solicitud de alta de empresa. |
+| `SolicitudesPendientes.tsx` | `/superadmin/solicitudes` | Lista de solicitudes de empresa pendientes de revisión. |
+

--- a/docs/rutas.md
+++ b/docs/rutas.md
@@ -1,0 +1,106 @@
+# Rutas de la aplicación
+
+## Resumen general
+
+| Tipo | Prefijo | Quién accede |
+|---|---|---|
+| Pública | `/` | Cualquiera (sin sesión) |
+| Dashboard | `/dashboard` | Empleados y admins de empresa |
+| Superadmin | `/superadmin` | Solo `ROLE_ADMIN` |
+
+---
+
+## Rutas públicas (`app/(public)/`)
+
+No requieren sesión. Agrupadas con paréntesis para que Next.js no las incluya en la URL.
+
+| Ruta | Página | Descripción |
+|---|---|---|
+| `/` | `(public)/page.tsx` | Landing pública con presentación de la plataforma. Accesible también para invitados. |
+| `/login` | `(public)/login/` | Formulario de inicio de sesión. |
+| `/register-empresa` | `(public)/register-empresa/` | Formulario de solicitud de alta de empresa. |
+| `/reset-password` | `reset-password/page.tsx` | Pantalla de restablecimiento de contraseña. |
+
+---
+
+## Dashboard (`app/dashboard/`)
+
+**Guard aplicado:** `app/dashboard/layout.tsx` comprueba la sesión antes de renderizar cualquier página. Si no hay sesión válida → redirige a `/login`. Si el rol es `INVITADO` → redirige a `/`.
+
+| Ruta | Descripción | Quién la ve |
+|---|---|---|
+| `/dashboard` | Inicio del dashboard. Resumen del usuario. | `ROLE_EMPLEADO`, `ROLE_ADMIN_EMPRESA` |
+| `/dashboard/formacion` | Lista de módulos formativos y progreso. | `ROLE_EMPLEADO`, `ROLE_ADMIN_EMPRESA` |
+| `/dashboard/comunicacion` | Bandeja de comunicados internos. | `ROLE_EMPLEADO`, `ROLE_ADMIN_EMPRESA` |
+| `/dashboard/admin` | Panel de administración de empresa: módulos, empleados, estadísticas. | Solo `ROLE_ADMIN_EMPRESA` (el backend protege el acceso a los datos) |
+| `/dashboard/noticias` | Anuncios y noticias de la empresa. | `ROLE_EMPLEADO`, `ROLE_ADMIN_EMPRESA` |
+| `/dashboard/onboarding` | Proceso de onboarding guiado. | `ROLE_EMPLEADO`, `ROLE_ADMIN_EMPRESA` |
+| `/dashboard/perfil` | Perfil personal del usuario. | `ROLE_EMPLEADO`, `ROLE_ADMIN_EMPRESA` |
+| `/dashboard/configuracion` | Ajustes de cuenta. | `ROLE_EMPLEADO`, `ROLE_ADMIN_EMPRESA` |
+
+> **Nota:** La visibilidad de las secciones en el menú de navegación está controlada por `NAV_ITEMS_BY_ROLE` en `lib/routes.ts`. Un empleado no verá el enlace a "Administración" aunque la URL exista. La protección real de los datos sensibles la hace el backend.
+
+---
+
+## Superadmin (`app/superadmin/`)
+
+**Guard aplicado:** `components/auth/SuperAdminRoute.tsx`. Si el usuario no tiene `codigoRol === "ROLE_ADMIN"`, es redirigido a `/dashboard`.
+
+| Ruta | Descripción |
+|---|---|
+| `/superadmin` | Inicio del panel de superadministración. |
+| `/superadmin/empresas` | Listado y gestión de todas las empresas. |
+| `/superadmin/solicitudes` | Solicitudes de alta de empresa pendientes de revisión. |
+| `/superadmin/estadisticas` | Estadísticas globales de uso de la plataforma. |
+| `/superadmin/comunicados` | Gestión de comunicados globales (visibles para todas las empresas). |
+| `/superadmin/configuracion` | Configuración del superadministrador. |
+
+---
+
+## Sistema de navegación por rol (`lib/routes.ts`)
+
+El Header carga los enlaces de navegación dinámicamente según el rol del usuario.
+
+```ts
+// Rutas del dashboard
+export const NAV_ROUTES: Record<string, string> = {
+  "Inicio":         "/dashboard",
+  "Formación":      "/dashboard/formacion",
+  "Comunicación":   "/dashboard/comunicacion",
+  "Administración": "/dashboard/admin",
+}
+
+// Qué ítems ve cada rol en el menú
+export const NAV_ITEMS_BY_ROLE: Record<string, string[]> = {
+  ROLE_EMPLEADO:      ["Inicio", "Formación", "Comunicación"],
+  ROLE_ADMIN_EMPRESA: ["Inicio", "Formación", "Comunicación", "Administración"],
+}
+```
+
+El superadmin (`ROLE_ADMIN`) usa una lista de enlaces propia definida directamente en `Header.tsx`:
+
+```ts
+const SUPERADMIN_LINKS = [
+  { label: "Inicio",        path: "/superadmin" },
+  { label: "Empresas",      path: "/superadmin/empresas" },
+  { label: "Solicitudes",   path: "/superadmin/solicitudes" },
+  { label: "Estadísticas",  path: "/superadmin/estadisticas" },
+  { label: "Comunicados",   path: "/superadmin/comunicados" },
+]
+```
+
+---
+
+## Tabla de acceso completa
+
+| Ruta | Sin sesión | INVITADO | ROLE_EMPLEADO | ROLE_ADMIN_EMPRESA | ROLE_ADMIN |
+|---|---|---|---|---|---|
+| `/` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `/login` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `/register-empresa` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `/dashboard` | 🔄 `/login` | 🔄 `/` | ✅ | ✅ | ✅ |
+| `/dashboard/admin` | 🔄 `/login` | 🔄 `/` | ⚠️ visible pero sin datos | ✅ | — |
+| `/superadmin` | 🔄 `/login` | 🔄 `/login` | 🔄 `/dashboard` | 🔄 `/dashboard` | ✅ |
+
+> **Leyenda:** ✅ Acceso permitido · 🔄 Redirige · ⚠️ Acceso a la URL pero el backend rechaza los datos · — No aplica
+

--- a/docs/variables-de-entorno.md
+++ b/docs/variables-de-entorno.md
@@ -1,0 +1,82 @@
+# Variables de entorno
+
+El proyecto necesita **5 variables de entorno** para funcionar correctamente. Se definen en un fichero `.env.local` en la raíz del proyecto (nunca se sube al repositorio).
+
+---
+
+## Variables del frontend (Vercel)
+
+| Variable | Ámbito | Obligatoria | Descripción |
+|---|---|---|---|
+| `NEXT_PUBLIC_API_URL` | Cliente + Servidor | No* | URL base del backend REST. Si no se define, se usa `https://atalayas-backend-c25d.onrender.com/api/v1` como fallback. |
+| `NEXT_PUBLIC_SUPABASE_URL` | Cliente + Servidor | Sí | URL del proyecto de Supabase. Se obtiene en Supabase → Settings → API. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Cliente + Servidor | Sí | Clave anónima pública de Supabase. Se obtiene en el mismo lugar. |
+| `BACKEND_URL` | Solo servidor | No* | URL base del backend para las llamadas internas de servidor (chatbot proxy). Fallback igual que `NEXT_PUBLIC_API_URL`. |
+
+> **\* `NEXT_PUBLIC_API_URL` y `BACKEND_URL`** son opcionales solo si el backend de producción sigue siendo el de Render. En desarrollo local define ambas apuntando a tu instancia local.
+
+## Variables del backend (Render)
+
+Las claves de IA **ya no están en Vercel**. Deben configurarse en el panel de Render del servicio backend:
+
+| Variable | Descripción |
+|---|---|
+| `GOOGLE_GEMINI_API_KEY` | Clave de Google AI Studio para Gemini 2.0 Flash. Consola: [aistudio.google.com](https://aistudio.google.com). |
+| `GROQ_API_KEY` | Clave de Groq Cloud para llama-3.3-70b (fallback). Consola: [console.groq.com](https://console.groq.com). |
+
+---
+
+## Diferencia entre variables públicas y de servidor
+
+- **Variables con `NEXT_PUBLIC_`**: Next.js las incluye en el bundle del cliente. Son visibles en el navegador. Úsalas solo para valores que no sean secretos (URLs de servicios públicos, claves anónimas de Supabase).
+- **Variables sin `NEXT_PUBLIC_`**: Solo disponibles en el servidor (rutas de API, funciones de servidor). Nunca llegan al navegador. Úsalas para claves secretas como las de Gemini o Groq.
+
+---
+
+## Dónde se usan
+
+| Variable | Fichero |
+|---|---|
+| `NEXT_PUBLIC_API_URL` | `lib/api.ts` |
+| `NEXT_PUBLIC_SUPABASE_URL` | `lib/supabase.ts` |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | `lib/supabase.ts` |
+| `BACKEND_URL` | `app/api/chat/route.ts` (proxy del chatbot) |
+
+---
+
+## Qué falla si no están definidas
+
+| Variable ausente | Consecuencia |
+|---|---|
+| `NEXT_PUBLIC_API_URL` | Se usa la URL de producción por defecto. En desarrollo, las peticiones REST irán al backend de Render en lugar del local. |
+| `NEXT_PUBLIC_SUPABASE_URL` | La subida de imágenes de portada de módulos fallará con un error de cliente. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | La subida de imágenes de portada de módulos fallará con un error de autenticación. |
+| `BACKEND_URL` | El proxy del chatbot usará la URL de producción de Render por defecto. En desarrollo apuntar a la instancia local. |
+| `GOOGLE_GEMINI_API_KEY` *(en Render)* | El backend intentará usar Gemini, fallará y pasará automáticamente a Groq. |
+| `GROQ_API_KEY` *(en Render)* | Si Gemini también falla, el chatbot devolverá un error `⚠️ El servicio de IA no está disponible`. |
+
+---
+
+## Plantilla `.env.local` (Vercel / desarrollo local)
+
+Crea este fichero en la raíz del proyecto y rellena los valores:
+
+```bash
+# Backend REST (usado por el cliente y el servidor de Next.js)
+NEXT_PUBLIC_API_URL=http://localhost:3001/api/v1
+
+# Backend URL para llamadas internas de servidor (proxy del chatbot)
+# Puede coincidir con NEXT_PUBLIC_API_URL o apuntar a otra URL/puerto
+BACKEND_URL=http://localhost:3001/api/v1
+
+# Supabase (obtener en: Project Settings → API)
+NEXT_PUBLIC_SUPABASE_URL=https://xxxxxxxxxxxx.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+> **Las claves de IA (`GOOGLE_GEMINI_API_KEY`, `GROQ_API_KEY`) ya no van aquí.**
+> Configúralas en el panel de Render del servicio backend:
+> **Render → tu servicio backend → Environment**.
+
+> **Importante:** El fichero `.env.local` está incluido en `.gitignore` por defecto en Next.js. Nunca lo subas al repositorio. Comparte las claves con el equipo por un canal seguro.
+

--- a/lib/api/progreso.ts
+++ b/lib/api/progreso.ts
@@ -1,8 +1,14 @@
 import { apiFetch, API_URL } from "@/lib/api";
-import type { ProgresoEmpleado } from "@/lib/types/progreso";
+import type { ProgresoEmpleado, ActividadItem } from "@/lib/types/progreso";
 
 export async function getProgresoEmpresa(empresaId: string): Promise<ProgresoEmpleado[]> {
   const res = await apiFetch(`${API_URL}/progreso/empresa/${empresaId}`);
   if (!res.ok) throw new Error("Error al cargar progreso");
+  return res.json();
+}
+
+export async function getActividadReciente(limit = 5): Promise<ActividadItem[]> {
+  const res = await apiFetch(`${API_URL}/dashboard/admin/actividad?limit=${limit}`);
+  if (!res.ok) throw new Error("Error al cargar actividad reciente");
   return res.json();
 }

--- a/lib/types/progreso.ts
+++ b/lib/types/progreso.ts
@@ -1,3 +1,11 @@
+export type ActividadTipo = "completado" | "inicio" | "logro" | "grupo" | "nuevo";
+
+export interface ActividadItem {
+  tipo: ActividadTipo;
+  texto: string;
+  timestamp: string;
+}
+
 export interface ProgresoModulo {
     moduloId: string;
     nombreModulo: string;


### PR DESCRIPTION
This pull request introduces several key improvements to the Atalayas frontend, focusing on documentation, API architecture, and user interface enhancements. The most significant changes include the addition of comprehensive technical documentation, a refactor of the chatbot API route to proxy backend requests securely, and the integration of real recent activity data in the admin dashboard.

**Documentation Improvements:**

* Added a detailed project README (`docs/README.md`), outlining the stack, project structure, and documentation index for easier onboarding and maintenance.
* Introduced architectural documentation (`docs/arquitectura.md`), including stack overview, folder structure, and project conventions.
* Added a complete API reference (`docs/api.md`), detailing all backend endpoints, usage patterns, and integration guidelines for frontend developers.
* Documented authentication flows, session management, and role-based access in `docs/autenticacion.md`.

**API and Backend Integration:**

* Refactored the chatbot API route (`app/api/chat/route.ts`) to act as a secure proxy, forwarding chat requests to the backend on Render, which now manages AI keys and streaming responses. Improved error handling and removed direct AI provider calls from the frontend. [[1]](diffhunk://#diff-801bec1474c7c5e37b836db21695f406a724ef597a38129f6a6bb4959e6b4135L4-R14) [[2]](diffhunk://#diff-801bec1474c7c5e37b836db21695f406a724ef597a38129f6a6bb4959e6b4135L67-R96)

**Admin Dashboard Enhancements:**

* Updated the admin dashboard (`components/pages/AdminEmpresa.tsx`) to fetch and display real recent activity using `getActividadReciente`, replacing static mock data. Added a user-friendly empty state when no activity is present and improved timestamp formatting for activity items. [[1]](diffhunk://#diff-217bbbf405db1d504cf394e762bfa63a3b63602cf401798a66bf1427a53155cbR7-R8) [[2]](diffhunk://#diff-217bbbf405db1d504cf394e762bfa63a3b63602cf401798a66bf1427a53155cbL34-R46) [[3]](diffhunk://#diff-217bbbf405db1d504cf394e762bfa63a3b63602cf401798a66bf1427a53155cbR112-R128) [[4]](diffhunk://#diff-217bbbf405db1d504cf394e762bfa63a3b63602cf401798a66bf1427a53155cbR323-R340)