### PR TITLE
feat(ui): rediseño completo de NotifMenu, UserMenu y Header responsive

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -208,9 +208,8 @@ export default function Header({ logoEmpresa }: HeaderProps) {
           {/* Avatar + menú — sin separador, el gap del nav los aleja naturalmente */}
           <UserMenu
             nombreMostrado={nombreMostrado}
-            empresaNombre={isSuperAdmin ? "Administración EGM" : usuario?.nombreEmpresa}
+            email={usuario?.email}
             initials={initials}
-            logoEmpresa={logoEmpresa}
             avatarUrl={usuario?.avatarUrl}
             onPerfil={() => router.push(linkPerfil)}
             onConfiguracion={() => router.push(linkConfiguracion)}
@@ -359,10 +358,9 @@ export default function Header({ logoEmpresa }: HeaderProps) {
           {/* Configuración */}
           <button
             onClick={() => { setMobileOpen(false); router.push(linkConfiguracion); }}
-            className="flex items-center gap-3 px-4 py-3 text-sm rounded-xl"
+            className="flex items-center px-4 py-3 text-sm rounded-xl active:bg-white/10"
             style={{ color: "rgba(255,255,255,0.7)", transition: "background 0.15s ease" }}
           >
-            <i className="bi bi-gear" style={{ fontSize: "15px", opacity: 0.7, width: "16px" }} />
             Configuración
           </button>
 
@@ -372,10 +370,9 @@ export default function Header({ logoEmpresa }: HeaderProps) {
           {/* Cerrar sesión */}
           <button
             onClick={handleLogout}
-            className="flex items-center gap-3 px-4 py-3 text-sm font-medium rounded-xl"
+            className="flex items-center px-4 py-3 text-sm font-medium rounded-xl active:bg-red-500/10"
             style={{ color: "#f87171", transition: "background 0.15s ease" }}
           >
-            <i className="bi bi-box-arrow-right" style={{ fontSize: "15px", width: "16px" }} />
             Cerrar sesión
           </button>
         </div>

--- a/components/ui/NotifMenu.tsx
+++ b/components/ui/NotifMenu.tsx
@@ -1,179 +1,281 @@
 "use client";
 
-import { useLayoutEffect, useRef, useState, useEffect } from "react";
+import { useLayoutEffect, useRef, useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { useAuth } from "@/context/AuthContext";
 import { gsap } from "gsap";
 import { getNotificacionesNoLeidas, marcarNotificacionLeida, marcarTodasLeidas, type Notificacion } from "@/lib/api/notifusuario";
-import { getNoticias } from "@/lib/api/noticias";
-import type { Noticia } from "@/lib/types/noticias";
 
 interface NotifMenuProps {
   noLeidas: number;
   onMarcarLeidas: () => void;
 }
 
+const POR_PAGINA = 3;
+
+/** Páginas con elipsis — más agresiva en pantallas estrechas */
+function getPaginasMostradas(actual: number, total: number, estrecho = false): (number | "...")[] {
+  if (total <= 5) return Array.from({ length: total }, (_, i) => i);
+
+  // En móvil solo mostramos actual ± 1 + primera + última
+  if (estrecho) {
+    const result: (number | "...")[] = [0];
+    if (actual <= 1) {
+      result.push(1, "...", total - 1);
+    } else if (actual >= total - 2) {
+      result.push("...", total - 2, total - 1);
+    } else {
+      result.push("...", actual, "...", total - 1);
+    }
+    return result;
+  }
+
+  const result: (number | "...")[] = [0];
+  if (actual <= 2) {
+    result.push(1, 2, "...", total - 1);
+  } else if (actual >= total - 3) {
+    result.push("...", total - 3, total - 2, total - 1);
+  } else {
+    result.push("...", actual - 1, actual, actual + 1, "...", total - 1);
+  }
+  return result;
+}
+
 export default function NotifMenu({ noLeidas, onMarcarLeidas }: NotifMenuProps) {
-  const { usuario } = useAuth();
-  const isSuperAdmin = usuario?.codigoRol === "ROLE_ADMIN";
-  const [open, setOpen] = useState(false);
-  const [visible, setVisible] = useState(false);
-  const [hovered, setHovered] = useState(false);
+  const [open, setOpen]                     = useState(false);
+  const [visible, setVisible]               = useState(false);
+  const [hovered, setHovered]               = useState(false);
   const [notificaciones, setNotificaciones] = useState<Notificacion[]>([]);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const cardsRef = useRef<HTMLDivElement[]>([]);
-  const tlRef = useRef<gsap.core.Timeline | null>(null);
-  const router = useRouter();
-  const [anuncios, setAnuncios] = useState<Noticia[]>([]);
-  const [anunciosNuevosCount, setAnunciosNuevosCount] = useState(0);
-  
-  // ── ESTADO PARA EL POLLING DEL CONTADOR ──
+  const [cargando, setCargando]             = useState(false);
+  const [paginaActual, setPaginaActual]     = useState(0);
+  const [estrecho, setEstrecho]             = useState(false);
+  const [panelPos, setPanelPos]             = useState<{ top: number; right: number; caretRight: number; isMobile: boolean }>({ top: 60, right: 16, caretRight: 21, isMobile: false });
+  const containerRef  = useRef<HTMLDivElement>(null);
+  const dropdownRef   = useRef<HTMLDivElement>(null);
+  const listaRef      = useRef<HTMLDivElement>(null);
+  const cardsRef      = useRef<HTMLDivElement[]>([]);
+  const tlRef         = useRef<gsap.core.Timeline | null>(null);
+  const cacheNotifs   = useRef<Notificacion[]>([]); // última respuesta conocida
+  const router        = useRouter();
+
+  // ── Contador sincronizado con el polling del Header ──
   const [contadorNotifs, setContadorNotifs] = useState(noLeidas);
+  useEffect(() => { setContadorNotifs(noLeidas); }, [noLeidas]);
 
-  // Sync contador desde el prop que ya gestiona el Header con su propio polling
+  // ── Detectar ancho de pantalla ──
   useEffect(() => {
-    setContadorNotifs(noLeidas);
-  }, [noLeidas]);
-
-  // 2. Efecto para los anuncios (como lo tenías)
-  useEffect(() => {
-    const ultimaVisita = localStorage.getItem("notif_ultima_visita");
-    if (!ultimaVisita) return;
-    getNoticias().then(data => {
-      const nuevos = data.filter(a => new Date(a.creadoEn) > new Date(ultimaVisita));
-      setAnunciosNuevosCount(nuevos.length);
-    });
+    function checkWidth() {
+      setEstrecho(window.innerWidth < 360);
+    }
+    checkWidth();
+    window.addEventListener("resize", checkWidth);
+    return () => window.removeEventListener("resize", checkWidth);
   }, []);
 
+  // ── Calcular posición del panel (reutilizable en open y en resize) ──
+  const calcularPosicion = useCallback(() => {
+    if (!containerRef.current) return;
+    const rect       = containerRef.current.getBoundingClientRect();
+    const vw         = window.innerWidth;
+    const isMobile   = vw < 640;
+    const panelWidth = Math.min(380, vw - 12);
+
+    let right: number;
+    if (isMobile) {
+      // Móvil: centrado horizontalmente en pantalla
+      right = Math.round((vw - panelWidth) / 2);
+    } else {
+      // Desktop: alineado con el borde derecho del botón campana
+      const rightFromEdge = vw - rect.right;
+      right = Math.max(8, Math.min(rightFromEdge, vw - panelWidth - 8));
+    }
+
+    // Centro exacto del botón campana desde el borde derecho del panel
+    const caretRight = Math.round((vw - right) - (rect.left + rect.width / 2));
+    setPanelPos({ top: rect.bottom + 8, right, caretRight, isMobile });
+  }, []);
+
+  // ── Recalcular posición al redimensionar si el panel está abierto (F12, rotación…) ──
+  useEffect(() => {
+    if (!open) return;
+    window.addEventListener("resize", calcularPosicion);
+    return () => window.removeEventListener("resize", calcularPosicion);
+  }, [open, calcularPosicion]);
+
+  // ── Cerrar menú — definido antes del effect que lo referencia ──
+  const closeMenu = useCallback(() => {
+    if (!tlRef.current) { setVisible(false); setOpen(false); return; }
+    tlRef.current.reverse().then(() => { setVisible(false); setOpen(false); });
+  }, []);
+
+  // ── Cierre al clicar fuera ──
+  // Como el panel usa position:fixed, comprobamos tanto el botón como el panel
   useLayoutEffect(() => {
     function handleClick(e: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        closeMenu();
-      }
+      const target = e.target as Node;
+      const clickEnBoton = containerRef.current?.contains(target);
+      const clickEnPanel = dropdownRef.current?.contains(target);
+      if (!clickEnBoton && !clickEnPanel) closeMenu();
     }
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
-  }, []);
+  }, [closeMenu]);
 
+  // ── Animación de entrada del dropdown ──
   useLayoutEffect(() => {
     if (!visible || !dropdownRef.current) return;
+    // Calculamos cuántos items hay en la página actual para truncar refs obsoletos
+    const itemsEnPagina = Math.min(POR_PAGINA, Math.max(0, notificaciones.length - paginaActual * POR_PAGINA));
+    cardsRef.current = cardsRef.current.slice(0, itemsEnPagina);
     const cards = cardsRef.current.filter(Boolean);
     gsap.set(dropdownRef.current, { opacity: 0, y: -8, scale: 0.97 });
-    if (cards.length > 0) {
-      gsap.set(cards, { y: 20, opacity: 0 });
-    }
+    if (cards.length > 0) gsap.set(cards, { y: 16, opacity: 0 });
     const tl = gsap.timeline({ paused: true });
     tl.to(dropdownRef.current, { opacity: 1, y: 0, scale: 1, duration: 0.22, ease: "power3.out" });
-    if (cards.length > 0) {
-      tl.to(cards, { y: 0, opacity: 1, duration: 0.3, ease: "power3.out", stagger: 0.07 }, "-=0.08");
-    }
+    if (cards.length > 0) tl.to(cards, { y: 0, opacity: 1, duration: 0.28, ease: "power3.out", stagger: 0.06 }, "-=0.08");
     tlRef.current = tl;
     tl.play();
     return () => { tl.kill(); };
-  }, [visible, notificaciones]);
+  }, [visible]);
 
