### PR TITLE
feat(header/hero): rediseño visual header y DashboardHero

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -179,7 +179,7 @@ export default function Header({ logoEmpresa }: HeaderProps) {
         </div>
 
         {/* Navegación desktop — centrada en el header */}
-        <nav className="hidden md:flex items-stretch absolute left-1/2 -translate-x-1/2 h-full">
+        <nav className="hidden lg:flex items-stretch absolute left-1/2 -translate-x-1/2 h-full">
           {linksToRender.map((link) => {
             const isActive = pathname === link.path || (pathname.startsWith(link.path) && link.path !== linkLogo);
             return (
@@ -195,7 +195,7 @@ export default function Header({ logoEmpresa }: HeaderProps) {
         </nav>
 
         {/* Lado derecho — campana pegada al avatar */}
-        <div className="ml-auto flex items-center h-full gap-3 md:gap-0 z-10">
+        <div className="ml-auto flex items-center h-full gap-2 lg:gap-1 z-10">
 
           {/* Campana — px reducido para quedar cerca del avatar */}
           <div className="flex items-center h-full">
@@ -217,12 +217,14 @@ export default function Header({ logoEmpresa }: HeaderProps) {
             onCerrarSesion={handleLogout}
           />
 
-          {/* Hamburguesa → X — solo móvil */}
+          {/* Hamburguesa → X — solo hasta lg */}
           <button
-            className="md:hidden flex flex-col justify-center items-center rounded-lg gap-[5px]"
+            className="lg:hidden flex flex-col justify-center items-center gap-[5px]"
             style={{
-              width: "40px", height: "40px",
-              background: mobileOpen ? "rgba(255,255,255,0.08)" : "transparent",
+              width: "42px", height: "42px",
+              borderRadius: "11px",
+              background: mobileOpen ? "rgba(255,255,255,0.12)" : "rgba(255,255,255,0.06)",
+              border: "1px solid rgba(255,255,255,0.14)",
               transition: "background 0.15s ease",
             }}
             onClick={() => setMobileOpen((prev) => !prev)}
@@ -252,14 +254,15 @@ export default function Header({ logoEmpresa }: HeaderProps) {
 
       {/* Menú móvil — con animación suave de entrada */}
       <div
-        className="md:hidden flex flex-col overflow-hidden"
+        className="lg:hidden flex flex-col overflow-hidden"
         style={{
           maxHeight: mobileOpen ? "100dvh" : "0px",
           opacity:   mobileOpen ? 1 : 0,
           transition: "max-height 0.3s ease, opacity 0.2s ease",
-          borderTop: mobileOpen ? "1px solid rgba(255,255,255,0.08)" : "none",
+          borderTop: mobileOpen ? "1px solid rgba(255,255,255,0.07)" : "none",
           background: "rgba(22,50,105,0.98)",
           backdropFilter: "blur(14px)",
+          WebkitBackdropFilter: "blur(14px)",
           overflowY: "auto",
         }}
       >
@@ -420,12 +423,10 @@ function NavButton({ label, isActive, scrolled, onClick }: NavButtonProps) {
       style={{
         fontSize: "15px",
         fontWeight: isActive ? 600 : 500,
-        color: isActive
-          ? (scrolled ? "var(--verde-oliva-hover)" : "#ffffff")
-          : hovered
-            ? "#ffffff"
-            : (scrolled ? "rgba(255,255,255,0.60)" : "rgba(255,255,255,0.85)"),
-        transition: "color 0.35s ease",
+        color: isActive || hovered
+          ? "#ffffff"
+          : (scrolled ? "rgba(255,255,255,0.58)" : "rgba(255,255,255,0.82)"),
+        transition: "color 0.3s ease",
         background: "transparent",
       }}
     >

--- a/components/ui/DashboardHero.tsx
+++ b/components/ui/DashboardHero.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { useAuth } from "@/context/AuthContext";
-
 interface DashboardHeroProps {
   prefijo?: string;
   titulo: string;
-  subtitulo?: string; // mantenido por retrocompatibilidad, ya no se renderiza
+  subtitulo?: string; // mantenido por retrocompatibilidad
   imagenFondo?: string;
   objectPosition?: string;
   /** "inicio"  = hero grande (home de cada rol)
@@ -22,60 +20,91 @@ export default function DashboardHero({
   variante = "seccion",
 }: DashboardHeroProps) {
 
-  const { usuario } = useAuth();
-
-  const esSuperAdmin = usuario?.codigoRol === "ROLE_ADMIN";
-  const etiquetaRol  = esSuperAdmin ? "SuperAdmin" : null; // reservado para uso futuro
-
-  /* ── Tamaños según variante ── */
+  /* ── Alturas ── */
   const alturaMin = variante === "inicio"
-    ? "clamp(190px, 28vw, 360px)"
+    ? "clamp(220px, 35vw, 400px)"
     : variante === "minima"
       ? "clamp(100px, 12vw, 160px)"
-      : "clamp(170px, 25vw, 290px)";
+      : "clamp(200px, 28vw, 320px)";
 
-  const paddingY = variante === "inicio"
-    ? "py-8 sm:py-12 lg:py-16"
-    : variante === "minima"
-      ? "py-5 sm:py-7"
-      : "py-8 sm:py-11 lg:py-14";
-
-  const sizePrefijo = variante === "inicio"
-    ? "clamp(1.4rem, 3.2vw, 3rem)"
-    : variante === "minima"
-      ? "clamp(0.95rem, 1.6vw, 1.25rem)"
-      : "clamp(1.6rem, 3.2vw, 2.8rem)";
-
+  /* ── Tipografía ── */
   const sizeTitulo = variante === "inicio"
-    ? "clamp(2.6rem, 6vw, 5.8rem)"   // más grande en inicio
+    ? "clamp(2.4rem, 5.5vw, 5rem)"
     : variante === "minima"
       ? "clamp(1.2rem, 2vw, 1.6rem)"
       : "clamp(2.6rem, 5vw, 4.2rem)";
 
-  /* ── Opacidades de overlay según variante ── */
-  const overlayBase    = variante === "minima" ? "rgba(8,17,34,0.60)" : "rgba(8,17,34,0.45)";
-  const overlayLateral = variante === "minima"
-    ? "none"
-    : "linear-gradient(to right, rgba(8,17,34,0.75) 0%, rgba(8,17,34,0.35) 55%, transparent 100%)";
+  const sizePrefijo = sizeTitulo;
 
-  /* ── En móvil suavizamos el overlay lateral ── */
-  const overlayMobile = variante !== "minima"
-    ? "linear-gradient(to right, rgba(8,17,34,0.60) 0%, rgba(8,17,34,0.20) 70%, transparent 100%)"
-    : "none";
+  /* ── Overlay base ── */
+  const overlayBase = variante === "minima"
+    ? "rgba(8,17,34,0.60)"
+    : "rgba(8,17,34,0.30)";
+
+  /* ── Padding inferior ── */
+  const paddingBottom = variante === "inicio"
+    ? "clamp(2.5rem, 5vw, 3.5rem)"
+    : variante === "minima"
+      ? "1.5rem"
+      : "clamp(1.75rem, 3.5vw, 2.5rem)";
 
   const fechaHoy = new Date().toLocaleDateString("es-ES", {
     weekday: "long", day: "numeric", month: "long",
   }).replace(/^\w/, (c) => c.toUpperCase());
 
+  /* ── Minima: centrado, sin cambios ── */
+  if (variante === "minima") {
+    return (
+      <div
+        className="relative overflow-hidden flex items-center"
+        style={{ minHeight: alturaMin, boxShadow: "0 8px 40px rgba(0,0,0,0.18)" }}
+      >
+        <img src={imagenFondo} alt="" aria-hidden
+          className="absolute inset-0 w-full h-full object-cover"
+          style={{ objectPosition }} />
+        <div className="absolute inset-0" style={{ background: overlayBase }} />
+        <div
+          className="absolute top-0 left-0 right-0 pointer-events-none"
+          style={{ height: "60%", background: "linear-gradient(to bottom, rgba(8,17,34,0.50) 0%, transparent 100%)" }}
+        />
+        <div
+          className="relative z-10 w-full px-6 sm:px-9 lg:px-14 flex flex-wrap items-baseline gap-x-2"
+          style={{ paddingTop: "80px" }}
+        >
+          {prefijo && (
+            <span style={{
+              fontSize:   sizeTitulo,
+              fontFamily: "'Instrument Serif', serif",
+              fontStyle:  "italic",
+              fontWeight: 500,
+              color:      "rgba(255,255,255,0.65)",
+              lineHeight: 1.1,
+            }}>
+              {prefijo}
+            </span>
+          )}
+          <span style={{
+            fontSize:   sizeTitulo,
+            fontFamily: "'Instrument Serif', serif",
+            fontStyle:  "italic",
+            fontWeight: 500,
+            color:      "rgba(255,255,255,0.90)",
+            lineHeight: 1.1,
+          }}>
+            {titulo}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Inicio / Seccion: texto anclado abajo-izquierda ── */
   return (
     <div
-      className="relative overflow-hidden flex items-center"
-      style={{
-        minHeight: alturaMin,
-        boxShadow: "0 8px 40px rgba(0,0,0,0.18)",
-      }}
+      className="relative overflow-hidden flex items-end"
+      style={{ minHeight: alturaMin, boxShadow: "0 8px 40px rgba(0,0,0,0.18)" }}
     >
-      {/* Imagen de fondo */}
+      {/* Imagen */}
       <img
         src={imagenFondo}
         alt=""
@@ -87,78 +116,76 @@ export default function DashboardHero({
       {/* Overlay base */}
       <div className="absolute inset-0" style={{ background: overlayBase }} />
 
-      {/* Overlay lateral — desktop */}
-      {overlayLateral !== "none" && (
-        <div
-          className="absolute inset-0 hidden sm:block"
-          style={{ background: overlayLateral }}
-        />
-      )}
-
-      {/* Overlay lateral — móvil (más suave) */}
-      {overlayMobile !== "none" && (
-        <div
-          className="absolute inset-0 block sm:hidden"
-          style={{ background: overlayMobile }}
-        />
-      )}
-
-      {/* Fade inferior */}
+      {/* Gradiente superior — protege header transparente */}
       <div
-        className="absolute bottom-0 left-0 right-0 pointer-events-none"
+        className="absolute top-0 left-0 right-0 pointer-events-none"
         style={{
-          height: "60px",
-          background: "linear-gradient(to bottom, transparent, rgba(8,17,34,0.30))",
+          height: "45%",
+          background: "linear-gradient(to bottom, rgba(8,17,34,0.55) 0%, transparent 100%)",
         }}
       />
 
-      {/* Contenido — en inicio limitamos el ancho en desktop */}
+      {/* Gradiente inferior — legibilidad del texto */}
       <div
-        className={`relative z-10 w-full px-6 sm:px-9 lg:px-14 ${paddingY}`}
+        className="absolute bottom-0 left-0 right-0 pointer-events-none"
         style={{
-          paddingTop:  "80px",
-          ...(variante === "inicio" ? { maxWidth: "720px" } : {}),
+          height: "65%",
+          background: "linear-gradient(to bottom, transparent 0%, rgba(8,17,34,0.55) 50%, rgba(8,17,34,0.82) 100%)",
+        }}
+      />
+
+      {/* Contenido */}
+      <div
+        className="relative z-10 w-full px-6 sm:px-9 lg:px-14"
+        style={{
+          paddingBottom,
+          ...(variante === "inicio" ? { maxWidth: "800px" } : {}),
         }}
       >
-        {/* Etiqueta: punto pulsante + fecha */}
-        <p
-          className="flex items-center gap-2 text-xs font-semibold uppercase mb-3 sm:mb-4"
-          style={{
-            color:         "rgba(255,255,255,0.45)",
-            letterSpacing: "0.12em",
-            animation:     "heroFadeUp 0.6s ease both",
-          }}
-        >
-          <span
-            className="inline-block rounded-full shrink-0"
+        {/* Fecha — solo en inicio */}
+        {variante === "inicio" && (
+          <p
+            className="flex items-center gap-2 mb-3 sm:mb-4"
             style={{
-              width:      "6px",
-              height:     "6px",
-              background: "var(--verde-oliva-hover)",
-              animation:  "heroPulse 2.4s ease-in-out infinite",
+              fontSize:      "0.875rem",
+              fontWeight:    500,
+              color:         "rgba(255,255,255,0.68)",
+              letterSpacing: "0.02em",
+              animation:     "heroFadeUp 0.6s ease both",
             }}
-          />
-          <span className="whitespace-nowrap shrink-0">{fechaHoy}</span>
-        </p>
+          >
+            <span
+              className="inline-block rounded-full shrink-0"
+              style={{
+                width:      "6px",
+                height:     "6px",
+                background: "var(--verde-oliva-hover)",
+                animation:  "heroPulse 2.4s ease-in-out infinite",
+              }}
+            />
+            <span className="whitespace-nowrap">{fechaHoy}</span>
+          </p>
+        )}
 
-        {/* Título */}
+        {/* Prefijo + Título */}
         <div style={{ animation: "heroFadeUp 0.7s ease 0.1s both" }}>
-          <div className="leading-tight flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <div className="leading-tight flex flex-wrap items-baseline gap-x-3 gap-y-1">
+
             {prefijo && (
               <span
-                className="text-white"
                 style={{
-                  fontSize:      sizePrefijo,
-                  fontFamily:    "var(--font-poppins), sans-serif",
-                  fontWeight:    400,
-                  letterSpacing: "-0.025em",
-                  lineHeight:    1.1,
-                  opacity:       0.7,   // prefijo más tenue para que el título destaque
+                  fontSize:   sizePrefijo,
+                  fontFamily: "'Instrument Serif', serif",
+                  fontStyle:  "italic",
+                  fontWeight: 500,
+                  lineHeight: 1.05,
+                  color:      "#ffffff",
                 }}
               >
                 {prefijo}
               </span>
             )}
+
             <span
               style={{
                 fontSize:             sizeTitulo,
@@ -181,7 +208,6 @@ export default function DashboardHero({
               {titulo}
             </span>
           </div>
-
         </div>
       </div>
     </div>

--- a/components/ui/NotifMenu.tsx
+++ b/components/ui/NotifMenu.tsx
@@ -155,30 +155,45 @@ export default function NotifMenu({ noLeidas, onMarcarLeidas }: NotifMenuProps) 
   const totalNuevas = contadorNotifs + anunciosNuevosCount;
 
   return (
-    <div className="relative h-full" ref={containerRef}>
+    <div className="relative flex items-center h-full px-1" ref={containerRef}>
       {/* ── BOTÓN DE LA CAMPANITA ── */}
       <button
         onClick={toggle}
-        className="relative flex items-center justify-center h-full px-3 border-none cursor-pointer group"
+        className="relative flex items-center justify-center border-none cursor-pointer"
         style={{
-          background: "transparent",
-          color: hovered || open ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.7)",
-          transition: "all 0.2s ease",
+          width:        "42px",
+          height:       "42px",
+          borderRadius: "11px",
+          background:   open
+            ? "rgba(255,255,255,0.13)"
+            : hovered
+              ? "rgba(255,255,255,0.10)"
+              : "transparent",
+          border:      open || hovered
+            ? "1px solid rgba(255,255,255,0.18)"
+            : "1px solid transparent",
+          color:       hovered || open ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.72)",
+          transition:  "background 0.15s ease, color 0.15s ease, border-color 0.15s ease",
         }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
         aria-label="Notificaciones"
       >
-        <div className={`p-2 rounded-full transition-colors ${open ? "bg-white/10" : "group-hover:bg-white/10"}`}>
-          <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-          </svg>
-        </div>
+        <svg width="21" height="21" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+        </svg>
 
-        {/* El famoso puntito rojo alimentado por el polling */}
+        {/* Badge de notificaciones */}
         {totalNuevas > 0 && (
-          <span className="absolute top-3 right-3 min-w-[18px] h-[18px] text-white text-[10px] font-bold rounded-full flex items-center justify-center px-1 leading-none shadow-sm animate-pulse" 
-                style={{ background: "#ef4444", border: "2px solid var(--azul-egm)" }}>
+          <span
+            className="absolute min-w-[16px] h-[16px] text-white text-[9px] font-bold rounded-full flex items-center justify-center px-1 leading-none pointer-events-none"
+            style={{
+              top:       "-4px",
+              right:     "-4px",
+              background: "#ef4444",
+              boxShadow: "0 0 0 2px rgba(0,0,0,0.25)",
+            }}
+          >
             {totalNuevas > 99 ? "99+" : totalNuevas}
           </span>
         )}
@@ -186,7 +201,7 @@ export default function NotifMenu({ noLeidas, onMarcarLeidas }: NotifMenuProps) 
 
       {/* ── PANEL DESPLEGABLE ── */}
       {visible && (
-        <div ref={dropdownRef} className="absolute right-0 top-full mt-2 z-50 will-change-transform" style={{ width: "380px" }}>
+        <div ref={dropdownRef} className="absolute right-0 top-full mt-2 z-50 will-change-transform" style={{ width: "min(380px, calc(100vw - 2rem))" }}>
           <div className="bg-white rounded-2xl overflow-hidden shadow-2xl border border-slate-100">
             
             <div className="px-5 py-4 flex items-center justify-between bg-slate-50/50 border-b border-slate-100">

--- a/components/ui/UserMenu.tsx
+++ b/components/ui/UserMenu.tsx
@@ -125,14 +125,24 @@ export default function UserMenu({
   }
 
   return (
-    <div className="hidden md:flex relative h-full items-stretch" ref={containerRef}>
+    <div className="hidden lg:flex relative h-full items-center px-1" ref={containerRef}>
       {/* Trigger */}
       <button
         onClick={toggle}
-        className="flex items-center gap-2.5 px-4 h-full border-none cursor-pointer rounded-none"
+        className="flex items-center gap-2 border-none cursor-pointer"
         style={{
-          background:  hovered || open ? "rgba(255,255,255,0.07)" : "transparent",
-          transition:  "background 0.15s ease",
+          height:       "42px",
+          padding:      "0 12px 0 6px",
+          borderRadius: "11px",
+          background:   open
+            ? "rgba(255,255,255,0.13)"
+            : hovered
+              ? "rgba(255,255,255,0.10)"
+              : "transparent",
+          border:      open || hovered
+            ? "1px solid rgba(255,255,255,0.18)"
+            : "1px solid transparent",
+          transition:  "background 0.15s ease, border-color 0.15s ease",
         }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
@@ -141,19 +151,19 @@ export default function UserMenu({
         <div
           className="rounded-full flex items-center justify-center font-bold select-none shrink-0 text-sm overflow-hidden"
           style={{
-            width:      "34px",
-            height:     "34px",
+            width:      "30px",
+            height:     "30px",
             background: "rgba(255,255,255,0.15)",
             color:      "var(--blanco)",
-            border:     `2px solid ${hovered || open ? "rgba(255,255,255,0.7)" : "rgba(255,255,255,0.4)"}`,
+            border:     `2px solid ${hovered || open ? "rgba(255,255,255,0.65)" : "rgba(255,255,255,0.30)"}`,
             transition: "border-color 0.15s ease",
           }}
         >
           {avatarUrl ? (
-            <Image src={avatarUrl} alt="Avatar" width={34} height={34}
+            <Image src={avatarUrl} alt="Avatar" width={30} height={30}
               className="object-cover rounded-full" />
           ) : logoEmpresa ? (
-            <Image src={logoEmpresa} alt="Logo empresa" width={34} height={34}
+            <Image src={logoEmpresa} alt="Logo empresa" width={30} height={30}
               className="object-cover rounded-full" />
           ) : initials}
         </div>
@@ -162,7 +172,7 @@ export default function UserMenu({
         <span
           className="max-w-[110px] truncate whitespace-nowrap hidden lg:block"
           style={{
-            fontSize:   "15px",
+            fontSize:   "14px",
             fontWeight: 500,
             color:      hovered || open ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.75)",
             transition: "color 0.15s ease",
@@ -176,7 +186,7 @@ export default function UserMenu({
           className={`w-3 h-3 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
           fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}
           style={{
-            color:      hovered || open ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.4)",
+            color:      hovered || open ? "rgba(255,255,255,0.90)" : "rgba(255,255,255,0.50)",
             transition: "color 0.15s ease",
             flexShrink: 0,
           }}


### PR DESCRIPTION
Header:
- Breakpoints nav/UserMenu/hamburguesa de md → lg (tablet usa hamburguesa)
- Hamburguesa con borde sutil siempre visible, tamaño 42×42px
- Nav links siempre blancos, solo underline verde marca activo
- Botón campana y perfil: pastillas contenidas 42×42px con hover consistente
- Gap y alineación campana-avatar unificados
- Menú móvil sincronizado con colores del header

DashboardHero:
- Texto anclado abajo-izquierda (items-end) en variantes inicio/seccion
- Gradiente superior para proteger header transparente sobre imagen
- Gradiente inferior generoso para legibilidad del texto
- Prefijo en Instrument Serif italic blanco, mismo tamaño que título
- Fecha solo en variante inicio, más visible (14px, opacity 0.68)
- Alturas responsive mejoradas en todos los breakpoints
- Variante minima: limpieza y consistencia tipográfica
- Eliminado useAuth/usuario no usados

NotifMenu:
- Dropdown ancho: width fijo 380px → min(380px, 100vw-2rem) para móvil
- Badge sin animate-pulse, ring neutral sobre cualquier fondo