### PR TITLE
feat: mejoras de header y heroes + correcciones

### DIFF
--- a/app/dashboard/admin/comunicados/page.tsx
+++ b/app/dashboard/admin/comunicados/page.tsx
@@ -259,7 +259,7 @@ export default function ComunicadosAdminPage() {
 
   return (
     <>
-      <DashboardHero prefijo="Panel de " titulo="Comunicados." imagenFondo="/background-comunicacion-empleado.webp" />
+      <DashboardHero prefijo="Panel de " titulo="Comunicados" imagenFondo="/background-comunicacion-empleado.webp" />
 
       <div className="px-6 md:px-10 lg:px-16 pt-10 pb-16">
 

--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -317,7 +317,7 @@ function AdminContent() {
     <>
       <DashboardHero
         prefijo="Panel de "
-        titulo="Administración."
+        titulo="Administración"
         imagenFondo="/background-formacion-empleado.webp"
       />
 

--- a/app/dashboard/colaboradores/page.tsx
+++ b/app/dashboard/colaboradores/page.tsx
@@ -6,7 +6,7 @@ export default function Page() {
         <div>
             <DashboardHero
                 prefijo="Ecosistema de"
-                titulo="Proximidad."
+                titulo="Proximidad"
                 imagenFondo="/bg-colaboraciones.webp"
                 objectPosition="center 55%"
             />

--- a/app/dashboard/configuracion/page.tsx
+++ b/app/dashboard/configuracion/page.tsx
@@ -150,7 +150,7 @@ export default function ConfiguracionPage() {
   return (
     <div className="min-h-screen pb-20" style={{ background: "var(--gris-pagina)" }}>
 
-      <DashboardHero prefijo="Mi " titulo="Configuración." />
+      <DashboardHero prefijo="Mi " titulo="Configuración" variante="minima" />
 
       <div className="px-10 lg:px-16 pt-14 pb-16">
 

--- a/app/dashboard/formacion/[moduloId]/page.tsx
+++ b/app/dashboard/formacion/[moduloId]/page.tsx
@@ -395,7 +395,7 @@ export default function Page() {
       {/* ── HERO ─────────────────────────────────────────────────────────────── */}
       <div
         className="relative overflow-hidden flex items-center"
-        style={{ minHeight: "320px", boxShadow: "0 6px 32px rgba(0,0,0,0.22)" }}
+        style={{ minHeight: "clamp(260px, 30vw, 380px)", boxShadow: "0 6px 32px rgba(0,0,0,0.22)" }}
       >
         {/* Imagen de fondo */}
         <img

--- a/app/dashboard/formacion/page.tsx
+++ b/app/dashboard/formacion/page.tsx
@@ -171,7 +171,7 @@ export default function FormacionPage() {
 
   return (
     <div className="w-full">
-      <DashboardHero prefijo="Centro de " titulo="Formación." imagenFondo="/background-formacion-empleado.webp" />
+      <DashboardHero prefijo="Centro de " titulo="Formación" imagenFondo="/background-formacion-empleado.webp" />
 
       <div className="px-10 lg:px-16 pt-14 pb-16">
       {/* ── Loading ───────────────────────────────────────────────────── */}

--- a/app/dashboard/perfil/page.tsx
+++ b/app/dashboard/perfil/page.tsx
@@ -508,21 +508,10 @@ export default function PerfilPage() {
 
   const disp = DISPONIBILIDAD_CONFIG[perfil?.disponibilidad ?? "DISPONIBLE"];
   const initials = getInitials(perfil?.nombre ?? "", perfil?.apellidos ?? "");
-  const bannerFondo = perfil?.bannerUrl ?? "/background-dashboard.webp";
-
   return (
     <div className="min-h-screen pb-20" style={{ background: "var(--gris-pagina)" }}>
 
       <style>{`
-        @keyframes heroFadeUp {
-          from { opacity: 0; transform: translateY(22px); }
-          to   { opacity: 1; transform: translateY(0); }
-        }
-        @keyframes gradientShift {
-          0%   { background-position: 0% 50%; }
-          50%  { background-position: 100% 50%; }
-          100% { background-position: 0% 50%; }
-        }
         .buzon-card.buzon-focused {
           border-color: var(--azul-egm) !important;
         }
@@ -530,7 +519,7 @@ export default function PerfilPage() {
 
       {/* ── Hero con imagen de fondo + contenido encima ── */}
       <div className="relative overflow-hidden flex items-center group"
-        style={{ minHeight: "260px", boxShadow: "0 6px 32px rgba(0,0,0,0.22)" }}>
+        style={{ minHeight: "clamp(200px, 26vw, 300px)", boxShadow: "0 6px 32px rgba(0,0,0,0.22)" }}>
         <img
           src={perfil?.bannerUrl ?? "/background-dashboard.webp"}
           alt=""
@@ -542,7 +531,7 @@ export default function PerfilPage() {
         <div className="absolute inset-0" style={{ background: "linear-gradient(to bottom, rgba(13,27,46,0.50) 0%, transparent 40%)" }} />
 
         {/* Contenido sobre la imagen */}
-        <div className="relative z-10 w-full px-6 sm:px-12 lg:px-24 py-10 sm:py-14">
+        <div className="relative z-10 w-full px-6 sm:px-9 lg:px-14 py-10 sm:py-14">
           <div className="flex flex-col sm:flex-row items-center sm:items-center gap-5 sm:gap-6">
             {/* Avatar */}
             <div className="relative shrink-0" style={{ animation: "heroFadeUp 0.5s ease both" }}>
@@ -571,8 +560,8 @@ export default function PerfilPage() {
             </div>
 
             {/* Nombre + empresa */}
-            <div className="text-center sm:text-left min-w-0">
-              <p className="text-xs font-bold uppercase tracking-widest mb-1.5"
+            <div className="text-center sm:text-left min-w-0 overflow-hidden">
+              <p className="text-xs font-bold uppercase tracking-widest mb-1.5 truncate"
                 style={{ color: "rgba(255,255,255,0.85)", animation: "heroFadeUp 0.6s ease both" }}>
                 {perfil?.nombreEmpresa ?? ""}
               </p>
@@ -584,7 +573,7 @@ export default function PerfilPage() {
                     fontWeight:           700,
                     fontSize:             "clamp(2.2rem, 5vw, 3.5rem)",
                     lineHeight:           1.05,
-                    background:           "linear-gradient(90deg, #ffffff, #A3B535, #ffffff)",
+                    backgroundImage:      "linear-gradient(90deg, #ffffff, #A3B535, #ffffff)",
                     backgroundSize:       "300% auto",
                     WebkitBackgroundClip: "text",
                     WebkitTextFillColor:  "transparent",
@@ -599,7 +588,7 @@ export default function PerfilPage() {
                 </span>
               </div>
               {perfil?.puestoTrabajo && (
-                <p className="text-sm mt-1.5" style={{ color: "rgba(255,255,255,0.55)", animation: "heroFadeUp 0.6s ease 0.2s both" }}>
+                <p className="text-sm mt-1.5 truncate" style={{ color: "rgba(255,255,255,0.55)", animation: "heroFadeUp 0.6s ease 0.2s both" }}>
                   {perfil.puestoTrabajo}
                 </p>
               )}
@@ -607,24 +596,35 @@ export default function PerfilPage() {
           </div>
         </div>
 
-        {/* Botón cambiar portada — siempre visible, esquina inferior derecha */}
+        {/* Botón cambiar portada — esquina inferior derecha */}
         <button
           type="button"
           onClick={() => setShowBannerPicker(true)}
-          className="absolute z-20 flex items-center gap-2 font-medium text-sm bottom-3 right-3 sm:right-12 lg:right-20"
+          className="absolute z-20 flex items-center gap-2 bottom-4 right-4 sm:bottom-5 sm:right-5"
           style={{
-            padding: "10px 18px",
-            borderRadius: "10px",
-            background: "rgba(0,0,0,0.55)",
-            color: "#fff",
-            border: "1px solid rgba(255,255,255,0.2)",
+            padding: "8px 14px",
+            borderRadius: "8px",
+            background: "rgba(0,0,0,0.50)",
+            backdropFilter: "blur(8px)",
+            WebkitBackdropFilter: "blur(8px)",
+            color: "rgba(255,255,255,0.85)",
+            border: "1px solid rgba(255,255,255,0.15)",
             cursor: "pointer",
             userSelect: "none",
+            fontSize: "13px",
+            fontWeight: 500,
+            transition: "background 0.15s ease, border-color 0.15s ease",
           }}
-          onMouseEnter={(e) => e.currentTarget.style.background = "rgba(0,0,0,0.75)"}
-          onMouseLeave={(e) => e.currentTarget.style.background = "rgba(0,0,0,0.55)"}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = "rgba(0,0,0,0.70)";
+            e.currentTarget.style.borderColor = "rgba(255,255,255,0.30)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = "rgba(0,0,0,0.50)";
+            e.currentTarget.style.borderColor = "rgba(255,255,255,0.15)";
+          }}
         >
-          <Camera size={15} strokeWidth={2} />
+          <Camera size={14} strokeWidth={2} />
           <span>Cambiar portada</span>
         </button>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "bootstrap-icons/font/bootstrap-icons.css";
 
 /* Ocultar scrollbar nativo */
 html,
@@ -170,6 +169,17 @@ body::-webkit-scrollbar,
     transition-duration: 0.01ms !important;
     animation-duration: 0.01ms !important;
   }
+}
+
+/* ── Hero animations (compartidas entre DashboardHero, perfil, homes) ───────── */
+@keyframes heroFadeUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes gradientShift {
+  0%, 100% { background-position: 0% 50%; }
+  50%       { background-position: 100% 50%; }
 }
 
 /* Ayuda al browser a promover capas solo cuando sea necesario */

--- a/app/superadmin/layout.tsx
+++ b/app/superadmin/layout.tsx
@@ -15,49 +15,76 @@ export default function SuperAdminLayout({ children }: { children: React.ReactNo
 
   const nombreParaMostrar = usuario?.nombre ? usuario.nombre.split(" ")[0] : "Admin";
 
-  let heroConfig = {
-    prefijo: "Bienvenido, ",
-    titulo: nombreParaMostrar
+  type HeroConfig = {
+    prefijo?: string;
+    titulo: string;
+    subtitulo?: string;
+    imagenFondo?: string;
+    objectPosition?: string;
   };
+
+  let heroConfig: HeroConfig = {
+    prefijo:        "Bienvenido, ",
+    titulo:         nombreParaMostrar,
+    subtitulo:      "Panel de administración de EGM Atalayas",
+    imagenFondo:    "/background-dashboard.webp",
+    objectPosition: "center 40%",
+  };
+
+  // El inicio es grande, el resto secciones medianas
+  const variante: "inicio" | "seccion" = pathname === "/superadmin" ? "inicio" : "seccion";
 
   if (pathname.includes("/superadmin/administracion")) {
     heroConfig = {
-      prefijo: "Panel de ",
-      titulo: "Administración"
+      prefijo:      "Panel de ",
+      titulo:       "Administración",
+      subtitulo:    "Gestiona empresas, usuarios y configuración global de la plataforma",
+      imagenFondo:  "/background-empresa.webp",
+      objectPosition: "center 30%",
     };
   } else if (pathname.includes("/superadmin/empresas")) {
     heroConfig = {
-      prefijo: "Gestiona las ",
-      titulo: "Empresas"
+      prefijo:      "Gestiona las ",
+      titulo:       "Empresas",
+      subtitulo:    "Alta, edición y seguimiento de todas las empresas del parque",
+      imagenFondo:  "/background-empresa.webp",
+      objectPosition: "center 50%",
     };
   } else if (pathname.includes("/superadmin/solicitudes")) {
     heroConfig = {
-      prefijo: "Revisa las ",
-      titulo: "Solicitudes"
+      prefijo:      "Revisa las ",
+      titulo:       "Solicitudes",
+      subtitulo:    "Gestiona las solicitudes pendientes de empresas y usuarios",
+      imagenFondo:  "/background-comunidad.webp",
+      objectPosition: "center 40%",
     };
   } else if (pathname.includes("/superadmin/estadisticas")) {
     heroConfig = {
-      prefijo: "Analiza las ",
-      titulo: "Estadísticas"
-    };
-  } else if (pathname.includes("/superadmin/configuracion")) {
-    heroConfig = {
-      prefijo: "Panel de ",
-      titulo: "Configuración"
+      prefijo:      "Analiza las ",
+      titulo:       "Estadísticas",
+      subtitulo:    "Métricas de uso, formación y actividad en la plataforma",
+      imagenFondo:  "/background-dashboard.webp",
+      objectPosition: "center 60%",
     };
   } else if (pathname.includes("/superadmin/comunicados")) {
     heroConfig = {
-      prefijo: "Gestiona los ",
-      titulo: "Comunicados"
+      prefijo:      "Gestiona los ",
+      titulo:       "Comunicados",
+      imagenFondo:  "/background-comunicacion-empleado.webp",
+      objectPosition: "center 40%",
     };
   }
 
   return (
     <div className="min-h-screen bg-slate-50/50 pb-10 pt-20">
       <Header />
-      <DashboardHero 
-        prefijo={heroConfig.prefijo} 
-        titulo={heroConfig.titulo} 
+      <DashboardHero
+        prefijo={heroConfig.prefijo}
+        titulo={heroConfig.titulo}
+        subtitulo={heroConfig.subtitulo}
+        imagenFondo={heroConfig.imagenFondo}
+        objectPosition={heroConfig.objectPosition}
+        variante={variante}
       />
       <main className="relative z-10 pt-8 sm:pt-10">
         {children}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -23,14 +23,17 @@ function getInitials(nombre: string): string {
 
 // Enlaces exclusivos para el SuperAdmin
 const SUPERADMIN_LINKS = [
-  { label: "Inicio", path: "/superadmin" },
+  { label: "Inicio",         path: "/superadmin" },
   { label: "Administración", path: "/superadmin/administracion" },
-  { label: "Comunicados", path: "/superadmin/comunicados" },
+  { label: "Comunicados",    path: "/superadmin/comunicados" },
 ];
 
 export default function Header({ logoEmpresa }: HeaderProps) {
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const [noLeidas, setNoLeidas] = useState(0);
+  const [mobileOpen, setMobileOpen]   = useState(false);
+  const [noLeidas, setNoLeidas]       = useState(0);
+  const [scrolled, setScrolled]       = useState(false);
+  const [navProgress, setNavProgress] = useState(0); // 0 = oculto, 1-100 = progreso
+  const prevPathname                  = useRef<string | null>(null);
 
   const router = useRouter();
   const pathname = usePathname();
@@ -67,6 +70,33 @@ export default function Header({ logoEmpresa }: HeaderProps) {
     return () => clearInterval(interval);
   }, [fetchContador]);
 
+  // Scroll: sombra+blur en desktop, cerrar menú mobile si está abierto
+  useEffect(() => {
+    const onScroll = () => {
+      setScrolled(window.scrollY > 8);
+      if (window.scrollY > 8) setMobileOpen(false);
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // Barra de progreso de navegación: se dispara cuando cambia el pathname
+  useEffect(() => {
+    if (prevPathname.current === null) {
+      prevPathname.current = pathname;
+      return;
+    }
+    if (prevPathname.current === pathname) return;
+    prevPathname.current = pathname;
+
+    // Animación: sube rápido a 80%, luego espera y completa
+    setNavProgress(15);
+    const t1 = setTimeout(() => setNavProgress(80), 80);
+    const t2 = setTimeout(() => setNavProgress(100), 350);
+    const t3 = setTimeout(() => setNavProgress(0), 650);
+    return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); };
+  }, [pathname]);
+
 
 
   const marcarTodasLeidas = async () => {
@@ -89,23 +119,45 @@ export default function Header({ logoEmpresa }: HeaderProps) {
   const initials = usuario?.nombre ? getInitials(usuario.nombre) : "U";
   const nombreMostrado = usuario?.nombre ?? "Usuario";
 
-  const linkLogo = isSuperAdmin ? "/superadmin" : "/dashboard";
-  const linkPerfil = isSuperAdmin ? "/superadmin/configuracion?tab=perfil" : "/dashboard/perfil";
-  const linkConfiguracion = isSuperAdmin ? "/superadmin/configuracion?tab=seguridad" : "/dashboard/configuracion";
-  const linkNotificaciones = isSuperAdmin ? "/superadmin/solicitudes" : "/dashboard/comunicacion";
+  const linkLogo           = isSuperAdmin ? "/superadmin" : "/dashboard";
+  const linkPerfil         = "/dashboard/perfil";
+  const linkConfiguracion  = "/dashboard/configuracion";
 
   return (
     <header
-      className="w-full fixed top-0 left-0 right-0 z-100"
+      className="w-full fixed top-0 left-0 right-0 z-50"
       style={{
-        background: "#1b3f7e",
+        background: scrolled ? "rgba(22,50,105,0.97)" : "#1b3f7e",
         borderBottom: "1px solid rgba(255,255,255,0.08)",
+        backdropFilter: scrolled ? "blur(12px)" : "none",
+        WebkitBackdropFilter: scrolled ? "blur(12px)" : "none",
+        boxShadow: scrolled ? "0 4px 24px rgba(0,0,0,0.25)" : "none",
+        transition: "background 0.2s ease, box-shadow 0.2s ease, backdrop-filter 0.2s ease",
       }}
     >
-      <div className="max-w-7xl mx-auto px-6 sm:px-8 flex items-stretch h-20">
+      {/* Barra de progreso de navegación */}
+      {navProgress > 0 && (
+        <div
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            height: "2px",
+            width: `${navProgress}%`,
+            background: "var(--verde-oliva-hover)",
+            transition: navProgress === 100
+              ? "width 0.15s ease, opacity 0.3s ease 0.15s"
+              : "width 0.3s ease",
+            opacity: navProgress === 100 ? 0 : 1,
+            borderRadius: "0 2px 2px 0",
+          }}
+        />
+      )}
 
-        {/* Logo dinámico */}
-        <div className="flex items-center pr-6 shrink-0">
+      <div className="w-full max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-14 flex items-stretch h-20 relative">
+
+        {/* Logo — izquierda, z-10 para no quedar bajo el nav centrado */}
+        <div className="flex items-center pr-4 sm:pr-6 lg:pr-10 shrink-0 z-10">
           <Link href={linkLogo}>
             <Image
               src={logo}
@@ -113,20 +165,18 @@ export default function Header({ logoEmpresa }: HeaderProps) {
               width={180}
               height={50}
               priority
-              style={{ height: "52px", width: "auto" }}
-              className="brightness-0 invert cursor-pointer"
+              style={{
+                height: "clamp(40px, 6vw, 50px)",
+                width: "auto",
+                transition: "opacity 0.15s ease",
+              }}
+              className="brightness-0 invert cursor-pointer hover:opacity-75"
             />
           </Link>
         </div>
 
-        {/* Divisor vertical */}
-        <div
-          className="hidden sm:block w-px my-4 mr-8 shrink-0"
-          style={{ background: "rgba(255,255,255,0.25)" }}
-        />
-
-        {/* Navegación desktop unificada */}
-        <nav className="hidden sm:flex items-stretch flex-1">
+        {/* Navegación desktop — centrada en el header */}
+        <nav className="hidden md:flex items-stretch absolute left-1/2 -translate-x-1/2 h-full">
           {linksToRender.map((link) => {
             const isActive = pathname === link.path || (pathname.startsWith(link.path) && link.path !== linkLogo);
             return (
@@ -140,10 +190,10 @@ export default function Header({ logoEmpresa }: HeaderProps) {
           })}
         </nav>
 
-        {/* Lado derecho - Modificado para alinear verticalmente en móvil */}
-        <div className="ml-auto flex items-center h-full gap-2 sm:gap-0">
+        {/* Lado derecho — campana pegada al avatar */}
+        <div className="ml-auto flex items-center h-full gap-3 md:gap-0 z-10">
 
-          {/* Campana */}
+          {/* Campana — px reducido para quedar cerca del avatar */}
           <div className="flex items-center h-full">
             <NotifMenu
               noLeidas={noLeidas}
@@ -151,114 +201,177 @@ export default function Header({ logoEmpresa }: HeaderProps) {
             />
           </div>
 
-          {/* Divisor (solo desktop) */}
-          <div className="hidden sm:block w-px self-stretch my-4"
-            style={{ background: "rgba(255,255,255,0.2)" }} />
+          {/* Avatar + menú — sin separador, el gap del nav los aleja naturalmente */}
+          <UserMenu
+            nombreMostrado={nombreMostrado}
+            empresaNombre={isSuperAdmin ? "Administración EGM" : usuario?.nombreEmpresa}
+            initials={initials}
+            logoEmpresa={logoEmpresa}
+            avatarUrl={usuario?.avatarUrl}
+            onPerfil={() => router.push(linkPerfil)}
+            onConfiguracion={() => router.push(linkConfiguracion)}
+            onCerrarSesion={handleLogout}
+          />
 
-          {/* Avatar + menú — solo desktop */}
-          <div className="hidden sm:flex items-center h-full">
-            <UserMenu
-              nombreMostrado={nombreMostrado}
-              empresaNombre={isSuperAdmin ? "Administración EGM" : usuario?.nombreEmpresa}
-              initials={initials}
-              logoEmpresa={logoEmpresa}
-              avatarUrl={usuario?.avatarUrl}
-              onPerfil={() => router.push(linkPerfil)}
-              onConfiguracion={() => router.push(linkConfiguracion)}
-              onCerrarSesion={handleLogout}
-            />
-          </div>
-
-          {/* Hamburguesa — solo móvil */}
+          {/* Hamburguesa → X — solo móvil */}
           <button
-            className="sm:hidden flex flex-col justify-center items-center rounded-lg transition-colors gap-1.5"
-            style={{ width: "40px", height: "40px" }}
+            className="md:hidden flex flex-col justify-center items-center rounded-lg gap-[5px]"
+            style={{
+              width: "40px", height: "40px",
+              background: mobileOpen ? "rgba(255,255,255,0.08)" : "transparent",
+              transition: "background 0.15s ease",
+            }}
             onClick={() => setMobileOpen((prev) => !prev)}
-            onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.08)")}
-            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-            aria-label="Menú"
+            aria-label={mobileOpen ? "Cerrar menú" : "Abrir menú"}
           >
-            <span className="block h-0.5 rounded-full"
-              style={{ background: "rgba(255,255,255,0.8)", width: "18px" }} />
-            <span className="block h-0.5 rounded-full transition-all"
-              style={{ background: "rgba(255,255,255,0.8)", width: mobileOpen ? "12px" : "18px" }} />
-            <span className="block h-0.5 rounded-full"
-              style={{ background: "rgba(255,255,255,0.8)", width: "18px" }} />
+            <span style={{
+              display: "block", height: "2px", borderRadius: "2px",
+              background: "rgba(255,255,255,0.85)", width: "20px",
+              transform: mobileOpen ? "translateY(7px) rotate(45deg)" : "none",
+              transition: "transform 0.25s ease",
+            }} />
+            <span style={{
+              display: "block", height: "2px", borderRadius: "2px",
+              background: "rgba(255,255,255,0.85)", width: "20px",
+              opacity: mobileOpen ? 0 : 1,
+              transition: "opacity 0.15s ease",
+            }} />
+            <span style={{
+              display: "block", height: "2px", borderRadius: "2px",
+              background: "rgba(255,255,255,0.85)", width: "20px",
+              transform: mobileOpen ? "translateY(-7px) rotate(-45deg)" : "none",
+              transition: "transform 0.25s ease",
+            }} />
           </button>
         </div>
       </div>
 
-      {/* Menú móvil unificado */}
-      {mobileOpen && (
-        <div
-          className="sm:hidden flex flex-col"
-          style={{ borderTop: "1px solid rgba(255,255,255,0.08)", background: "var(--azul-egm)" }}
-        >
-          <div className="px-4 py-3 flex flex-col gap-1"
-            style={{ borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
-            {linksToRender.map((link) => {
-              const isActive = pathname === link.path || (pathname.startsWith(link.path) && link.path !== linkLogo);
-              return (
-                <button
-                  key={link.path}
-                  onClick={() => handleNavClick(link.path)}
-                  className="text-left px-3 py-2.5 text-sm font-medium rounded-lg transition-colors"
-                  style={{
-                    color: isActive ? "var(--blanco)" : "rgba(255,255,255,0.65)",
-                    background: isActive ? "rgba(255,255,255,0.1)" : "transparent",
-                    fontWeight: isActive ? 600 : 400,
-                  }}
-                >
-                  {link.label}
-                </button>
-              );
-            })}
-          </div>
-
-          <div className="px-4 py-3 flex flex-col gap-1">
-            <div className="flex items-center gap-3 px-3 py-2 mb-1">
-              <div
-                className="rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+      {/* Menú móvil — con animación suave de entrada */}
+      <div
+        className="md:hidden flex flex-col overflow-hidden"
+        style={{
+          maxHeight: mobileOpen ? "100dvh" : "0px",
+          opacity:   mobileOpen ? 1 : 0,
+          transition: "max-height 0.3s ease, opacity 0.2s ease",
+          borderTop: mobileOpen ? "1px solid rgba(255,255,255,0.08)" : "none",
+          background: "var(--azul-egm)",
+          overflowY: "auto",
+        }}
+      >
+        {/* ── Sección nav ── */}
+        <div className="px-3 pt-3 pb-2 flex flex-col gap-0.5">
+          {linksToRender.map((link) => {
+            const isActive = pathname === link.path || (pathname.startsWith(link.path) && link.path !== linkLogo);
+            return (
+              <button
+                key={link.path}
+                onClick={() => handleNavClick(link.path)}
+                className="relative text-left px-4 py-3 text-sm rounded-xl"
                 style={{
-                  width: "32px",
-                  height: "32px",
-                  background: "rgba(255,255,255,0.15)",
-                  color: "var(--blanco)",
-                  border: "2px solid rgba(255,255,255,0.3)",
+                  color:      isActive ? "#fff" : "rgba(255,255,255,0.65)",
+                  background: isActive ? "rgba(255,255,255,0.08)" : "transparent",
+                  fontWeight: isActive ? 600 : 400,
+                  transition: "background 0.15s ease, color 0.15s ease",
                 }}
               >
-                {initials}
-              </div>
-              <div className="min-w-0">
-                <p className="text-sm font-semibold truncate" style={{ color: "rgba(255,255,255,0.9)" }}>
-                  {nombreMostrado}
-                </p>
-                <p className="text-xs truncate" style={{ color: "rgba(255,255,255,0.45)" }}>
-                  {isSuperAdmin ? "Administración EGM" : usuario?.nombreEmpresa}
-                </p>
-              </div>
-            </div>
-            <button
-              onClick={() => { setMobileOpen(false); router.push(linkPerfil); }}
-              className="text-left px-3 py-2.5 text-sm rounded-lg transition-colors"
-              style={{ color: "rgba(255,255,255,0.75)" }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.06)")}
-              onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-            >
-              Mi perfil
-            </button>
-            <button
-              onClick={handleLogout}
-              className="text-left px-3 py-2.5 text-sm font-medium rounded-lg transition-colors"
-              style={{ color: "#f87171" }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(248,113,113,0.1)")}
-              onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-            >
-              Cerrar sesión
-            </button>
-          </div>
+                {/* Barra verde izquierda en activo */}
+                {isActive && (
+                  <span style={{
+                    position: "absolute", left: "6px", top: "50%",
+                    transform: "translateY(-50%)",
+                    width: "3px", height: "18px",
+                    background: "var(--verde-oliva-hover)",
+                    borderRadius: "2px",
+                  }} />
+                )}
+                {link.label}
+              </button>
+            );
+          })}
         </div>
-      )}
+
+        {/* ── Separador ── */}
+        <div style={{ height: "1px", background: "rgba(255,255,255,0.08)", margin: "0 16px" }} />
+
+        {/* ── Sección usuario ── */}
+        <div className="px-3 pt-2 pb-3 flex flex-col gap-0.5">
+
+          {/* Tarjeta usuario — clickable, va a perfil */}
+          <button
+            onClick={() => { setMobileOpen(false); router.push(linkPerfil); }}
+            className="w-full flex items-center gap-3 px-3 py-3 rounded-xl text-left"
+            style={{
+              background: "rgba(255,255,255,0.05)",
+              transition: "background 0.15s ease",
+            }}
+          >
+            {/* Avatar */}
+            <div className="shrink-0">
+              {usuario?.avatarUrl ? (
+                <img
+                  src={usuario.avatarUrl}
+                  alt={nombreMostrado}
+                  style={{
+                    width: "40px", height: "40px", borderRadius: "50%",
+                    objectFit: "cover", border: "2px solid rgba(255,255,255,0.3)",
+                  }}
+                />
+              ) : (
+                <div
+                  className="rounded-full flex items-center justify-center text-sm font-bold"
+                  style={{
+                    width: "40px", height: "40px",
+                    background: "rgba(255,255,255,0.15)",
+                    color: "#fff",
+                    border: "2px solid rgba(255,255,255,0.3)",
+                  }}
+                >
+                  {initials}
+                </div>
+              )}
+            </div>
+
+            {/* Nombre + empresa */}
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold truncate" style={{ color: "rgba(255,255,255,0.92)" }}>
+                {nombreMostrado}
+              </p>
+              <p className="text-xs truncate mt-0.5" style={{ color: "rgba(255,255,255,0.42)" }}>
+                {isSuperAdmin ? "Administración EGM" : usuario?.nombreEmpresa}
+              </p>
+            </div>
+
+            {/* Chevron → indica que es tappable */}
+            <svg width="14" height="14" fill="none" viewBox="0 0 24 24"
+              stroke="currentColor" strokeWidth={2.5} style={{ color: "rgba(255,255,255,0.3)", flexShrink: 0 }}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+
+          {/* Configuración */}
+          <button
+            onClick={() => { setMobileOpen(false); router.push(linkConfiguracion); }}
+            className="flex items-center gap-3 px-4 py-3 text-sm rounded-xl"
+            style={{ color: "rgba(255,255,255,0.7)", transition: "background 0.15s ease" }}
+          >
+            <i className="bi bi-gear" style={{ fontSize: "15px", opacity: 0.7, width: "16px" }} />
+            Configuración
+          </button>
+
+          {/* Separador antes de acción destructiva */}
+          <div style={{ height: "1px", background: "rgba(255,255,255,0.08)", margin: "4px 8px" }} />
+
+          {/* Cerrar sesión */}
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-3 px-4 py-3 text-sm font-medium rounded-xl"
+            style={{ color: "#f87171", transition: "background 0.15s ease" }}
+          >
+            <i className="bi bi-box-arrow-right" style={{ fontSize: "15px", width: "16px" }} />
+            Cerrar sesión
+          </button>
+        </div>
+      </div>
     </header>
   );
 }
@@ -297,10 +410,10 @@ function NavButton({ label, isActive, onClick }: NavButtonProps) {
       onClick={onClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className="relative flex items-center px-5 whitespace-nowrap border-none cursor-pointer h-full"
+      className="relative flex items-center px-3 md:px-4 whitespace-nowrap border-none cursor-pointer h-full"
       style={{
-        fontSize: "16px",
-        fontWeight: isActive ? 700 : 500,
+        fontSize: "15px",
+        fontWeight: isActive ? 600 : 500,
         color: isActive
           ? "var(--verde-oliva-hover)"
           : hovered
@@ -311,23 +424,22 @@ function NavButton({ label, isActive, onClick }: NavButtonProps) {
       }}
     >
       {label}
-      {!isActive && (
-        <span
-          style={{
-            position: "absolute",
-            bottom: "25px",
-            left: "12px",
-            right: "12px",
-            height: "2px",
-            background: "var(--verde-oliva-hover)",
-            borderRadius: "2px",
-            display: "block",
-            transform: hovered ? "scaleX(1)" : "scaleX(0)",
-            transformOrigin: origin,
-            transition: "transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)",
-          }}
-        />
-      )}
+      {/* Underline: fijo y visible cuando activo, animado desde el ratón en hover */}
+      <span
+        style={{
+          position: "absolute",
+          bottom: "18px",
+          left: "10px",
+          right: "10px",
+          height: "2px",
+          background: "var(--verde-oliva-hover)",
+          borderRadius: "2px",
+          display: "block",
+          transform: isActive || hovered ? "scaleX(1)" : "scaleX(0)",
+          transformOrigin: isActive ? "center" : origin,
+          transition: isActive ? "none" : "transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)",
+        }}
+      />
     </button>
   );
 }

--- a/components/pages/AdminEmpresa.tsx
+++ b/components/pages/AdminEmpresa.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/context/AuthContext";
 import { apiFetch, API_URL } from "@/lib/api";
 import { getActividadReciente } from "@/lib/api/progreso";
 import type { ActividadItem } from "@/lib/types/progreso";
+import DashboardHero from "@/components/ui/DashboardHero";
 
 interface ResumenAdmin {
   nombreEmpresa: string;
@@ -157,82 +158,16 @@ export default function AdminEmpresa() {
 
   return (
     <div>
-      {/* ── KEYFRAMES ── */}
-      <style>{`
-        @keyframes heroFadeUp {
-          from { opacity: 0; transform: translateY(22px); }
-          to   { opacity: 1; transform: translateY(0); }
-        }
-        @keyframes gradientShift {
-          0%   { background-position: 0% 50%; }
-          50%  { background-position: 100% 50%; }
-          100% { background-position: 0% 50%; }
-        }
-      `}</style>
-
       {/* ══════════════════════════════════════════
           HERO
       ══════════════════════════════════════════ */}
-      <div
-        className="-mx-8 mb-0 relative overflow-hidden"
-        style={{ minHeight: "300px" }}
-      >
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            backgroundImage: "url('/background-dashboard.webp')",
-            backgroundSize: "cover",
-            backgroundPosition: "center",
-          }}
-        />
-        <div style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.50)" }} />
-        <div style={{ position: "absolute", inset: 0, background: "linear-gradient(135deg, rgba(10,20,40,0.55) 0%, rgba(0,0,0,0.15) 100%)" }} />
-
-        <div
-          className="relative z-10 px-10 lg:px-16 flex flex-col justify-center"
-          style={{ minHeight: "300px", paddingTop: "3rem", paddingBottom: "3rem" }}
-        >
-          <p
-            className="text-xs font-bold uppercase tracking-widest mb-4"
-            style={{ color: "var(--verde-oliva-hover)", animation: "heroFadeUp 0.6s ease both" }}
-          >
-            {nombreEmpresa}
-            <span style={{ color: "rgba(255,255,255,0.25)" }}> · </span>
-            {fechaHoy}
-          </p>
-
-          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "baseline", gap: "0.4em", animation: "heroFadeUp 0.7s ease 0.08s both" }}>
-            <span style={{ fontFamily: "'Poppins', sans-serif", fontWeight: 300, fontSize: "clamp(3rem, 6vw, 4rem)", color: "#ffffff", lineHeight: 1.1 }}>
-              Hola,
-            </span>
-            <span
-              style={{
-                fontFamily: "'Instrument Serif', serif",
-                fontStyle: "italic",
-                fontWeight: 400,
-                fontSize: "clamp(3rem, 6vw, 5rem)",
-                lineHeight: 1.05,
-                background: "linear-gradient(90deg, #A3B535, #ffffff, #A3B535)",
-                backgroundSize: "300% auto",
-                WebkitBackgroundClip: "text",
-                WebkitTextFillColor: "transparent",
-                backgroundClip: "text",
-                animation: "heroFadeUp 0.7s ease 0.12s both, gradientShift 6s ease infinite",
-              }}
-            >
-              {firstName}
-            </span>
-          </div>
-
-          <p
-            className="text-sm mt-3"
-            style={{ color: "rgba(255,255,255,0.50)", animation: "heroFadeUp 0.7s ease 0.2s both" }}
-          >
-            Panel de administración · {nombreEmpresa}
-          </p>
-        </div>
-      </div>
+      <DashboardHero
+        prefijo="Hola, "
+        titulo={firstName}
+        subtitulo={`Administrando ${nombreEmpresa}`}
+        imagenFondo={usuario?.bannerUrl ?? "/background-dashboard.webp"}
+        variante="inicio"
+      />
 
       {/* ══════════════════════════════════════════
           CONTENT

--- a/components/pages/Empleado.tsx
+++ b/components/pages/Empleado.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import DashboardHero from "@/components/ui/DashboardHero";
 import { useAuth } from "@/context/AuthContext";
 import { getNoticias } from "@/lib/api/noticias";
 import { getModulosConProgreso } from "@/lib/api/modulos";
@@ -263,76 +264,14 @@ export default function Empleado() {
   return (
     <div>
       {/* ════════════════════════════════════════════
-          BANDA HERO
+          BANDA HERO — usa el banner personalizado del perfil
       ════════════════════════════════════════════ */}
-      <div
-        className="relative overflow-hidden flex items-center"
-        style={{ minHeight: "320px", boxShadow: "0 6px 32px rgba(0,0,0,0.22)" }}
-      >
-        <img src={usuario?.bannerUrl ?? "/background-dashboard.webp"} alt="" aria-hidden
-          className="absolute inset-0 w-full h-full object-cover"
-          style={{ objectPosition: "center 40%" }} />
-        <div className="absolute inset-0"
-          style={{ background: "rgba(10,20,40,0.60)" }} />
-        <div className="absolute inset-0"
-          style={{ background: "linear-gradient(to right, rgba(13,27,46,0.92) 0%, rgba(13,27,46,0.50) 45%, transparent 100%)" }} />
-        <div className="absolute inset-0"
-          style={{ background: "linear-gradient(to bottom, rgba(13,27,46,0.60) 0%, transparent 35%)" }} />
-
-        <div className="relative z-10 w-full px-10 lg:px-16 py-16">
-          <p className="text-xs font-bold uppercase tracking-[0.2em] mb-5"
-            style={{ color: "var(--verde-oliva-hover)" }}>
-            {usuario?.nombreEmpresa ?? "Mi empresa"}
-            <span style={{ color: "rgba(255,255,255,0.2)" }}> · </span>
-            {new Date().toLocaleDateString("es-ES", {
-              weekday: "long", day: "numeric", month: "long",
-            }).replace(/^\w/, (c) => c.toUpperCase())}
-          </p>
-
-          <div className="leading-none flex flex-wrap items-center gap-x-3">
-            <span
-              className="text-white"
-              style={{
-                fontSize: "clamp(3.5rem, 7vw, 4.5rem)",
-                fontFamily: "var(--font-poppins), sans-serif",
-                fontWeight: 300,
-                letterSpacing: "-0.03em",
-                animation: "heroFadeUp 0.8s ease both",
-              }}
-            >
-              Hola,
-            </span>
-            <span
-              style={{
-                fontSize: "clamp(3.5rem, 7vw, 6rem)",
-                fontFamily: "'Instrument Serif', serif",
-                fontStyle: "italic",
-                fontWeight: 400,
-                letterSpacing: "-0.01em",
-                lineHeight: 1,
-                background: "linear-gradient(90deg, #A3B535, #ffffff, #A3B535)",
-                backgroundSize: "300% 100%",
-                WebkitBackgroundClip: "text",
-                WebkitTextFillColor: "transparent",
-                backgroundClip: "text",
-                animation: "heroFadeUp 0.8s ease 0.15s both, gradientShift 8s ease infinite",
-              }}
-            >
-              {usuario?.nombre?.split(" ")[0] ?? "Empleado"}
-            </span>
-          </div>
-          <style>{`
-              @keyframes heroFadeUp {
-                from { opacity: 0; transform: translateY(24px); }
-                to   { opacity: 1; transform: translateY(0); }
-              }
-              @keyframes gradientShift {
-                0%, 100% { background-position: 0% 50%; }
-                50%       { background-position: 100% 50%; }
-              }
-            `}</style>
-        </div>
-      </div>
+      <DashboardHero
+        prefijo="Hola, "
+        titulo={usuario?.nombre?.split(" ")[0] ?? "Empleado"}
+        imagenFondo={usuario?.bannerUrl ?? "/background-dashboard.webp"}
+        variante="inicio"
+      />
 
       {/* ════════════════════════════════════════════
           ONBOARDING BANNER (permanente)

--- a/components/pages/Noticias.tsx
+++ b/components/pages/Noticias.tsx
@@ -646,7 +646,7 @@ export default function ComunicacionPage() {
         }
       `}</style>
 
-      <DashboardHero prefijo="Centro de " titulo="Comunicación." imagenFondo="/background-comunicacion-empleado.webp" />
+      <DashboardHero prefijo="Centro de " titulo="Comunicación" imagenFondo="/background-comunicacion-empleado.webp" />
 
       <div className="px-6 md:px-10 lg:px-16 pt-8 md:pt-12 pb-20">
 

--- a/components/ui/DashboardHero.tsx
+++ b/components/ui/DashboardHero.tsx
@@ -5,93 +5,174 @@ import { useAuth } from "@/context/AuthContext";
 interface DashboardHeroProps {
   prefijo?: string;
   titulo: string;
+  subtitulo?: string;
   imagenFondo?: string;
-  objectPosition?: string;     // ← Nueva prop (opcional)
+  objectPosition?: string;
+  /** "inicio"  = hero grande (home de cada rol)
+   *  "seccion" = hero medio (formación, comunicación, etc.) — por defecto
+   *  "minima"  = hero barra (configuración, páginas utilitarias) */
+  variante?: "inicio" | "seccion" | "minima";
 }
 
 export default function DashboardHero({
   prefijo,
   titulo,
+  subtitulo,
   imagenFondo = "/background-dashboard.webp",
-  objectPosition = "center 40%"   // valor por defecto (el que tenías antes)
+  objectPosition = "center 40%",
+  variante = "seccion",
 }: DashboardHeroProps) {
 
   const { usuario } = useAuth();
 
+  const esSuperAdmin    = usuario?.codigoRol === "ROLE_ADMIN";
+  const etiquetaEmpresa = esSuperAdmin
+    ? "EGM Atalayas · Administración"
+    : (usuario?.nombreEmpresa ?? "");
+
+  /* ── Tamaños según variante ── */
+  const alturaMin = variante === "inicio"
+    ? "clamp(190px, 28vw, 360px)"
+    : variante === "minima"
+      ? "clamp(100px, 12vw, 160px)"
+      : "clamp(170px, 25vw, 290px)";
+
+  const paddingY = variante === "inicio"
+    ? "py-8 sm:py-12 lg:py-16"
+    : variante === "minima"
+      ? "py-5 sm:py-7"
+      : "py-8 sm:py-11 lg:py-14";
+
+  const sizePrefijo = variante === "inicio"
+    ? "clamp(1.6rem, 3.8vw, 3.6rem)"
+    : variante === "minima"
+      ? "clamp(0.95rem, 1.6vw, 1.25rem)"
+      : "clamp(1.8rem, 3.8vw, 3.2rem)";
+
+  const sizeTitulo = variante === "inicio"
+    ? "clamp(2rem, 4.8vw, 4.6rem)"
+    : variante === "minima"
+      ? "clamp(1.2rem, 2vw, 1.6rem)"
+      : "clamp(2.6rem, 5vw, 4.2rem)";
+
+  /* ── Opacidades de overlay según variante ── */
+  const overlayBase    = variante === "minima" ? "rgba(8,17,34,0.60)" : "rgba(8,17,34,0.50)";
+  const overlayLateral = variante === "minima"
+    ? "none"
+    : "linear-gradient(to right, rgba(8,17,34,0.80) 0%, rgba(8,17,34,0.40) 55%, transparent 100%)";
+
   return (
     <div
       className="relative overflow-hidden flex items-center"
-      style={{ minHeight: "320px", boxShadow: "0 6px 32px rgba(0,0,0,0.22)" }}
+      style={{
+        minHeight: alturaMin,
+        boxShadow: "0 6px 32px rgba(0,0,0,0.22)",
+      }}
     >
+      {/* Imagen de fondo */}
       <img
         src={imagenFondo}
         alt=""
         aria-hidden
         className="absolute inset-0 w-full h-full object-cover"
-        style={{
-          objectPosition: objectPosition   // ← Ahora usa la prop
-        }}
+        style={{ objectPosition }}
       />
-      <div className="absolute inset-0" style={{ background: "rgba(10,20,40,0.60)" }} />
-      <div className="absolute inset-0" style={{ background: "linear-gradient(to right, rgba(13,27,46,0.92) 0%, rgba(13,27,46,0.50) 45%, transparent 100%)" }} />
-      <div className="absolute inset-0" style={{ background: "linear-gradient(to bottom, rgba(13,27,46,0.60) 0%, transparent 35%)" }} />
 
-      <div className="relative z-10 w-full px-10 lg:px-16 py-14">
+      {/* Overlay base */}
+      <div className="absolute inset-0" style={{ background: overlayBase }} />
+
+      {/* Overlay lateral — no en minima */}
+      {overlayLateral !== "none" && (
+        <div className="absolute inset-0" style={{ background: overlayLateral }} />
+      )}
+
+      {/* Contenido */}
+      <div className={`relative z-10 w-full px-6 sm:px-9 lg:px-14 ${paddingY}`}>
+
+        {/* Etiqueta: empresa · fecha */}
         <p
-          className="text-xs font-bold uppercase tracking-[0.2em] mb-5"
-          style={{ color: "var(--verde-oliva-hover)" }}
+          className="flex items-center gap-2 text-xs font-semibold uppercase mb-3 sm:mb-4 overflow-hidden"
+          style={{
+            color: "rgba(255,255,255,0.50)",
+            letterSpacing: "0.12em",
+            animation: "heroFadeUp 0.6s ease both",
+          }}
         >
-          {usuario?.nombreEmpresa ?? "Mi empresa"}
-          <span style={{ color: "rgba(255,255,255,0.2)" }}> · </span>
-          {new Date().toLocaleDateString("es-ES", {
-            weekday: "long", day: "numeric", month: "long",
-          }).replace(/^\w/, (c) => c.toUpperCase())}
+          <span
+            className="inline-block rounded-full shrink-0"
+            style={{ width: "6px", height: "6px", background: "var(--verde-oliva-hover)" }}
+          />
+          {etiquetaEmpresa && (
+            <>
+              <span className="truncate min-w-0" style={{ maxWidth: "200px" }}>
+                {etiquetaEmpresa}
+              </span>
+              <span className="shrink-0" style={{ opacity: 0.3 }}>·</span>
+            </>
+          )}
+          <span className="whitespace-nowrap shrink-0">
+            {new Date().toLocaleDateString("es-ES", {
+              weekday: "long", day: "numeric", month: "long",
+            }).replace(/^\w/, (c) => c.toUpperCase())}
+          </span>
         </p>
 
-        <div className="leading-none flex flex-wrap items-center gap-x-3">
-          {prefijo && (
+        {/* Título — prefijo y nombre en bloque unificado en móvil */}
+        <div
+          style={{ animation: "heroFadeUp 0.7s ease 0.1s both" }}
+        >
+          <div className="leading-tight flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            {prefijo && (
+              <span
+                className="text-white"
+                style={{
+                  fontSize:      sizePrefijo,
+                  fontFamily:    "var(--font-poppins), sans-serif",
+                  fontWeight:    400,
+                  letterSpacing: "-0.025em",
+                  lineHeight:    1.1,
+                }}
+              >
+                {prefijo}
+              </span>
+            )}
             <span
-              className="text-white"
               style={{
-                fontSize: "clamp(3rem, 6vw, 4rem)",
-                fontFamily: "var(--font-poppins), sans-serif",
-                fontWeight: 300,
-                letterSpacing: "-0.03em",
-                animation: "heroFadeUp 0.7s ease both",
+                fontSize:             sizeTitulo,
+                fontFamily:           "'Instrument Serif', serif",
+                fontStyle:            "italic",
+                fontWeight:           500,
+                letterSpacing:        "-0.01em",
+                lineHeight:           1.05,
+                backgroundImage:      "linear-gradient(90deg, #ffffff, #c8d96a, #ffffff)",
+                backgroundSize:       "250% auto",
+                WebkitBackgroundClip: "text",
+                WebkitTextFillColor:  "transparent",
+                backgroundClip:       "text",
+                animation:            "gradientShift 6s ease infinite",
+                overflowWrap:         "break-word",
+                wordBreak:            "break-word",
+                maxWidth:             "100%",
               }}
             >
-              {prefijo}
+              {titulo}
             </span>
-          )}
-          <span
+          </div>
+        </div>
+
+        {/* Subtítulo opcional */}
+        {subtitulo && (
+          <p
+            className="mt-2.5 sm:mt-3 text-sm sm:text-base max-w-md"
             style={{
-              fontSize: "clamp(3rem, 6vw, 5rem)",
-              fontFamily: "'Instrument Serif', serif",
-              fontStyle: "italic",
-              fontWeight: 400,
-              letterSpacing: "-0.01em",
-              lineHeight: 1,
-              background: "linear-gradient(90deg, #A3B535, #ffffff, #A3B535)",
-              backgroundSize: "300% 100%",
-              WebkitBackgroundClip: "text",
-              WebkitTextFillColor: "transparent",
-              backgroundClip: "text",
-              animation: "heroFadeUp 0.7s ease 0.12s both, gradientShift 8s ease infinite",
+              color:      "rgba(255,255,255,0.65)",
+              animation:  "heroFadeUp 0.7s ease 0.22s both",
+              lineHeight: 1.55,
             }}
           >
-            {titulo}
-          </span>
-        </div>
-        <style>{`
-          @keyframes heroFadeUp {
-            from { opacity: 0; transform: translateY(20px); }
-            to   { opacity: 1; transform: translateY(0); }
-          }
-          @keyframes gradientShift {
-            0%, 100% { background-position: 0% 50%; }
-            50%       { background-position: 100% 50%; }
-          }
-        `}</style>
+            {subtitulo}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/components/ui/NotifMenu.tsx
+++ b/components/ui/NotifMenu.tsx
@@ -2,8 +2,8 @@
 
 import { useLayoutEffect, useRef, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
 import { gsap } from "gsap";
-import { API_URL } from "@/lib/api"; // <-- Asegúrate de tener esto importado
 import { getNotificacionesNoLeidas, marcarNotificacionLeida, marcarTodasLeidas, type Notificacion } from "@/lib/api/notifusuario";
 import { getNoticias } from "@/lib/api/noticias";
 import type { Noticia } from "@/lib/types/noticias";
@@ -14,6 +14,8 @@ interface NotifMenuProps {
 }
 
 export default function NotifMenu({ noLeidas, onMarcarLeidas }: NotifMenuProps) {
+  const { usuario } = useAuth();
+  const isSuperAdmin = usuario?.codigoRol === "ROLE_ADMIN";
   const [open, setOpen] = useState(false);
   const [visible, setVisible] = useState(false);
   const [hovered, setHovered] = useState(false);
@@ -29,36 +31,10 @@ export default function NotifMenu({ noLeidas, onMarcarLeidas }: NotifMenuProps) 
   // ── ESTADO PARA EL POLLING DEL CONTADOR ──
   const [contadorNotifs, setContadorNotifs] = useState(noLeidas);
 
-  // 1. Efecto Polling (Llama al endpoint de César cada 30s)
+  // Sync contador desde el prop que ya gestiona el Header con su propio polling
   useEffect(() => {
-    const revisarContador = async () => {
-      try {
-        const token = localStorage.getItem("accessToken");
-        if (!token) return;
-
-        const res = await fetch(`${API_URL}/notificaciones/me/contador`, {
-          headers: { "Authorization": `Bearer ${token}` }
-        });
-
-        if (res.ok) {
-          const data = await res.json();
-          // Ajusta 'data' según lo que devuelva tu backend (ej: data.contador, data.count, o solo data)
-          const cantidad = typeof data === "number" ? data : (data.contador || data.count || 0);
-          setContadorNotifs(cantidad);
-        }
-      } catch (error) {
-        console.error("Error revisando contador:", error);
-      }
-    };
-
-    // Llamamos nada más cargar la web
-    revisarContador();
-
-    // Lo programamos cada 30 segundos (30000 milisegundos)
-    const intervalo = setInterval(revisarContador, 30000);
-
-    return () => clearInterval(intervalo);
-  }, []);
+    setContadorNotifs(noLeidas);
+  }, [noLeidas]);
 
   // 2. Efecto para los anuncios (como lo tenías)
   useEffect(() => {
@@ -139,7 +115,6 @@ export default function NotifMenu({ noLeidas, onMarcarLeidas }: NotifMenuProps) 
   async function handleClickNotificacion(notif: Notificacion) {
     await marcarNotificacionLeida(notif.notificacionId);
     setContadorNotifs(prev => Math.max(0, prev - 1)); // Restamos 1 al contador visual
-    onMarcarLeidas();
     closeMenu();
     if (notif.enlace) {
       const enlace = notif.enlace.replace("/formacion/modulo/", "/dashboard/formacion/");
@@ -184,7 +159,7 @@ export default function NotifMenu({ noLeidas, onMarcarLeidas }: NotifMenuProps) 
       {/* ── BOTÓN DE LA CAMPANITA ── */}
       <button
         onClick={toggle}
-        className="relative flex items-center justify-center h-full px-4 border-none cursor-pointer group"
+        className="relative flex items-center justify-center h-full px-3 border-none cursor-pointer group"
         style={{
           background: "transparent",
           color: hovered || open ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.7)",
@@ -302,8 +277,8 @@ export default function NotifMenu({ noLeidas, onMarcarLeidas }: NotifMenuProps) 
             
             {(notificaciones.length > 0 || anuncios.length > 0) && (
               <div className="p-3 border-t border-slate-100 bg-slate-50/50 text-center">
-                <button 
-                  onClick={() => { closeMenu(); router.push("/superadmin/comunicados"); }} 
+                <button
+                  onClick={() => { closeMenu(); router.push(isSuperAdmin ? "/superadmin/comunicados" : "/dashboard/comunicacion"); }}
                   className="text-xs font-semibold text-slate-500 hover:text-slate-800 transition-colors"
                 >
                   Ir al panel general

--- a/components/ui/UserMenu.tsx
+++ b/components/ui/UserMenu.tsx
@@ -125,43 +125,61 @@ export default function UserMenu({
   }
 
   return (
-    <div className="hidden sm:flex relative h-full items-stretch" ref={containerRef}>
+    <div className="hidden md:flex relative h-full items-stretch" ref={containerRef}>
       {/* Trigger */}
       <button
         onClick={toggle}
-        className="flex items-center gap-2.5 px-4 h-full border-none cursor-pointer"
-        style={{ background: "transparent", transition: "background 0.15s ease" }}
+        className="flex items-center gap-2.5 px-4 h-full border-none cursor-pointer rounded-none"
+        style={{
+          background:  hovered || open ? "rgba(255,255,255,0.07)" : "transparent",
+          transition:  "background 0.15s ease",
+        }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
+        {/* Avatar / logo / iniciales */}
         <div
           className="rounded-full flex items-center justify-center font-bold select-none shrink-0 text-sm overflow-hidden"
           style={{
-            width:      "36px",
-            height:     "36px",
+            width:      "34px",
+            height:     "34px",
             background: "rgba(255,255,255,0.15)",
             color:      "var(--blanco)",
-            border:     "2px solid rgba(255,255,255,0.5)",
+            border:     `2px solid ${hovered || open ? "rgba(255,255,255,0.7)" : "rgba(255,255,255,0.4)"}`,
+            transition: "border-color 0.15s ease",
           }}
         >
           {avatarUrl ? (
-            <Image src={avatarUrl} alt="Avatar" width={36} height={36}
+            <Image src={avatarUrl} alt="Avatar" width={34} height={34}
               className="object-cover rounded-full" />
           ) : logoEmpresa ? (
-            <Image src={logoEmpresa} alt="Logo empresa" width={36} height={36}
+            <Image src={logoEmpresa} alt="Logo empresa" width={34} height={34}
               className="object-cover rounded-full" />
           ) : initials}
         </div>
 
-        <span className="max-w-[120px] truncate whitespace-nowrap"
-          style={{ fontSize: "18px", fontWeight: 600, color: hovered ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.6)", transition: "color 0.15s ease" }}>
+        {/* Nombre */}
+        <span
+          className="max-w-[110px] truncate whitespace-nowrap hidden lg:block"
+          style={{
+            fontSize:   "15px",
+            fontWeight: 500,
+            color:      hovered || open ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.75)",
+            transition: "color 0.15s ease",
+          }}
+        >
           {nombreMostrado}
         </span>
 
+        {/* Chevron */}
         <svg
-          className={`w-3.5 h-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          className={`w-3 h-3 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
           fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}
-          style={{ color: hovered ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.5)", transition: "color 0.15s ease" }}
+          style={{
+            color:      hovered || open ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.4)",
+            transition: "color 0.15s ease",
+            flexShrink: 0,
+          }}
         >
           <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
         </svg>

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -7,16 +7,6 @@ export const NAV_ROUTES: Record<string, string> = {
   "Administración": "/dashboard/admin",
 };
 
-// Rutas del superadmin
-export const SUPERADMIN_ROUTES: Record<string, string> = {
-  "Inicio": "/superadmin",
-  "Empresas": "/superadmin/empresas",
-  "Solicitudes": "/superadmin/solicitudes",
-  "Estadísticas": "/superadmin/estadisticas",
-  "Comunicados": "/superadmin/comunicados",
-  "Configuración": "/superadmin/configuracion",
-};
-
 // Items visibles según rol
 export const NAV_ITEMS_BY_ROLE: Record<string, string[]> = {
   // El empleado ve Formación y Comunicación — sin Administración


### PR DESCRIPTION
Header:
- Nav centrado con posición absoluta (logo izq, perfil der)
- Padding full-width con max-w-[1600px] y valores progresivos
- Breakpoints sm: → md: para tablet correcta (768px)
- Scroll: sombra + blur + barra de progreso de navegación
- Hamburguesa → X animada, menú móvil suave
- Corrección ruta Comunicados superadmin (/superadmin/comunicados)
- Fix onMarcarLeidas no reseteaba contador a 0 incorrectamente
- NotifMenu: "Ir al panel general" role-aware
- Eliminado import API_URL/apiFetch sin usar en NotifMenu
- Eliminado SUPERADMIN_ROUTES (código muerto en routes.ts)
- Wrapper hidden md:flex redundante eliminado en Header

Heroes:
- DashboardHero: 3 variantes (inicio, seccion, minima)
- Tamaños responsive con clamp() por variante
- Overlays ajustados: base 0.50, lateral 0.80, sin lateral en minima
- Título: Instrument Serif italic 500, gradiente blanco/verde suave
- Etiqueta empresa real (no "Mi empresa"), truncada con max-w
- Fecha con whitespace-nowrap, punto condicional
- Subtítulo color subido a 0.65
- Perfil: altura responsive clamp(200px, 26vw, 300px)
- Perfil: botón "Cambiar portada" con glassmorphism
- Perfil: backgroundImage en lugar de background (fix warning React)
- AdminEmpresa: bannerUrl del usuario en hero inicio
- Eliminado bannerFondo (variable muerta en perfil)
- Padding hero alineado con header (px-6 sm:px-9 lg:px-14)
- Puntos finales eliminados en títulos de sección
- Overflow protection: truncate en empresa/puesto, wordBreak en título