-  // 3. Al abrir, hacemos la petición pesada de la lista
+  // ── Animación de cambio de página — slide horizontal según dirección ──
+  const animarCambioPagina = useCallback((cb: () => void, direccion: 1 | -1) => {
+    if (!listaRef.current) { cb(); return; }
+    const xSalida  = direccion === 1 ? -28 : 28;  // sale hacia la izquierda si avanza
+    const xEntrada = direccion === 1 ?  28 : -28; // entra desde la derecha si avanza
+    gsap.to(listaRef.current, {
+      x: xSalida, opacity: 0, duration: 0.18, ease: "power2.in",
+      onComplete: () => {
+        cb();
+        gsap.set(listaRef.current, { x: xEntrada, opacity: 0 });
+        requestAnimationFrame(() => {
+          gsap.to(listaRef.current, {
+            x: 0, opacity: 1, duration: 0.26, ease: "power3.out",
+          });
+        });
+      },
+    });
+  }, []);
+
+  function cambiarPagina(nuevaPagina: number) {
+    if (nuevaPagina === paginaActual) return;
+    const direccion = nuevaPagina > paginaActual ? 1 : -1;
+    animarCambioPagina(() => setPaginaActual(nuevaPagina), direccion);
+  }
+
+  // ── Abrir ──
   async function openMenu() {
-    const ultimaVisita = localStorage.getItem("notif_ultima_visita");
-    const ahora = new Date().toISOString();
+    if (open) return;
+    calcularPosicion();
+    setPaginaActual(0);
+
+    const tieneCaché = cacheNotifs.current.length > 0;
+    if (tieneCaché) {
+      // Datos conocidos → abre inmediato sin skeleton, refresca en silencio
+      setNotificaciones(cacheNotifs.current);
+      setCargando(false);
+    } else {
+      // Primera vez → skeleton hasta que llegue la respuesta
+      setNotificaciones([]);
+      setCargando(true);
+    }
+
+    setVisible(true);
+    setOpen(true);
 
     try {
-      // AQUÍ OCURRE EL GET /me?page=0&size=20 a través de tu función
-      const [notifs, anunciosData] = await Promise.all([
-        getNotificacionesNoLeidas(),
-        getNoticias(),
-      ]);
-
-      const anunciosNuevos = ultimaVisita
-        ? anunciosData.filter(a => new Date(a.creadoEn) > new Date(ultimaVisita))
-        : anunciosData.slice(0, 3);
-
+      const notifs = await getNotificacionesNoLeidas();
+      cacheNotifs.current = notifs;
       setNotificaciones(notifs);
-      setAnuncios(anunciosNuevos);
-      localStorage.setItem("notif_ultima_visita", ahora);
-      setVisible(true);
-      setOpen(true);
     } catch (error) {
-      console.error("[NotifMenu] Error cargando notificaciones completas:", error);
+      console.error("[NotifMenu] Error cargando notificaciones:", error);
+    } finally {
+      setCargando(false);
     }
   }
 
-  function closeMenu() {
-    if (!tlRef.current) { setVisible(false); setOpen(false); return; }
-    tlRef.current.reverse().then(() => { setVisible(false); setOpen(false); });
-  }
+  function toggle() { open ? closeMenu() : openMenu(); }
 
-  function toggle() {
-    if (open) {
-      closeMenu();
-    } else {
-      openMenu();
-    }
-  }
-
+  // ── Leer notificación ──
   async function handleClickNotificacion(notif: Notificacion) {
     await marcarNotificacionLeida(notif.notificacionId);
-    setContadorNotifs(prev => Math.max(0, prev - 1)); // Restamos 1 al contador visual
-    closeMenu();
+    setContadorNotifs(prev => Math.max(0, prev - 1));
+
+    setNotificaciones(prev => {
+      const siguiente = prev.filter(n => n.notificacionId !== notif.notificacionId);
+      cacheNotifs.current = siguiente;
+      const totalPags = Math.ceil(siguiente.length / POR_PAGINA);
+      setPaginaActual(p => Math.min(p, Math.max(0, totalPags - 1)));
+      return siguiente;
+    });
+
     if (notif.enlace) {
-      const enlace = notif.enlace.replace("/formacion/modulo/", "/dashboard/formacion/");
+      const enlace = notif.enlace
+        .replace("/formacion/modulo/", "/dashboard/formacion/");
+      closeMenu();
       router.push(enlace);
     }
   }
 
+  // ── Marcar todas leídas ──
   async function handleMarcarTodas() {
     await marcarTodasLeidas();
+    cacheNotifs.current = [];
     setNotificaciones([]);
-    setContadorNotifs(0); // Ponemos a 0 el contador visual
+    setPaginaActual(0);
+    setContadorNotifs(0);
     onMarcarLeidas();
   }
 
+  // ── Iconos por tipo ──
   function getIconoPorTipo(tipo: string) {
     switch (tipo) {
-      case "MODULO": return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M4 19.5A2.5 2.5 0 016.5 17H20" /><path strokeLinecap="round" strokeLinejoin="round" d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" /></svg>;
-      case "ANUNCIO": return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M3 11l19-9-9 19-2-8-8-2z" /></svg>;
-      case "SOLICITUD_EMPRESA": return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 5 7 13" /><line x1="7" y1="9" x2="17" y2="9" /></svg>;
-      case "EMPRESA_APROBADA": return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m7 0a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>;
-      case "EMPRESA_RECHAZADA": return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M10 14l2.59-2.59m0 0l2.59-2.59m-5.18 5.18l-2.59-2.59m5.18 0l2.59 2.59M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z" /></svg>;
-      default: return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" /></svg>;
+      case "MODULO_NUEVO":
+        return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M4 19.5A2.5 2.5 0 016.5 17H20" /><path strokeLinecap="round" strokeLinejoin="round" d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" /></svg>;
+      case "SOLICITUD_EMPRESA":
+        return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M3 21h18M3 7l9-4 9 4M4 7v14M20 7v14M8 11h2m4 0h2M8 15h2m4 0h2" /></svg>;
+      case "BIENVENIDA":
+        return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" /></svg>;
+      case "EMPLEADO_NUEVO":
+        return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" /></svg>;
+      case "COMUNICADO_NUEVO":
+        return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" /></svg>;
+      default:
+        return <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" /></svg>;
     }
   }
 
   function getColorPorTipo(tipo: string): string {
     switch (tipo) {
+      case "MODULO_NUEVO":      return "#8b5cf6";
       case "SOLICITUD_EMPRESA": return "#3b82f6";
-      case "EMPRESA_APROBADA": return "#10b981";
-      case "EMPRESA_RECHAZADA": return "#ef4444";
-      case "MODULO":
-      case "ANUNCIO": return "#8b5cf6";
-      default: return "#6b7280";
+      case "BIENVENIDA":        return "#f59e0b";
+      case "EMPLEADO_NUEVO":    return "#10b981";
+      case "COMUNICADO_NUEVO":  return "#0ea5e9";
+      default:                  return "#6b7280";
     }
   }
 
-  // Ahora el total visual suma los anuncios + nuestro contador asíncrono
-  const totalNuevas = contadorNotifs + anunciosNuevosCount;
+  // ── Datos paginados ──
+  const totalPaginas  = Math.ceil(notificaciones.length / POR_PAGINA);
+  const notifsPagina  = notificaciones.slice(paginaActual * POR_PAGINA, (paginaActual + 1) * POR_PAGINA);
+  const hayPaginacion = totalPaginas > 1;
+
+  // Tamaño de botones de paginación: más pequeños en pantallas estrechas
+  const btnSize = estrecho ? "w-6 h-6" : "w-7 h-7";
 
   return (
     <div className="relative flex items-center h-full px-1" ref={containerRef}>
-      {/* ── BOTÓN DE LA CAMPANITA ── */}
+
+      {/* ── Botón campana ── */}
       <button
         onClick={toggle}
         className="relative flex items-center justify-center border-none cursor-pointer"
         style={{
-          width:        "42px",
-          height:       "42px",
-          borderRadius: "11px",
-          background:   open
-            ? "rgba(255,255,255,0.13)"
-            : hovered
-              ? "rgba(255,255,255,0.10)"
-              : "transparent",
-          border:      open || hovered
-            ? "1px solid rgba(255,255,255,0.18)"
-            : "1px solid transparent",
-          color:       hovered || open ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.72)",
-          transition:  "background 0.15s ease, color 0.15s ease, border-color 0.15s ease",
+          width: "42px", height: "42px", borderRadius: "11px",
+          background: open ? "rgba(255,255,255,0.13)" : hovered ? "rgba(255,255,255,0.10)" : "transparent",
+          border:     open || hovered ? "1px solid rgba(255,255,255,0.18)" : "1px solid transparent",
+          color:      hovered || open ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.72)",
+          transition: "background 0.15s ease, color 0.15s ease, border-color 0.15s ease",
         }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
@@ -182,124 +284,202 @@ export default function NotifMenu({ noLeidas, onMarcarLeidas }: NotifMenuProps) 
         <svg width="21" height="21" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
         </svg>
-
-        {/* Badge de notificaciones */}
-        {totalNuevas > 0 && (
+        {contadorNotifs > 0 && (
           <span
             className="absolute min-w-[16px] h-[16px] text-white text-[9px] font-bold rounded-full flex items-center justify-center px-1 leading-none pointer-events-none"
-            style={{
-              top:       "-4px",
-              right:     "-4px",
-              background: "#ef4444",
-              boxShadow: "0 0 0 2px rgba(0,0,0,0.25)",
-            }}
+            style={{ top: "-4px", right: "-4px", background: "#ef4444", boxShadow: "0 0 0 2px rgba(0,0,0,0.25)" }}
           >
-            {totalNuevas > 99 ? "99+" : totalNuevas}
+            {contadorNotifs > 99 ? "99+" : contadorNotifs}
           </span>
         )}
       </button>
 
-      {/* ── PANEL DESPLEGABLE ── */}
+      {/* ── Panel desplegable — position:fixed para romper cualquier overflow:hidden del header ── */}
       {visible && (
-        <div ref={dropdownRef} className="absolute right-0 top-full mt-2 z-50 will-change-transform" style={{ width: "min(380px, calc(100vw - 2rem))" }}>
-          <div className="bg-white rounded-2xl overflow-hidden shadow-2xl border border-slate-100">
-            
-            <div className="px-5 py-4 flex items-center justify-between bg-slate-50/50 border-b border-slate-100">
-              <h3 className="text-sm font-bold text-slate-800">Notificaciones</h3>
+        <div
+          ref={dropdownRef}
+          className="will-change-transform z-[300]"
+          style={{
+            position: "fixed",
+            top:      panelPos.top,
+            right:    panelPos.right,
+            width:    `min(380px, calc(100vw - 12px))`,
+          }}
+        >
+
+          {/* Caret — apunta al centro exacto del botón campana. Oculto en móvil (panel centrado) */}
+          {!panelPos.isMobile && (
+            <div style={{ position: "absolute", top: "-6px", right: `${panelPos.caretRight - 6}px`, width: "12px", height: "6px", overflow: "hidden" }}>
+              <div style={{ width: "10px", height: "10px", background: "#ffffff", border: "1px solid rgba(0,0,0,0.08)", transform: "rotate(45deg) translate(1px, 3px)", boxShadow: "-2px -2px 4px rgba(0,0,0,0.04)" }} />
+            </div>
+          )}
+
+          <div className="rounded-2xl overflow-hidden" style={{ background: "#ffffff", border: "1px solid rgba(0,0,0,0.08)", boxShadow: "0 8px 32px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.06)" }}>
+
+            {/* ── Cabecera ── */}
+            <div className="px-4 py-3.5 flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <h3 className="text-[15px] font-bold shrink-0" style={{ color: "#111827" }}>Notificaciones</h3>
+                {contadorNotifs > 0 && (
+                  <span className="min-w-[18px] h-[18px] text-white text-[10px] font-bold rounded-full flex items-center justify-center px-1 leading-none shrink-0" style={{ background: "#ef4444" }}>
+                    {contadorNotifs > 99 ? "99+" : contadorNotifs}
+                  </span>
+                )}
+              </div>
               {notificaciones.length > 0 && (
-                <button onClick={handleMarcarTodas} className="text-xs font-semibold text-blue-600 hover:text-blue-800 transition-colors">
-                  Marcar todas leídas
+                <button
+                  onClick={handleMarcarTodas}
+                  className="text-xs font-semibold shrink-0"
+                  style={{ color: "var(--azul-egm)", opacity: 0.75, transition: "opacity 0.15s ease" }}
+                  onMouseEnter={(e) => { e.currentTarget.style.opacity = "1"; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.opacity = "0.75"; }}
+                >
+                  Marcar leídas
                 </button>
               )}
             </div>
 
-            <div className="flex flex-col p-2 max-h-[400px] overflow-y-auto bg-white">
-              {notificaciones.length === 0 && anuncios.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-10 text-center">
-                  <div className="p-3 bg-slate-50 rounded-full mb-3 text-slate-300">
-                    <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            {/* ── Lista ── */}
+            <div className="overflow-hidden">
+              <div ref={listaRef} className="flex flex-col pt-1 pb-2 px-2">
+              {cargando ? (
+
+                /* Skeleton de carga */
+                <div className="flex flex-col gap-1 px-1 py-1">
+                  {[0, 1, 2].map(i => (
+                    <div key={i} className="flex items-center gap-3 px-2 py-2.5 rounded-xl">
+                      <div style={{ width: "3px", borderRadius: "2px", background: "#e5e7eb", minHeight: "36px", flexShrink: 0 }} />
+                      <div style={{ width: "34px", height: "34px", borderRadius: "8px", background: "#f3f4f6", flexShrink: 0 }} />
+                      <div className="flex-1 flex flex-col gap-1.5">
+                        <div style={{ height: "12px", borderRadius: "6px", background: "#f3f4f6", width: `${75 - i * 10}%` }} />
+                        <div style={{ height: "10px", borderRadius: "6px", background: "#f3f4f6", width: "40%" }} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+              ) : notificaciones.length === 0 ? (
+
+                /* Estado vacío */
+                <div className="flex flex-col items-center justify-center py-10 px-6 text-center gap-3">
+                  <div style={{ width: "44px", height: "44px", borderRadius: "12px", background: "var(--azul-egm-light)", color: "var(--azul-egm)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.6}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
                     </svg>
                   </div>
-                  <p className="text-sm font-bold text-slate-600">Todo al día</p>
-                  <p className="text-xs mt-1 text-slate-400">No hay avisos ni solicitudes pendientes.</p>
+                  <div>
+                    <p className="text-sm font-semibold" style={{ color: "#111827" }}>Todo al día</p>
+                    <p className="text-xs mt-1 leading-relaxed" style={{ color: "#9ca3af" }}>Te avisaremos cuando tengas novedades</p>
+                  </div>
                 </div>
-              ) : (
-                <>
-                  {notificaciones.map((notif, idx) => {
-                    const color = getColorPorTipo(notif.tipo);
-                    return (
-                      <div
-                        key={notif.notificacionId}
-                        ref={(el) => { if (el) cardsRef.current[idx] = el; }}
-                        onClick={() => handleClickNotificacion(notif)}
-                        className="flex items-start gap-3 p-3 rounded-xl cursor-pointer transition-colors hover:bg-slate-50 border border-transparent hover:border-slate-100 group"
-                      >
-                        <div className="shrink-0 p-2.5 rounded-full mt-0.5 transition-transform group-hover:scale-105" 
-                             style={{ backgroundColor: `${color}15`, color: color }}>
-                          {getIconoPorTipo(notif.tipo)}
-                        </div>
-                        
-                        <div className="min-w-0 flex-1">
-                          <p className="text-sm font-semibold text-slate-800 leading-snug mb-1">
-                            {notif.mensaje}
-                          </p>
-                          <p className="text-[11px] font-medium text-slate-400">
-                            {new Date(notif.creadoEn).toLocaleDateString("es-ES", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" })}
-                          </p>
-                        </div>
-                        
-                        <div className="w-2 h-2 bg-blue-500 rounded-full mt-2 shrink-0"></div>
-                      </div>
-                    );
-                  })}
 
-                  {anuncios.length > 0 && (
-                    <>
-                      <div className="px-3 pt-4 pb-2 mt-2 border-t border-slate-100">
-                        <p className="text-[10px] font-bold uppercase tracking-wider text-slate-400">
-                          Comunicados recientes
+              ) : (
+                notifsPagina.map((notif, idx) => {
+                  const color = getColorPorTipo(notif.tipo);
+                  return (
+                    <div
+                      key={notif.notificacionId}
+                      ref={(el) => { if (el) cardsRef.current[idx] = el; }}
+                      onClick={() => handleClickNotificacion(notif)}
+                      className="flex items-center gap-3 py-2.5 px-2 rounded-xl cursor-pointer"
+                      style={{ transition: "background 0.12s ease" }}
+                      onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(0,0,0,0.03)")}
+                      onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+                    >
+                      {/* Franja izquierda */}
+                      <div className="shrink-0 self-stretch" style={{ width: "3px", borderRadius: "2px", background: color, minHeight: "36px" }} />
+
+                      {/* Icono */}
+                      <div className="shrink-0 p-2 rounded-lg" style={{ background: `${color}18`, color }}>
+                        {getIconoPorTipo(notif.tipo)}
+                      </div>
+
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold leading-snug mb-0.5 line-clamp-2" style={{ color: "#1f2937" }}>
+                          {notif.mensaje}
+                        </p>
+                        <p className="text-[11px]" style={{ color: "#9ca3af" }}>
+                          {new Date(notif.creadoEn).toLocaleDateString("es-ES", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" })}
                         </p>
                       </div>
-                      {anuncios.map((anuncio, idx) => (
-                        <div
-                          key={anuncio.anuncioId}
-                          ref={(el) => { if (el) cardsRef.current[notificaciones.length + idx] = el; }}
-                          onClick={() => { closeMenu(); router.push("/dashboard/noticias"); }}
-                          className="flex items-start gap-3 p-3 rounded-xl cursor-pointer transition-colors hover:bg-slate-50 border border-transparent hover:border-slate-100 group"
-                        >
-                          <div className="shrink-0 p-2.5 rounded-full bg-slate-100 text-slate-500 mt-0.5 transition-transform group-hover:scale-105">
-                            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M3 11l19-9-9 19-2-8-8-2z" />
-                            </svg>
-                          </div>
-                          <div className="min-w-0 flex-1">
-                            <p className="text-sm font-semibold text-slate-800 leading-snug mb-0.5 truncate">
-                              {anuncio.titulo}
-                            </p>
-                            <p className="text-xs text-slate-500 line-clamp-1 mb-1">{anuncio.contenido}</p>
-                            <p className="text-[11px] font-medium text-slate-400">
-                              {new Date(anuncio.creadoEn).toLocaleDateString("es-ES", { day: "numeric", month: "short" })}
-                            </p>
-                          </div>
-                        </div>
-                      ))}
-                    </>
-                  )}
-                </>
+
+                      {/* Punto no leída */}
+                      <div className="w-2 h-2 rounded-full shrink-0 self-center" style={{ background: color }} />
+                    </div>
+                  );
+                })
               )}
             </div>
-            
-            {(notificaciones.length > 0 || anuncios.length > 0) && (
-              <div className="p-3 border-t border-slate-100 bg-slate-50/50 text-center">
+            </div>{/* /overflow-hidden */}
+
+            {/* ── Paginación ── */}
+            {hayPaginacion && (
+              <div className="px-2 py-2.5 flex items-center justify-center gap-0.5" style={{ borderTop: "1px solid rgba(0,0,0,0.06)" }}>
+
+                {/* Flecha anterior */}
                 <button
-                  onClick={() => { closeMenu(); router.push(isSuperAdmin ? "/superadmin/comunicados" : "/dashboard/comunicacion"); }}
-                  className="text-xs font-semibold text-slate-500 hover:text-slate-800 transition-colors"
+                  onClick={() => cambiarPagina(paginaActual - 1)}
+                  disabled={paginaActual === 0}
+                  className={`${btnSize} flex items-center justify-center rounded-lg`}
+                  style={{
+                    color:      paginaActual === 0 ? "#d1d5db" : "#6b7280",
+                    background: "transparent",
+                    cursor:     paginaActual === 0 ? "not-allowed" : "pointer",
+                    transition: "background 0.12s ease",
+                  }}
+                  onMouseEnter={(e) => { if (paginaActual > 0) e.currentTarget.style.background = "rgba(0,0,0,0.05)"; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
                 >
-                  Ir al panel general
+                  <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
                 </button>
+
+                {/* Números de página */}
+                {getPaginasMostradas(paginaActual, totalPaginas, estrecho).map((p, i) =>
+                  p === "..." ? (
+                    <span key={`e-${i}`} className={`${btnSize} flex items-center justify-center text-xs`} style={{ color: "#9ca3af" }}>…</span>
+                  ) : (
+                    <button
+                      key={p}
+                      onClick={() => cambiarPagina(p as number)}
+                      className={`${btnSize} flex items-center justify-center rounded-lg text-xs font-semibold`}
+                      style={{
+                        background: p === paginaActual ? "var(--azul-egm)" : "transparent",
+                        color:      p === paginaActual ? "#ffffff" : "#6b7280",
+                        cursor:     "pointer",
+                        transition: "background 0.12s ease",
+                      }}
+                      onMouseEnter={(e) => { if (p !== paginaActual) e.currentTarget.style.background = "rgba(0,0,0,0.05)"; }}
+                      onMouseLeave={(e) => { if (p !== paginaActual) e.currentTarget.style.background = "transparent"; }}
+                    >
+                      {(p as number) + 1}
+                    </button>
+                  )
+                )}
+
+                {/* Flecha siguiente */}
+                <button
+                  onClick={() => cambiarPagina(paginaActual + 1)}
+                  disabled={paginaActual === totalPaginas - 1}
+                  className={`${btnSize} flex items-center justify-center rounded-lg`}
+                  style={{
+                    color:      paginaActual === totalPaginas - 1 ? "#d1d5db" : "#6b7280",
+                    background: "transparent",
+                    cursor:     paginaActual === totalPaginas - 1 ? "not-allowed" : "pointer",
+                    transition: "background 0.12s ease",
+                  }}
+                  onMouseEnter={(e) => { if (paginaActual < totalPaginas - 1) e.currentTarget.style.background = "rgba(0,0,0,0.05)"; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+                >
+                  <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+
               </div>
             )}
+
           </div>
         </div>
       )}

--- a/components/ui/UserMenu.tsx
+++ b/components/ui/UserMenu.tsx
@@ -6,56 +6,48 @@ import { gsap } from "gsap";
 
 interface UserMenuProps {
   nombreMostrado: string;
-  empresaNombre?: string;
+  email?: string;
   initials: string;
-  logoEmpresa?: string;
   avatarUrl?: string;
   onPerfil: () => void;
   onConfiguracion: () => void;
   onCerrarSesion: () => void;
 }
 
-const CARDS = [
+const ACCIONES = [
   {
-    label: "Mi perfil",
+    key:    "perfil" as const,
+    label:  "Mi perfil",
+    danger: false,
     icon: (
-      <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <svg width="17" height="17" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.9}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
       </svg>
     ),
-    bg: "#ffffff",
-    color: "#111827",
-    action: "perfil" as const,
   },
   {
-    label: "Configuración",
+    key:    "configuracion" as const,
+    label:  "Configuración",
+    danger: false,
     icon: (
-      <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      <svg width="17" height="17" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.9}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
       </svg>
     ),
-    bg: "#f9fafb",
-    color: "#374151",
-    action: "configuracion" as const,
-  },
-  {
-    label: "Cerrar sesión",
-    icon: (
-      <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-      </svg>
-    ),
-    bg: "#fff1f2",
-    color: "#e11d48",
-    action: "logout" as const,
   },
 ];
 
+const ICONO_LOGOUT = (
+  <svg width="17" height="17" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.9}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+  </svg>
+);
+
 export default function UserMenu({
   nombreMostrado,
-  empresaNombre,
+  email,
   initials,
-  logoEmpresa,
   avatarUrl,
   onPerfil,
   onConfiguracion,
@@ -69,7 +61,6 @@ export default function UserMenu({
   const cardsRef              = useRef<HTMLDivElement[]>([]);
   const tlRef                 = useRef<gsap.core.Timeline | null>(null);
 
-  // Close on outside click
   useLayoutEffect(() => {
     function handleClick(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
@@ -80,53 +71,36 @@ export default function UserMenu({
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
-  // Build / rebuild timeline whenever visibility changes
   useLayoutEffect(() => {
     if (!visible || !dropdownRef.current) return;
-
     const cards = cardsRef.current.filter(Boolean);
-
-    // Reset
     gsap.set(dropdownRef.current, { opacity: 0, y: -8, scale: 0.97 });
-    gsap.set(cards, { y: 20, opacity: 0 });
-
+    if (cards.length > 0) gsap.set(cards, { y: 12, opacity: 0 });
     const tl = gsap.timeline({ paused: true });
-    tl.to(dropdownRef.current, { opacity: 1, y: 0, scale: 1, duration: 0.22, ease: "power3.out" });
-    tl.to(cards, { y: 0, opacity: 1, duration: 0.3, ease: "power3.out", stagger: 0.07 }, "-=0.08");
-
+    tl.to(dropdownRef.current, { opacity: 1, y: 0, scale: 1, duration: 0.2, ease: "power3.out" });
+    if (cards.length > 0) tl.to(cards, { y: 0, opacity: 1, duration: 0.25, ease: "power3.out", stagger: 0.07 }, "-=0.08");
     tlRef.current = tl;
     tl.play();
-
     return () => { tl.kill(); };
   }, [visible]);
 
-  function openMenu() {
-    setVisible(true);
-    setOpen(true);
-  }
-
+  function openMenu()  { setVisible(true); setOpen(true); }
   function closeMenu() {
     if (!tlRef.current) { setVisible(false); setOpen(false); return; }
-    tlRef.current.reverse().then(() => {
-      setVisible(false);
-      setOpen(false);
-    });
+    tlRef.current.reverse().then(() => { setVisible(false); setOpen(false); });
   }
+  function toggle() { open ? closeMenu() : openMenu(); }
 
-  function toggle() {
-    open ? closeMenu() : openMenu();
-  }
-
-  function handleAction(action: "perfil" | "configuracion" | "logout") {
+  function handleAccion(key: "perfil" | "configuracion") {
     closeMenu();
-    if (action === "perfil") onPerfil();
-    else if (action === "configuracion") onConfiguracion();
-    else onCerrarSesion();
+    if (key === "perfil") onPerfil();
+    else                  onConfiguracion();
   }
 
   return (
     <div className="hidden lg:flex relative h-full items-center px-1" ref={containerRef}>
-      {/* Trigger */}
+
+      {/* ── Trigger ── */}
       <button
         onClick={toggle}
         className="flex items-center gap-2 border-none cursor-pointer"
@@ -134,11 +108,9 @@ export default function UserMenu({
           height:       "42px",
           padding:      "0 12px 0 6px",
           borderRadius: "11px",
-          background:   open
-            ? "rgba(255,255,255,0.13)"
-            : hovered
-              ? "rgba(255,255,255,0.10)"
-              : "transparent",
+          background:   open     ? "rgba(255,255,255,0.13)"
+                       : hovered ? "rgba(255,255,255,0.10)"
+                       : "transparent",
           border:      open || hovered
             ? "1px solid rgba(255,255,255,0.18)"
             : "1px solid transparent",
@@ -147,41 +119,34 @@ export default function UserMenu({
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
-        {/* Avatar / logo / iniciales */}
         <div
-          className="rounded-full flex items-center justify-center font-bold select-none shrink-0 text-sm overflow-hidden"
+          className="rounded-full flex items-center justify-center font-bold select-none shrink-0 text-xs overflow-hidden"
           style={{
             width:      "30px",
             height:     "30px",
-            background: "rgba(255,255,255,0.15)",
-            color:      "var(--blanco)",
+            background: avatarUrl ? "transparent" : "rgba(255,255,255,0.15)",
+            color:      "#fff",
             border:     `2px solid ${hovered || open ? "rgba(255,255,255,0.65)" : "rgba(255,255,255,0.30)"}`,
             transition: "border-color 0.15s ease",
           }}
         >
-          {avatarUrl ? (
-            <Image src={avatarUrl} alt="Avatar" width={30} height={30}
-              className="object-cover rounded-full" />
-          ) : logoEmpresa ? (
-            <Image src={logoEmpresa} alt="Logo empresa" width={30} height={30}
-              className="object-cover rounded-full" />
-          ) : initials}
+          {avatarUrl
+            ? <Image src={avatarUrl} alt="Avatar" width={30} height={30} className="object-cover rounded-full" />
+            : initials}
         </div>
 
-        {/* Nombre */}
         <span
           className="max-w-[110px] truncate whitespace-nowrap hidden lg:block"
           style={{
             fontSize:   "14px",
             fontWeight: 500,
-            color:      hovered || open ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.75)",
+            color:      hovered || open ? "#fff" : "rgba(255,255,255,0.75)",
             transition: "color 0.15s ease",
           }}
         >
           {nombreMostrado}
         </span>
 
-        {/* Chevron */}
         <svg
           className={`w-3 h-3 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
           fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}
@@ -195,79 +160,147 @@ export default function UserMenu({
         </svg>
       </button>
 
-      {/* Dropdown */}
+      {/* ── Dropdown ── */}
       {visible && (
         <div
           ref={dropdownRef}
-          className="absolute right-0 top-full mt-1 z-[200] will-change-transform"
-          style={{ width: "280px" }}
+          className="absolute right-0 top-full mt-2 z-[200] will-change-transform"
+          style={{ width: "260px" }}
         >
-          {/* Header card — user info */}
+          {/* Caret */}
+          <div style={{ position: "absolute", top: "-6px", right: "22px", width: "12px", height: "6px", overflow: "hidden" }}>
+            <div style={{ width: "10px", height: "10px", background: "#ffffff", border: "1px solid rgba(0,0,0,0.08)", transform: "rotate(45deg) translate(1px, 3px)", boxShadow: "-2px -2px 4px rgba(0,0,0,0.04)" }} />
+          </div>
+
           <div
-            className="rounded-xl overflow-hidden shadow-2xl"
-            style={{ border: "1px solid #e5e7eb" }}
+            className="rounded-2xl overflow-hidden"
+            style={{ background: "#ffffff", border: "1px solid rgba(0,0,0,0.08)", boxShadow: "0 8px 32px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.06)" }}
           >
-            <div
-              className="px-4 py-3 flex items-center gap-3"
-              style={{
-                background:   "#f9fafb",
-                borderBottom: "1px solid #e5e7eb",
-              }}
-            >
+            {/* ── Info — solo lectura ── */}
+            <div className="px-4 py-4 flex items-center gap-3">
               <div
-                className="rounded-full flex items-center justify-center text-xs font-bold shrink-0 overflow-hidden"
+                className="rounded-full flex items-center justify-center font-bold shrink-0 overflow-hidden"
                 style={{
-                  width:      "32px",
-                  height:     "32px",
-                  background: "var(--azul-egm)",
-                  color:      "#ffffff",
-                  border:     "2px solid #e5e7eb",
+                  width:      "46px",
+                  height:     "46px",
+                  fontSize:   "17px",
+                  background: avatarUrl ? "transparent" : "var(--azul-egm)",
+                  color:      "#fff",
+                  border:     "2px solid rgba(0,0,0,0.06)",
+                  flexShrink: 0,
                 }}
               >
-                {avatarUrl ? (
-                  <Image src={avatarUrl} alt="Avatar" width={32} height={32} className="object-cover rounded-full" />
-                ) : initials}
+                {avatarUrl
+                  ? <Image src={avatarUrl} alt="Avatar" width={46} height={46} className="object-cover rounded-full" />
+                  : initials}
               </div>
-              <div className="min-w-0">
-                <p className="text-sm font-semibold truncate" style={{ color: "#111827" }}>
+
+              <div className="min-w-0 flex-1">
+                <p className="text-[15px] font-semibold truncate" style={{ color: "#111827", lineHeight: 1.3 }}>
                   {nombreMostrado}
                 </p>
-                {empresaNombre && (
-                  <p className="text-xs mt-0.5 truncate" style={{ color: "#6b7280" }}>
-                    {empresaNombre}
+                {email && (
+                  <p className="text-xs truncate mt-0.5" style={{ color: "#9ca3af" }} title={email}>
+                    {email}
                   </p>
                 )}
               </div>
             </div>
 
-            {/* Action cards */}
-            <div
-              className="flex flex-col gap-1.5 p-2"
-              style={{ background: "#f3f4f6" }}
-            >
-              {CARDS.map((card, idx) => (
-                <div
-                  key={card.action}
-                  ref={(el) => { if (el) cardsRef.current[idx] = el; }}
-                  onClick={() => handleAction(card.action)}
-                  className="flex items-center gap-3 px-3 py-3 rounded-lg cursor-pointer transition-opacity hover:opacity-80 select-none"
-                  style={{
-                    background: card.bg,
-                    color:      card.color,
-                  }}
-                >
-                  <span className="shrink-0">{card.icon}</span>
-                  <span className="text-base font-medium">{card.label}</span>
-                  <svg className="ml-auto shrink-0 w-3.5 h-3.5 opacity-50" fill="none" viewBox="0 0 24 24"
-                    stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M7 17L17 7M17 7H7M17 7v10" />
-                  </svg>
-                </div>
+            {/* Separador */}
+            <div style={{ height: "1px", background: "rgba(0,0,0,0.07)", margin: "0 16px" }} />
+
+            {/* ── Mi perfil + Configuración ── */}
+            <div className="py-2 px-2 flex flex-col gap-0.5">
+              {ACCIONES.map((accion, idx) => (
+                <ActionItem
+                  key={accion.key}
+                  label={accion.label}
+                  icon={accion.icon}
+                  danger={false}
+                  refFn={(el) => { if (el) cardsRef.current[idx] = el; }}
+                  onClick={() => handleAccion(accion.key)}
+                />
               ))}
+            </div>
+
+            {/* Separador antes de cerrar sesión */}
+            <div style={{ height: "1px", background: "rgba(0,0,0,0.07)", margin: "0 16px" }} />
+
+            {/* ── Cerrar sesión ── */}
+            <div className="py-2 px-2">
+              <ActionItem
+                label="Cerrar sesión"
+                icon={ICONO_LOGOUT}
+                danger
+                refFn={(el) => { if (el) cardsRef.current[2] = el; }}
+                onClick={() => { closeMenu(); onCerrarSesion(); }}
+              />
             </div>
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/* ── ActionItem ── */
+function ActionItem({
+  label,
+  icon,
+  danger,
+  refFn,
+  onClick,
+}: {
+  label:  string;
+  icon:   React.ReactNode;
+  danger: boolean;
+  refFn:  (el: HTMLDivElement | null) => void;
+  onClick: () => void;
+}) {
+  const [hov, setHov] = useState(false);
+
+  return (
+    <div
+      ref={refFn}
+      onClick={onClick}
+      onMouseEnter={() => setHov(true)}
+      onMouseLeave={() => setHov(false)}
+      className="flex items-center gap-3 px-3 py-3 rounded-xl cursor-pointer select-none"
+      style={{
+        background: hov
+          ? (danger ? "rgba(239,68,68,0.07)" : "rgba(0,0,0,0.045)")
+          : "transparent",
+        color:      danger ? "#e11d48" : "#374151",
+        transition: "background 0.15s ease",
+      }}
+    >
+      <div
+        className="w-8 h-8 rounded-xl flex items-center justify-center shrink-0"
+        style={{
+          background: hov
+            ? (danger ? "rgba(239,68,68,0.12)" : "rgba(0,0,0,0.07)")
+            : (danger ? "rgba(239,68,68,0.07)" : "rgba(0,0,0,0.05)"),
+          color:      danger ? "#e11d48" : "#6b7280",
+          transition: "background 0.15s ease",
+        }}
+      >
+        {icon}
+      </div>
+
+      <span className="text-[15px] font-medium flex-1">{label}</span>
+
+      <svg
+        width="14" height="14" fill="none" viewBox="0 0 24 24"
+        stroke="currentColor" strokeWidth={2.5}
+        style={{
+          color:      danger ? "rgba(225,29,72,0.35)" : "rgba(0,0,0,0.18)",
+          opacity:    hov ? 1 : 0.5,
+          transition: "opacity 0.15s ease",
+        }}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+      </svg>
     </div>
   );
 }


### PR DESCRIPTION
- NotifMenu: panel position:fixed con calcularPosicion para romper overflow del header, centrado en móvil, caret alineado al botón campana, cache para apertura instantánea en sucesivas aperturas, skeleton solo en primera carga, animación de entrada independiente del cambio de página, paginación con elipsis adaptada a pantallas estrechas
- UserMenu: cabecera solo lectura con nombre y email, separador antes de cerrar sesión, hover sin translateX, iconos SVG inline consistentes
- Header: eliminados Bootstrap Icons del menú móvil, reemplazados por SVGs inline; Configuración y Cerrar sesión sin icono en móvil; feedback touch con active: en botones de acción