### PR TITLE
feat(servicios+eventos): páginas completas con datos mock

### DIFF
--- a/app/dashboard/eventos/page.tsx
+++ b/app/dashboard/eventos/page.tsx
@@ -243,8 +243,8 @@ function SkeletonCard() {
 
 // ── Página ────────────────────────────────────────────────────────────────────
 export default function EventosPage() {
-  const { user } = useAuth();
-  const esSuperAdmin = user?.rol === "ROLE_ADMIN";
+  const { usuario } = useAuth();
+  const esSuperAdmin = usuario?.codigoRol === "ROLE_ADMIN";
 
   const [eventos,   setEventos]   = useState<Evento[]>([]);
   const [cargando,  setCargando]  = useState(true);
@@ -284,17 +284,20 @@ export default function EventosPage() {
   return (
     <div className="flex flex-col gap-6 pb-10">
       <DashboardHero
-        title="Eventos"
-        subtitle="Actividades, jornadas y encuentros del área empresarial EGM Atalayas."
-        actions={esSuperAdmin ? (
+        titulo="Eventos"
+        subtitulo="Actividades, jornadas y encuentros del área empresarial EGM Atalayas."
+        variante="seccion"
+      />
+      {esSuperAdmin && (
+        <div className="px-4 sm:px-6 lg:px-8 -mt-2">
           <Button variant="primary" onClick={() => mostrarToast("Próximamente — modal de evento")}>
             <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2} className="mr-1.5">
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4"/>
             </svg>
             Nuevo evento
           </Button>
-        ) : undefined}
-      />
+        </div>
+      )}
 
       <div className="px-4 sm:px-6 lg:px-8 flex flex-col gap-8">
 

--- a/app/dashboard/eventos/page.tsx
+++ b/app/dashboard/eventos/page.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import DashboardHero from "@/components/ui/DashboardHero";
+import { Button }    from "@/components/ui/Button";
+import { useAuth }   from "@/context/AuthContext";
+import { getEventos, desactivarEvento } from "@/lib/api/eventos";
+import type { Evento, EstadoEvento } from "@/lib/types/eventos";
+
+// ── Mock ──────────────────────────────────────────────────────────────────────
+const hoy = new Date();
+const fmt  = (d: Date) => d.toISOString().slice(0, 10);
+const add  = (days: number) => { const d = new Date(hoy); d.setDate(d.getDate() + days); return d; };
+
+const MOCK_EVENTOS: Evento[] = [
+  {
+    eventoId: "e1", titulo: "Semana de la Movilidad Sostenible",
+    descripcion: "Jornadas de concienciación sobre movilidad sostenible en el área empresarial: talleres, exhibiciones y actividades para fomentar el transporte verde.",
+    fecha: fmt(add(12)), horaInicio: "09:00", horaFin: "18:00",
+    lugar: "Edificio central EGM Atalayas", urlInfo: "https://atalayas.com/semana-de-la-movilidad/",
+    imagenUrl: null, estado: "PROXIMO",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  {
+    eventoId: "e2", titulo: "En Femenino — Mesa redonda de liderazgo",
+    descripcion: "Encuentro de referentes femeninas del área empresarial para debatir sobre el papel de la mujer en el desarrollo económico y social.",
+    fecha: fmt(add(25)), horaInicio: "10:30", horaFin: "13:00",
+    lugar: "Aula de formación EGM Atalayas", urlInfo: "https://atalayas.com/en-femenino/",
+    imagenUrl: null, estado: "PROXIMO",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  {
+    eventoId: "e3", titulo: "100 Estudiantes · 20 Empresarios",
+    descripcion: "Programa de networking entre jóvenes estudiantes y líderes empresariales del área. Una oportunidad para conectar talento emergente con el tejido empresarial.",
+    fecha: fmt(add(40)), horaInicio: "16:00", horaFin: "19:00",
+    lugar: "Polígono Industrial Las Atalayas", urlInfo: "https://atalayas.com/100-estudiantes-20-empresarios/",
+    imagenUrl: null, estado: "PROXIMO",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  {
+    eventoId: "e4", titulo: "Jornada de Empresas Solidarias",
+    descripcion: "Entrega anual de lotes solidarios a familias en situación de vulnerabilidad, organizada por las empresas del área.",
+    fecha: fmt(add(-15)), horaInicio: "11:00", horaFin: "14:00",
+    lugar: "Edificio central EGM Atalayas", urlInfo: "https://atalayas.com/empresas-solidarias/",
+    imagenUrl: null, estado: "FINALIZADO",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const ESTADO_CONFIG: Record<EstadoEvento, { label: string; bg: string; color: string }> = {
+  PROXIMO:    { label: "Próximo",    bg: "rgba(59,130,246,0.09)",  color: "#2563eb" },
+  EN_CURSO:   { label: "En curso",   bg: "rgba(16,185,129,0.09)", color: "#059669" },
+  FINALIZADO: { label: "Finalizado", bg: "rgba(0,0,0,0.06)",       color: "#6b7280" },
+  CANCELADO:  { label: "Cancelado",  bg: "rgba(239,68,68,0.09)",   color: "#dc2626" },
+};
+
+function calcEstado(evento: Evento): EstadoEvento {
+  if (evento.estado) return evento.estado;
+  const fecha = new Date(evento.fecha);
+  const hoyMs = new Date().setHours(0, 0, 0, 0);
+  if (fecha.getTime() > hoyMs) return "PROXIMO";
+  if (fecha.getTime() === hoyMs) return "EN_CURSO";
+  return "FINALIZADO";
+}
+
+function formatFecha(iso: string) {
+  const d = new Date(iso + "T00:00:00");
+  return d.toLocaleDateString("es-ES", { weekday: "long", day: "numeric", month: "long", year: "numeric" });
+}
+
+// ── Card de evento ────────────────────────────────────────────────────────────
+function EventoCard({
+  evento, esSuperAdmin, onEditar, onDesactivar,
+}: {
+  evento: Evento; esSuperAdmin: boolean;
+  onEditar: (e: Evento) => void; onDesactivar: (e: Evento) => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const estado  = calcEstado(evento);
+  const cfg     = ESTADO_CONFIG[estado];
+  const pasado  = estado === "FINALIZADO" || estado === "CANCELADO";
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onOut(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    }
+    document.addEventListener("mousedown", onOut);
+    return () => document.removeEventListener("mousedown", onOut);
+  }, [menuOpen]);
+
+  return (
+    <div
+      className="relative flex flex-col rounded-2xl overflow-hidden"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background:  "#ffffff",
+        border:      "1px solid rgba(0,0,0,0.07)",
+        boxShadow:   hovered ? "0 8px 28px rgba(0,0,0,0.11)" : "0 2px 12px rgba(0,0,0,0.06)",
+        transform:   hovered ? "translateY(-2px)" : "translateY(0)",
+        transition:  "box-shadow 0.22s ease, transform 0.22s cubic-bezier(0.34,1.20,0.64,1)",
+        opacity:     pasado ? 0.72 : 1,
+      }}
+    >
+      {/* Franja de fecha */}
+      <div className="flex items-center gap-3 px-4 pt-4 pb-3">
+        {/* Bloque día */}
+        <div className="shrink-0 rounded-xl flex flex-col items-center justify-center"
+          style={{ width: 46, height: 46, background: pasado ? "#f3f4f6" : "linear-gradient(135deg, #e8eef8 0%, #d4e0f5 100%)", color: pasado ? "#9ca3af" : "var(--azul-egm)" }}>
+          <span className="text-lg font-bold leading-none">{new Date(evento.fecha + "T00:00:00").getDate()}</span>
+          <span className="text-[10px] font-semibold uppercase tracking-wide leading-none mt-0.5">
+            {new Date(evento.fecha + "T00:00:00").toLocaleDateString("es-ES", { month: "short" })}
+          </span>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold leading-snug text-sm" style={{ color: "#111827" }}>
+            {evento.titulo}
+          </h3>
+          <p className="text-xs mt-0.5" style={{ color: "#9ca3af" }}>
+            {formatFecha(evento.fecha)}
+            {evento.horaInicio && ` · ${evento.horaInicio}${evento.horaFin ? ` – ${evento.horaFin}` : ""}`}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Badge estado */}
+          <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full"
+            style={{ background: cfg.bg, color: cfg.color }}>
+            {cfg.label}
+          </span>
+
+          {/* Menú superadmin */}
+          {esSuperAdmin && (
+            <div ref={menuRef} style={{ position: "relative" }}>
+              <button
+                onClick={() => setMenuOpen(p => !p)}
+                className="flex items-center justify-center rounded-lg"
+                style={{ width: 30, height: 30, background: menuOpen ? "rgba(0,0,0,0.06)" : "transparent", border: "none", cursor: "pointer", color: "#9ca3af" }}
+                onMouseEnter={e => { e.currentTarget.style.background = "rgba(0,0,0,0.06)"; }}
+                onMouseLeave={e => { if (!menuOpen) e.currentTarget.style.background = "transparent"; }}
+              >
+                <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24">
+                  <circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/>
+                </svg>
+              </button>
+              {menuOpen && (
+                <div style={{
+                  position: "absolute", right: 0, top: "calc(100% + 6px)", width: "180px", zIndex: 20,
+                  background: "#fff", border: "1px solid rgba(0,0,0,0.08)", borderRadius: "14px",
+                  boxShadow: "0 8px 28px rgba(0,0,0,0.12)", padding: "6px",
+                }}>
+                  <MenuBtn label="Editar" onClick={() => { setMenuOpen(false); onEditar(evento); }}
+                    icon={<svg width="15" height="15" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.9}><path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>} />
+                  <MenuBtn label="Cancelar" danger onClick={() => { setMenuOpen(false); onDesactivar(evento); }}
+                    icon={<svg width="15" height="15" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.9}><path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/></svg>} />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Cuerpo */}
+      {(evento.descripcion || evento.lugar) && (
+        <>
+          <div style={{ height: "1px", background: "rgba(0,0,0,0.06)", margin: "0 16px" }} />
+          <div className="px-4 py-3 flex flex-col gap-2">
+            {evento.descripcion && (
+              <p className="text-xs leading-relaxed line-clamp-2" style={{ color: "#6b7280" }}>
+                {evento.descripcion}
+              </p>
+            )}
+            {evento.lugar && (
+              <div className="flex items-center gap-1.5">
+                <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} style={{ color: "#9ca3af", flexShrink: 0 }}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/><path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+                </svg>
+                <span className="text-xs" style={{ color: "#9ca3af" }}>{evento.lugar}</span>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Footer */}
+      {evento.urlInfo && (
+        <div className="px-4 pb-4 mt-auto">
+          <a href={evento.urlInfo} target="_blank" rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs font-semibold"
+            style={{ color: "var(--azul-egm)" }}>
+            Más información
+            <svg width="11" height="11" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+            </svg>
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MenuBtn({ label, icon, danger = false, onClick }: {
+  label: string; icon: React.ReactNode; danger?: boolean; onClick: () => void;
+}) {
+  const [hov, setHov] = useState(false);
+  return (
+    <button onClick={onClick}
+      onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
+      style={{
+        display: "flex", alignItems: "center", gap: "10px", width: "100%",
+        padding: "7px 10px", borderRadius: "10px", border: "none", cursor: "pointer",
+        background: hov ? (danger ? "rgba(239,68,68,0.07)" : "rgba(0,0,0,0.045)") : "transparent",
+        transition: "background 0.15s",
+      }}
+    >
+      <span style={{ width: 28, height: 28, borderRadius: "8px", display: "flex", alignItems: "center", justifyContent: "center", background: danger ? "rgba(239,68,68,0.07)" : "rgba(0,0,0,0.05)", color: danger ? "#ef4444" : "#374151", flexShrink: 0 }}>{icon}</span>
+      <span style={{ flex: 1, fontSize: "13px", fontWeight: 500, color: danger ? "#ef4444" : "#111827" }}>{label}</span>
+      <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2} style={{ color: danger ? "#ef4444" : "#9ca3af" }}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7"/>
+      </svg>
+    </button>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div className="rounded-2xl overflow-hidden" style={{ background: "#fff", border: "1px solid rgba(0,0,0,0.07)" }}>
+      <div className="flex items-center gap-3 px-4 py-4">
+        <div className="rounded-xl shrink-0" style={{ width: 46, height: 46, background: "#e5e7eb" }} />
+        <div className="flex-1 flex flex-col gap-2">
+          <div style={{ height: 14, width: "55%", background: "#e5e7eb", borderRadius: 6 }} />
+          <div style={{ height: 11, width: "35%", background: "#f3f4f6", borderRadius: 6 }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Página ────────────────────────────────────────────────────────────────────
+export default function EventosPage() {
+  const { user } = useAuth();
+  const esSuperAdmin = user?.rol === "ROLE_ADMIN";
+
+  const [eventos,   setEventos]   = useState<Evento[]>([]);
+  const [cargando,  setCargando]  = useState(true);
+  const [toast,     setToast]     = useState<{ msg: string; tipo: "ok" | "err" } | null>(null);
+
+  const mostrarToast = useCallback((msg: string, tipo: "ok" | "err" = "ok") => {
+    setToast({ msg, tipo });
+    setTimeout(() => setToast(null), 2200);
+  }, []);
+
+  useEffect(() => {
+    const useMock = true; // ← false cuando el backend esté listo
+    if (useMock) {
+      setTimeout(() => { setEventos(MOCK_EVENTOS); setCargando(false); }, 500);
+      return;
+    }
+    getEventos()
+      .then(setEventos)
+      .catch(() => mostrarToast("Error al cargar los eventos", "err"))
+      .finally(() => setCargando(false));
+  }, [mostrarToast]);
+
+  async function handleDesactivar(evento: Evento) {
+    try {
+      await desactivarEvento(evento.eventoId);
+      setEventos(prev => prev.filter(e => e.eventoId !== evento.eventoId));
+      mostrarToast("Evento cancelado");
+    } catch {
+      mostrarToast("Error al cancelar el evento", "err");
+    }
+  }
+
+  // Separar próximos de pasados
+  const proximos  = eventos.filter(e => calcEstado(e) !== "FINALIZADO" && calcEstado(e) !== "CANCELADO");
+  const pasados   = eventos.filter(e => calcEstado(e) === "FINALIZADO" || calcEstado(e) === "CANCELADO");
+
+  return (
+    <div className="flex flex-col gap-6 pb-10">
+      <DashboardHero
+        title="Eventos"
+        subtitle="Actividades, jornadas y encuentros del área empresarial EGM Atalayas."
+        actions={esSuperAdmin ? (
+          <Button variant="primary" onClick={() => mostrarToast("Próximamente — modal de evento")}>
+            <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2} className="mr-1.5">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4"/>
+            </svg>
+            Nuevo evento
+          </Button>
+        ) : undefined}
+      />
+
+      <div className="px-4 sm:px-6 lg:px-8 flex flex-col gap-8">
+
+        {/* Próximos */}
+        <section>
+          <h2 className="text-sm font-semibold uppercase tracking-wider mb-3" style={{ color: "#9ca3af" }}>
+            Próximos
+          </h2>
+          {cargando ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {[1, 2, 3].map(i => <SkeletonCard key={i} />)}
+            </div>
+          ) : proximos.length === 0 ? (
+            <div className="rounded-2xl flex flex-col items-center justify-center py-14 gap-3"
+              style={{ background: "#f9fafb", border: "1px solid rgba(0,0,0,0.06)" }}>
+              <svg width="36" height="36" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.4} style={{ color: "#d1d5db" }}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+              </svg>
+              <p className="text-sm" style={{ color: "#9ca3af" }}>No hay eventos próximos</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {proximos.map(e => (
+                <EventoCard key={e.eventoId} evento={e} esSuperAdmin={esSuperAdmin}
+                  onEditar={() => mostrarToast("Próximamente — editar evento")}
+                  onDesactivar={handleDesactivar}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Pasados */}
+        {!cargando && pasados.length > 0 && (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wider mb-3" style={{ color: "#9ca3af" }}>
+              Anteriores
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {pasados.map(e => (
+                <EventoCard key={e.eventoId} evento={e} esSuperAdmin={esSuperAdmin}
+                  onEditar={() => mostrarToast("Próximamente — editar evento")}
+                  onDesactivar={handleDesactivar}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+
+      {/* Toast */}
+      {toast && (
+        <div style={{
+          position: "fixed", bottom: `calc(28px + env(safe-area-inset-bottom))`,
+          left: "50%", transform: "translateX(-50%)", zIndex: 99999,
+          background: toast.tipo === "ok" ? "#111827" : "#dc2626",
+          color: "#fff", borderRadius: "14px", padding: "12px 20px",
+          fontSize: "0.875rem", fontWeight: 600,
+          display: "flex", alignItems: "center", gap: "10px",
+          boxShadow: "0 8px 24px rgba(0,0,0,0.25)",
+          animation: "toast-in 0.25s cubic-bezier(0.34,1.20,0.64,1) both",
+          whiteSpace: "nowrap",
+        }}>
+          <style>{`@keyframes toast-in { from { opacity:0; transform:translateX(-50%) translateY(12px) } to { opacity:1; transform:translateX(-50%) translateY(0) } }`}</style>
+          {toast.tipo === "ok"
+            ? <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#22c55e" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+            : <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+          }
+          {toast.msg}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/dashboard/servicios/page.tsx
+++ b/app/dashboard/servicios/page.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import DashboardHero from "@/components/ui/DashboardHero";
+import { Button }    from "@/components/ui/Button";
+import { useAuth }   from "@/context/AuthContext";
+import { getIconoBeneficio } from "@/lib/iconosBeneficio";
+import { getServicios, crearServicio, editarServicio, desactivarServicio } from "@/lib/api/servicios";
+import type { Servicio, ServicioInput, CategoriaServicio } from "@/lib/types/servicios";
+import ServicioModal  from "@/components/ui/ServicioModal";
+import ConfirmDialog  from "@/components/ui/ConfirmDialog";
+
+// ── Mock mientras no esté el backend conectado ───────────────────────────────
+const MOCK_SERVICIOS: Servicio[] = [
+  // MOVILIDAD
+  {
+    servicioId: "m1", titulo: "Autobús lanzadera", categoria: "MOVILIDAD",
+    descripcion: "Líneas 7 y 7P con frecuencias adaptadas al horario laboral. Bonos desde 7,50 €/mes.",
+    iconoUrl: "transporte", urlInfo: "https://atalayas.com/autobus-lanzadera/",
+    telefono: null, comoAcceder: "Adquiere tu bono en el portal de movilidad o en la parada de la línea 7.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  {
+    servicioId: "m2", titulo: "Coche compartido", categoria: "MOVILIDAD",
+    descripcion: "Plataforma Journify para compartir trayectos con compañeros del área. Ahorro de hasta 2.500 €/año.",
+    iconoUrl: "parking", urlInfo: "https://atalayas.com/journify-coche-compartido/",
+    telefono: null, comoAcceder: "Regístrate en Journify con tu correo corporativo y publica o busca tu ruta habitual.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  {
+    servicioId: "m3", titulo: "Aparcamiento VAO", categoria: "MOVILIDAD",
+    descripcion: "Plazas exclusivas para vehículos de alta ocupación (3-5 personas). Solicitud renovable cada 6 meses.",
+    iconoUrl: "parking", urlInfo: "https://atalayas.com/aparcamientovao/",
+    telefono: null, comoAcceder: "Forma un grupo de 3 a 5 trabajadores, registraos en Journify y solicitad la tarjeta VAO en recepción.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  // INSTALACIONES
+  {
+    servicioId: "i1", titulo: "Ludoteca", categoria: "INSTALACIONES",
+    descripcion: "Centro educativo para bebés y niños en el edificio principal. Horario adaptado a la jornada laboral.",
+    iconoUrl: "regalo", urlInfo: null,
+    telefono: "647 76 33 89", comoAcceder: "Contacta por teléfono para reservar plaza y conocer el horario vigente.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  {
+    servicioId: "i2", titulo: "Aula de formación", categoria: "INSTALACIONES",
+    descripcion: "Sala con capacidad para 24-30 personas, proyector, WiFi y pizarra. Disponible para empresas del área.",
+    iconoUrl: "formacion", urlInfo: null,
+    telefono: null, comoAcceder: "Reserva la sala a través del formulario de solicitud en la web de EGM Atalayas.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  {
+    servicioId: "i3", titulo: "Oficinas y salas de reuniones", categoria: "INSTALACIONES",
+    descripcion: "Oficinas amuebladas desde 20 m² y salas de reuniones para alquiler puntual.",
+    iconoUrl: "formacion", urlInfo: null,
+    telefono: null, comoAcceder: "Contacta con recepción para consultar disponibilidad y tarifas.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  // INICIATIVAS
+  {
+    servicioId: "n1", titulo: "Empresas Solidarias", categoria: "INICIATIVAS",
+    descripcion: "Programa colectivo de ayuda a familias en riesgo de exclusión. Más de 44.000 personas beneficiadas desde 2010.",
+    iconoUrl: "seguro", urlInfo: "https://atalayas.com/empresas-solidarias/",
+    telefono: null, comoAcceder: "Habla con tu empresa para sumarse al proyecto o contacta con EGM Atalayas directamente.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  {
+    servicioId: "n2", titulo: "En Femenino", categoria: "INICIATIVAS",
+    descripcion: "Red de visibilidad del talento femenino en el área empresarial. Jornadas, mesas redondas y mentoría.",
+    iconoUrl: "deporte", urlInfo: "https://atalayas.com/en-femenino/",
+    telefono: null, comoAcceder: "Sigue las próximas jornadas en la web y apúntate a través del formulario de inscripción.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  // COMUNES
+  {
+    servicioId: "c1", titulo: "Seguridad 24 h", categoria: "COMUNES",
+    descripcion: "Vigilancia y protección de zonas comunes del área empresarial durante todo el día.",
+    iconoUrl: "seguro", urlInfo: null,
+    telefono: null, comoAcceder: "Servicio permanente. Ante cualquier incidencia, usa el canal de notificación en el dashboard.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+  {
+    servicioId: "c2", titulo: "Correos y paquetería", categoria: "COMUNES",
+    descripcion: "Buzones centralizados para todas las empresas del parque. Atención al público de 11:30 a 13:30.",
+    iconoUrl: "compras", urlInfo: null,
+    telefono: null, comoAcceder: "Accede directamente a la zona de buzones en el edificio central en el horario indicado.",
+    creadoPor: null, activo: true, creadoEn: "", actualizadoEn: "",
+  },
+];
+
+const CATEGORIAS: { value: CategoriaServicio; label: string; icono: React.ReactNode }[] = [
+  {
+    value: "MOVILIDAD",
+    label: "Movilidad",
+    icono: <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><rect x="1" y="3" width="15" height="13" rx="2"/><path d="M16 8h4l3 3v5h-7V8zM5.5 21a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM19.5 21a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/></svg>,
+  },
+  {
+    value: "INSTALACIONES",
+    label: "Instalaciones",
+    icono: <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><path strokeLinecap="round" strokeLinejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0H5m-2 0h2M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>,
+  },
+  {
+    value: "INICIATIVAS",
+    label: "Iniciativas",
+    icono: <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/></svg>,
+  },
+  {
+    value: "COMUNES",
+    label: "Servicios comunes",
+    icono: <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}><path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>,
+  },
+];
+
+// ── Fila de servicio ──────────────────────────────────────────────────────────
+function FilaServicio({
+  servicio, esSuperAdmin, onEditar, onDesactivar,
+}: {
+  servicio: Servicio; esSuperAdmin: boolean;
+  onEditar: (s: Servicio) => void; onDesactivar: (s: Servicio) => void;
+}) {
+  const [expandido, setExpandido] = useState(false);
+  const [menuOpen,  setMenuOpen]  = useState(false);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const iconoNode = getIconoBeneficio(servicio.iconoUrl);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onOut(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    }
+    document.addEventListener("mousedown", onOut);
+    return () => document.removeEventListener("mousedown", onOut);
+  }, [menuOpen]);
+
+  return (
+    <div
+      className="flex flex-col"
+      style={{
+        borderBottom: "1px solid rgba(0,0,0,0.06)",
+        transition: "background 0.15s ease",
+      }}
+    >
+      {/* Fila principal */}
+      <button
+        type="button"
+        onClick={() => setExpandido(p => !p)}
+        className="flex items-center gap-4 px-5 py-4 text-left w-full"
+        style={{ background: "transparent", border: "none", cursor: "pointer" }}
+        onMouseEnter={e => { e.currentTarget.style.background = "rgba(27,63,126,0.03)"; }}
+        onMouseLeave={e => { e.currentTarget.style.background = "transparent"; }}
+      >
+        {/* Icono */}
+        <div
+          className="shrink-0 rounded-xl flex items-center justify-center"
+          style={{
+            width: "44px", height: "44px",
+            background: "linear-gradient(135deg, #e8eef8 0%, #d4e0f5 100%)",
+            color: "var(--azul-egm)",
+            boxShadow: "inset 0 1px 2px rgba(255,255,255,0.8), 0 1px 4px rgba(27,63,126,0.10)",
+            position: "relative", overflow: "hidden", flexShrink: 0,
+          }}
+        >
+          {iconoNode ? (
+            <span style={{
+              position: "absolute", top: "50%", left: "50%",
+              transform: "translate(-50%,-50%) scale(0.61)", display: "flex",
+            }}>
+              {iconoNode}
+            </span>
+          ) : (
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.7}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+          )}
+        </div>
+
+        {/* Texto */}
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold text-sm leading-snug" style={{ color: "#111827" }}>
+            {servicio.titulo}
+          </p>
+          {servicio.descripcion && !expandido && (
+            <p className="text-xs mt-0.5 line-clamp-1" style={{ color: "#6b7280" }}>
+              {servicio.descripcion}
+            </p>
+          )}
+        </div>
+
+        {/* Acciones SuperAdmin */}
+        {esSuperAdmin && (
+          <div ref={menuRef} onClick={e => e.stopPropagation()} style={{ position: "relative", flexShrink: 0 }}>
+            <button
+              onClick={() => setMenuOpen(p => !p)}
+              className="flex items-center justify-center rounded-lg"
+              style={{
+                width: "30px", height: "30px",
+                background: menuOpen ? "rgba(0,0,0,0.06)" : "transparent",
+                border: "none", cursor: "pointer", color: "#9ca3af",
+              }}
+              onMouseEnter={e => { e.currentTarget.style.background = "rgba(0,0,0,0.06)"; }}
+              onMouseLeave={e => { if (!menuOpen) e.currentTarget.style.background = "transparent"; }}
+            >
+              <svg width="15" height="15" fill="currentColor" viewBox="0 0 24 24">
+                <circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/>
+              </svg>
+            </button>
+            {menuOpen && (
+              <div style={{
+                position: "absolute", right: 0, top: "calc(100% + 6px)", width: "180px", zIndex: 20,
+                background: "#fff", border: "1px solid rgba(0,0,0,0.08)", borderRadius: "14px",
+                boxShadow: "0 8px 28px rgba(0,0,0,0.12)", padding: "6px",
+              }}>
+                <MenuBtn label="Editar" onClick={() => { setMenuOpen(false); onEditar(servicio); }}
+                  icon={<svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.9}><path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>}
+                />
+                <MenuBtn label="Desactivar" danger onClick={() => { setMenuOpen(false); onDesactivar(servicio); }}
+                  icon={<svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.9}><path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/></svg>}
+                />
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Chevron expandir */}
+        <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          style={{
+            color: "#9ca3af", flexShrink: 0,
+            transform: expandido ? "rotate(90deg)" : "rotate(0deg)",
+            transition: "transform 0.2s cubic-bezier(0.34,1.20,0.64,1)",
+          }}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7"/>
+        </svg>
+      </button>
+
+      {/* Detalle expandido */}
+      <div style={{
+        overflow: "hidden",
+        maxHeight: expandido ? "400px" : "0px",
+        opacity: expandido ? 1 : 0,
+        transition: "max-height 0.28s cubic-bezier(0.34,1.20,0.64,1), opacity 0.2s ease",
+      }}>
+        <div className="px-5 pb-5 flex flex-col gap-3" style={{ paddingLeft: "77px" }}>
+          {servicio.descripcion && (
+            <p className="text-sm leading-relaxed" style={{ color: "#6b7280" }}>{servicio.descripcion}</p>
+          )}
+          {servicio.comoAcceder && (
+            <div className="flex items-start gap-2.5 rounded-xl px-3 py-2.5" style={{ background: "rgba(27,63,126,0.05)" }}>
+              <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                style={{ color: "var(--azul-egm)", flexShrink: 0, marginTop: "2px" }}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+              </svg>
+              <p className="text-xs leading-relaxed" style={{ color: "var(--azul-egm)" }}>{servicio.comoAcceder}</p>
+            </div>
+          )}
+          <div className="flex items-center gap-4 flex-wrap">
+            {servicio.urlInfo && (
+              <a href={servicio.urlInfo} target="_blank" rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs font-semibold"
+                style={{ color: "var(--azul-egm)" }}>
+                Más información
+                <svg width="11" height="11" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+                </svg>
+              </a>
+            )}
+            {servicio.telefono && (
+              <a href={`tel:${servicio.telefono}`}
+                className="inline-flex items-center gap-1.5 text-xs font-semibold"
+                style={{ color: "#6b7280" }}>
+                <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                </svg>
+                {servicio.telefono}
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Botón mini menú ───────────────────────────────────────────────────────────
+function MenuBtn({ label, icon, danger = false, onClick }: {
+  label: string; icon: React.ReactNode; danger?: boolean; onClick: () => void;
+}) {
+  const [hov, setHov] = useState(false);
+  return (
+    <button onClick={onClick}
+      onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
+      style={{
+        display: "flex", alignItems: "center", gap: "10px", width: "100%",
+        padding: "7px 10px", borderRadius: "10px", border: "none", cursor: "pointer",
+        background: hov ? (danger ? "rgba(239,68,68,0.07)" : "rgba(0,0,0,0.045)") : "transparent",
+        transition: "background 0.15s",
+      }}
+    >
+      <span style={{
+        width: "28px", height: "28px", borderRadius: "8px", display: "flex",
+        alignItems: "center", justifyContent: "center",
+        background: danger ? "rgba(239,68,68,0.07)" : "rgba(0,0,0,0.05)",
+        color: danger ? "#ef4444" : "#374151", flexShrink: 0,
+      }}>{icon}</span>
+      <span style={{ flex: 1, fontSize: "13px", fontWeight: 500, color: danger ? "#ef4444" : "#111827" }}>{label}</span>
+      <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}
+        style={{ color: danger ? "#ef4444" : "#9ca3af" }}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7"/>
+      </svg>
+    </button>
+  );
+}
+
+// ── Skeleton ──────────────────────────────────────────────────────────────────
+function SkeletonFila() {
+  return (
+    <div className="flex items-center gap-4 px-5 py-4" style={{ borderBottom: "1px solid rgba(0,0,0,0.06)" }}>
+      <div className="rounded-xl shrink-0" style={{ width: 44, height: 44, background: "#e5e7eb" }} />
+      <div className="flex-1 flex flex-col gap-2">
+        <div style={{ height: 14, width: "40%", background: "#e5e7eb", borderRadius: 6 }} />
+        <div style={{ height: 11, width: "65%", background: "#f3f4f6", borderRadius: 6 }} />
+      </div>
+    </div>
+  );
+}
+
+// ── Página principal ──────────────────────────────────────────────────────────
+export default function ServiciosPage() {
+  const { user } = useAuth();
+  const esSuperAdmin = user?.rol === "ROLE_ADMIN";
+
+  const [servicios,  setServicios]  = useState<Servicio[]>([]);
+  const [cargando,   setCargando]   = useState(true);
+  const [modalOpen,  setModalOpen]  = useState(false);
+  const [editando,   setEditando]   = useState<Servicio | null>(null);
+  const [confirmDes, setConfirmDes] = useState<Servicio | null>(null);
+  const [toast,      setToast]      = useState<{ msg: string; tipo: "ok" | "err" } | null>(null);
+
+  const mostrarToast = useCallback((msg: string, tipo: "ok" | "err" = "ok") => {
+    setToast({ msg, tipo });
+    setTimeout(() => setToast(null), 2200);
+  }, []);
+
+  useEffect(() => {
+    const useMock = true; // ← cambiar a false cuando el backend esté conectado
+    if (useMock) {
+      setTimeout(() => { setServicios(MOCK_SERVICIOS); setCargando(false); }, 600);
+      return;
+    }
+    getServicios()
+      .then(setServicios)
+      .catch(() => mostrarToast("Error al cargar los servicios", "err"))
+      .finally(() => setCargando(false));
+  }, [mostrarToast]);
+
+  async function handleGuardar(data: ServicioInput) {
+    if (editando) {
+      const updated = await editarServicio(editando.servicioId, data);
+      setServicios(prev => prev.map(s => s.servicioId === updated.servicioId ? updated : s));
+    } else {
+      const nuevo = await crearServicio(data);
+      setServicios(prev => [nuevo, ...prev]);
+    }
+  }
+
+  async function confirmarDesactivar(servicio: Servicio) {
+    try {
+      await desactivarServicio(servicio.servicioId);
+      setServicios(prev => prev.filter(s => s.servicioId !== servicio.servicioId));
+      mostrarToast("Servicio desactivado");
+    } catch {
+      mostrarToast("Error al desactivar el servicio", "err");
+    }
+    setConfirmDes(null);
+  }
+
+  // Agrupar por categoría en el orden definido
+  const porCategoria = CATEGORIAS.map(cat => ({
+    ...cat,
+    items: servicios.filter(s => s.categoria === cat.value),
+  })).filter(g => g.items.length > 0 || cargando);
+
+  return (
+    <div className="flex flex-col gap-6 pb-10">
+      <DashboardHero
+        title="Servicios"
+        subtitle="Recursos y servicios del área empresarial EGM Atalayas disponibles para todos los trabajadores."
+        actions={esSuperAdmin ? (
+          <Button variant="primary" onClick={() => { setEditando(null); setModalOpen(true); }}>
+            <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2} className="mr-1.5">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4"/>
+            </svg>
+            Nuevo servicio
+          </Button>
+        ) : undefined}
+      />
+
+      <div className="px-4 sm:px-6 lg:px-8 flex flex-col gap-6">
+        {cargando ? (
+          // Skeleton agrupado
+          CATEGORIAS.map(cat => (
+            <div key={cat.value} className="rounded-2xl overflow-hidden" style={{ background: "#fff", border: "1px solid rgba(0,0,0,0.07)", boxShadow: "0 2px 12px rgba(0,0,0,0.05)" }}>
+              <div className="flex items-center gap-3 px-5 py-3.5" style={{ borderBottom: "1px solid rgba(0,0,0,0.07)", background: "#f9fafb" }}>
+                <div style={{ width: 18, height: 18, background: "#e5e7eb", borderRadius: 4 }} />
+                <div style={{ width: 100, height: 14, background: "#e5e7eb", borderRadius: 6 }} />
+              </div>
+              {[1, 2].map(i => <SkeletonFila key={i} />)}
+            </div>
+          ))
+        ) : (
+          porCategoria.map(grupo => (
+            <div key={grupo.value}
+              className="rounded-2xl overflow-hidden"
+              style={{ background: "#fff", border: "1px solid rgba(0,0,0,0.07)", boxShadow: "0 2px 12px rgba(0,0,0,0.05)" }}
+            >
+              {/* Cabecera de categoría */}
+              <div className="flex items-center gap-3 px-5 py-3.5"
+                style={{ borderBottom: "1px solid rgba(0,0,0,0.07)", background: "#f9fafb" }}>
+                <span style={{ color: "var(--azul-egm)" }}>{grupo.icono}</span>
+                <span className="font-semibold text-sm" style={{ color: "#374151" }}>{grupo.label}</span>
+                <span className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full"
+                  style={{ background: "rgba(27,63,126,0.08)", color: "var(--azul-egm)" }}>
+                  {grupo.items.length}
+                </span>
+              </div>
+
+              {/* Filas */}
+              {grupo.items.map(s => (
+                <FilaServicio
+                  key={s.servicioId}
+                  servicio={s}
+                  esSuperAdmin={esSuperAdmin}
+                  onEditar={s => { setEditando(s); setModalOpen(true); }}
+                  onDesactivar={s => setConfirmDes(s)}
+                />
+              ))}
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Modal crear / editar */}
+      {modalOpen && (
+        <ServicioModal
+          inicial={editando}
+          onGuardar={handleGuardar}
+          onCerrar={() => { setModalOpen(false); setEditando(null); }}
+        />
+      )}
+
+      {/* Confirm desactivar */}
+      {confirmDes && (
+        <ConfirmDialog
+          title="¿Desactivar servicio?"
+          description={`"${confirmDes.titulo}" dejará de ser visible para los empleados.`}
+          confirmLabel="Desactivar"
+          danger
+          onConfirm={() => confirmarDesactivar(confirmDes)}
+          onCancel={() => setConfirmDes(null)}
+        />
+      )}
+
+      {/* Toast */}
+      {toast && (
+        <div style={{
+          position: "fixed", bottom: `calc(28px + env(safe-area-inset-bottom))`,
+          left: "50%", transform: "translateX(-50%)", zIndex: 99999,
+          background: toast.tipo === "ok" ? "#111827" : "#dc2626",
+          color: "#fff", borderRadius: "14px", padding: "12px 20px",
+          fontSize: "0.875rem", fontWeight: 600,
+          display: "flex", alignItems: "center", gap: "10px",
+          boxShadow: "0 8px 24px rgba(0,0,0,0.25)",
+          animation: "toast-in 0.25s cubic-bezier(0.34,1.20,0.64,1) both",
+          whiteSpace: "nowrap",
+        }}>
+          <style>{`@keyframes toast-in { from { opacity:0; transform:translateX(-50%) translateY(12px) } to { opacity:1; transform:translateX(-50%) translateY(0) } }`}</style>
+          {toast.tipo === "ok"
+            ? <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#22c55e" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+            : <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+          }
+          {toast.msg}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/dashboard/servicios/page.tsx
+++ b/app/dashboard/servicios/page.tsx
@@ -325,8 +325,8 @@ function SkeletonFila() {
 
 // ── Página principal ──────────────────────────────────────────────────────────
 export default function ServiciosPage() {
-  const { user } = useAuth();
-  const esSuperAdmin = user?.rol === "ROLE_ADMIN";
+  const { usuario } = useAuth();
+  const esSuperAdmin = usuario?.codigoRol === "ROLE_ADMIN";
 
   const [servicios,  setServicios]  = useState<Servicio[]>([]);
   const [cargando,   setCargando]   = useState(true);
@@ -382,17 +382,20 @@ export default function ServiciosPage() {
   return (
     <div className="flex flex-col gap-6 pb-10">
       <DashboardHero
-        title="Servicios"
-        subtitle="Recursos y servicios del área empresarial EGM Atalayas disponibles para todos los trabajadores."
-        actions={esSuperAdmin ? (
+        titulo="Servicios"
+        subtitulo="Recursos y servicios del área empresarial EGM Atalayas disponibles para todos los trabajadores."
+        variante="seccion"
+      />
+      {esSuperAdmin && (
+        <div className="px-4 sm:px-6 lg:px-8 -mt-2">
           <Button variant="primary" onClick={() => { setEditando(null); setModalOpen(true); }}>
             <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2} className="mr-1.5">
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4"/>
             </svg>
             Nuevo servicio
           </Button>
-        ) : undefined}
-      />
+        </div>
+      )}
 
       <div className="px-4 sm:px-6 lg:px-8 flex flex-col gap-6">
         {cargando ? (
@@ -450,12 +453,12 @@ export default function ServiciosPage() {
       {/* Confirm desactivar */}
       {confirmDes && (
         <ConfirmDialog
-          title="¿Desactivar servicio?"
-          description={`"${confirmDes.titulo}" dejará de ser visible para los empleados.`}
-          confirmLabel="Desactivar"
-          danger
-          onConfirm={() => confirmarDesactivar(confirmDes)}
-          onCancel={() => setConfirmDes(null)}
+          titulo="¿Desactivar servicio?"
+          mensaje={`"${confirmDes.titulo}" dejará de ser visible para los empleados.`}
+          labelOk="Desactivar"
+          peligro
+          onOk={() => confirmarDesactivar(confirmDes)}
+          onCerrar={() => setConfirmDes(null)}
         />
       )}
 

--- a/components/pages/AdminEmpresa.tsx
+++ b/components/pages/AdminEmpresa.tsx
@@ -5,10 +5,11 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { apiFetch, API_URL } from "@/lib/api";
 import { getActividadReciente } from "@/lib/api/progreso";
-import { getServicios } from "@/lib/api/servicios";
+
 import { getModulos, getMiProgreso } from "@/lib/api/modulos";
 import type { ActividadItem } from "@/lib/types/progreso";
-import type { Servicio } from "@/lib/types/servicios";
+// Widget simplificado de servicios (pantalla inicio, no la página /servicios)
+type Servicio = { servicioId: string; nombre: string; descripcion: string | null; url: string | null; activo: boolean; icono: string | null; orden: number; };
 import type { Modulo, ProgresoItem } from "@/lib/types/modulos";
 import DashboardHero from "@/components/ui/DashboardHero";
 
@@ -161,11 +162,10 @@ export default function AdminEmpresa() {
   useEffect(() => {
     async function cargarDatos() {
       try {
-        const [resRes, anunciosRes, actividadData, serviciosData, modulosData, progresoData] = await Promise.all([
+        const [resRes, anunciosRes, actividadData, modulosData, progresoData] = await Promise.all([
           apiFetch(`${API_URL}/dashboard/admin/resumen`),
           apiFetch(`${API_URL}/anuncios`),
           getActividadReciente(5).catch(() => [] as ActividadItem[]),
-          getServicios().catch(() => []),
           getModulos().catch(() => [] as Modulo[]),
           getMiProgreso().catch(() => [] as ProgresoItem[]),
         ]);
@@ -175,9 +175,7 @@ export default function AdminEmpresa() {
           setAnuncios(data.filter((a: Anuncio) => a.activo).slice(0, 4));
         }
         setActividad(actividadData);
-        if (serviciosData && serviciosData.length > 0) {
-          setServicios(serviciosData);
-        }
+        // servicios: usa mock hasta conectar el nuevo endpoint
 
         // Calcular estadísticas reales de módulos
         const modulos = modulosData.filter((m: Modulo) => m.activo);

--- a/components/pages/Empleado.tsx
+++ b/components/pages/Empleado.tsx
@@ -7,10 +7,11 @@ import DashboardHero from "@/components/ui/DashboardHero";
 import { useAuth } from "@/context/AuthContext";
 import { getNoticias } from "@/lib/api/noticias";
 import { getModulosConProgreso } from "@/lib/api/modulos";
-import { getServicios } from "@/lib/api/servicios";
+
 import type { Noticia } from "@/lib/types/noticias";
 import type { ModuloConProgreso } from "@/lib/types/modulos";
-import type { Servicio } from "@/lib/types/servicios";
+// Widget simplificado de servicios (pantalla inicio, no la página /servicios)
+type Servicio = { servicioId: string; nombre: string; descripcion: string | null; url: string | null; activo: boolean; icono: string | null; orden: number; };
 import ComunicadosCarousel, { ComunicadoItem } from "@/components/ui/ComunicadosCarousel";
 import DotField from "@/components/ui/DotField";
 import BiIcon from "@/components/ui/BiIcon";
@@ -146,10 +147,9 @@ export default function Empleado() {
   useEffect(() => {
     async function cargarDatos() {
       try {
-        const [noticiasData, modulosData, serviciosData] = await Promise.all([
+        const [noticiasData, modulosData] = await Promise.all([
           getNoticias(usuario?.empresaId).catch(() => []),
           getModulosConProgreso().catch(() => []),
-          getServicios().catch(() => []),
         ]);
         setNoticias((noticiasData as Noticia[]).slice(0, 6));
         const real = (modulosData as ModuloConProgreso[]).sort((a, b) => a.orden - b.orden);
@@ -157,9 +157,7 @@ export default function Empleado() {
         if (real.length === 0) {
           setFormacionesLocal(applyProgress(MOCK_FORMACIONES_BASE, loadProgress()));
         }
-        if (serviciosData && serviciosData.length > 0) {
-          setServicios(serviciosData);
-        }
+        // servicios: usa mock hasta conectar el nuevo endpoint
       } finally {
         setCargando(false);
       }

--- a/components/ui/ServicioModal.tsx
+++ b/components/ui/ServicioModal.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { createPortal } from "react-dom";
+import type { Servicio, ServicioInput, CategoriaServicio } from "@/lib/types/servicios";
+import { Button } from "@/components/ui/Button";
+import { ICONOS_BENEFICIO } from "@/lib/iconosBeneficio";
+import Grainient from "@/components/ui/Grainient";
+
+interface Props {
+  inicial:   Servicio | null;
+  onGuardar: (data: ServicioInput) => Promise<void>;
+  onCerrar:  () => void;
+}
+
+const CAMPO_BASE =
+  "w-full rounded-xl px-3.5 text-sm outline-none transition-all duration-150 border";
+const ALTURA_CAMPO = "44px";
+
+const estiloInput = (foco: boolean) => ({
+  borderColor: foco ? "var(--azul-egm)" : "rgba(0,0,0,0.12)",
+  boxShadow:   foco ? "0 0 0 3px rgba(22,50,105,0.08)" : "none",
+  background:  "#ffffff",
+  color:       "#111827",
+});
+
+const CATEGORIAS: { value: CategoriaServicio; label: string; emoji: string }[] = [
+  { value: "MOVILIDAD",     label: "Movilidad",     emoji: "🚌" },
+  { value: "INSTALACIONES", label: "Instalaciones", emoji: "🏢" },
+  { value: "INICIATIVAS",   label: "Iniciativas",   emoji: "🤝" },
+  { value: "COMUNES",       label: "Servicios comunes", emoji: "🔧" },
+];
+
+// ── Botón cerrar ──────────────────────────────────────────────────────────────
+function CloseButton({ onClick }: { onClick: () => void }) {
+  const [hovered, setHovered] = useState(false);
+  const [pressed, setPressed] = useState(false);
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => { setHovered(false); setPressed(false); }}
+      onMouseDown={() => setPressed(true)}
+      onMouseUp={() => setPressed(false)}
+      aria-label="Cerrar"
+      style={{
+        width: "38px", height: "38px", borderRadius: "11px",
+        border: "1px solid rgba(255,255,255,0.28)", cursor: "pointer",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        background: pressed ? "rgba(0,0,0,0.28)" : hovered ? "rgba(0,0,0,0.20)" : "rgba(255,255,255,0.14)",
+        color: "rgba(255,255,255,0.90)",
+        boxShadow: hovered && !pressed ? "0 4px 14px rgba(0,0,0,0.30), 0 0 0 3px rgba(0,0,0,0.12)" : "0 2px 6px rgba(0,0,0,0.18)",
+        transform: pressed ? "scale(0.88)" : hovered ? "scale(1.10)" : "scale(1)",
+        transition: "background 0.15s ease, box-shadow 0.18s cubic-bezier(0.34,1.20,0.64,1), transform 0.18s cubic-bezier(0.34,1.20,0.64,1)",
+        flexShrink: 0,
+      }}
+    >
+      <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.4}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  );
+}
+
+// ── Selector de icono ─────────────────────────────────────────────────────────
+function IconoPicker({ value, onChange }: { value: string; onChange: (key: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const [pos,  setPos]  = useState({ top: 0, left: 0, width: 0 });
+  const ref         = useRef<HTMLDivElement>(null);
+  const triggerRef  = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const selected    = ICONOS_BENEFICIO.find(i => i.key === value);
+
+  function calcPos() {
+    if (!triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    setPos({ top: r.bottom + 6, left: r.left, width: r.width });
+  }
+
+  useEffect(() => {
+    function onOut(e: MouseEvent) {
+      const t = e.target as Node;
+      if (!ref.current?.contains(t) && !dropdownRef.current?.contains(t)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onOut);
+    return () => document.removeEventListener("mousedown", onOut);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-1.5" ref={ref}>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold" style={{ color: "#374151" }}>Icono</span>
+        {value && (
+          <button type="button" onClick={() => onChange("")}
+            style={{ color: "#9ca3af", background: "none", border: "none", cursor: "pointer", fontSize: "11px", padding: 0 }}>
+            Quitar
+          </button>
+        )}
+      </div>
+      <button
+        ref={triggerRef} type="button"
+        onClick={() => { calcPos(); setOpen(p => !p); }}
+        className="w-full flex items-center gap-3 px-3.5 rounded-xl text-sm border"
+        style={{
+          height: ALTURA_CAMPO, textAlign: "left",
+          borderColor: open ? "var(--azul-egm)" : "rgba(0,0,0,0.12)",
+          boxShadow:   open ? "0 0 0 3px rgba(22,50,105,0.08)" : "none",
+          background:  "#ffffff", transition: "border-color 0.15s, box-shadow 0.15s",
+        }}
+      >
+        {selected ? (
+          <>
+            <span style={{ display: "flex", width: 22, height: 22, flexShrink: 0, overflow: "hidden", color: "var(--azul-egm)" }}>
+              <span style={{ transform: "scale(0.61)", transformOrigin: "top left", display: "flex", flexShrink: 0 }}>{selected.svg}</span>
+            </span>
+            <span className="flex-1 font-medium text-sm" style={{ color: "#111827" }}>{selected.label}</span>
+          </>
+        ) : (
+          <span style={{ color: "#9ca3af" }}>Seleccionar icono</span>
+        )}
+        <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}
+          style={{ color: "#9ca3af", transform: open ? "rotate(180deg)" : "rotate(0)", transition: "transform 0.2s", flexShrink: 0 }}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </button>
+      {open && createPortal(
+        <div ref={dropdownRef} style={{
+          position: "fixed", top: pos.top, left: pos.left, width: pos.width,
+          zIndex: 9999, background: "#fff", border: "1px solid rgba(0,0,0,0.10)",
+          borderRadius: "14px", boxShadow: "0 8px 28px rgba(0,0,0,0.13)", padding: "10px",
+        }}>
+          <div className="grid grid-cols-4 gap-1">
+            {ICONOS_BENEFICIO.map(icono => {
+              const sel = value === icono.key;
+              return (
+                <button key={icono.key} type="button" title={icono.label}
+                  onClick={() => { onChange(sel ? "" : icono.key); setOpen(false); }}
+                  style={{
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                    padding: "7px", borderRadius: "10px",
+                    border: sel ? "2px solid var(--azul-egm)" : "2px solid transparent",
+                    background: sel ? "var(--azul-egm-light)" : "transparent",
+                    color: sel ? "var(--azul-egm)" : "#6b7280", cursor: "pointer",
+                    transition: "background 0.12s, color 0.12s",
+                  }}
+                  onMouseEnter={e => { if (!sel) { e.currentTarget.style.background = "rgba(27,63,126,0.07)"; e.currentTarget.style.color = "var(--azul-egm)"; }}}
+                  onMouseLeave={e => { if (!sel) { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "#6b7280"; }}}
+                >
+                  {icono.svg}
+                </button>
+              );
+            })}
+          </div>
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}
+
+// ── Selector de categoría ─────────────────────────────────────────────────────
+function CategoriaSelector({ value, onChange }: { value: CategoriaServicio | ""; onChange: (v: CategoriaServicio) => void }) {
+  const [foco, setFoco] = useState(false);
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-semibold" style={{ color: "#374151" }}>
+        Categoría<span title="Obligatorio" style={{ color: "#ef4444", marginLeft: 2 }}>*</span>
+      </label>
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value as CategoriaServicio)}
+        onFocus={() => setFoco(true)}
+        onBlur={() => setFoco(false)}
+        className="w-full rounded-xl px-3.5 text-sm outline-none border appearance-none cursor-pointer"
+        style={{ height: ALTURA_CAMPO, ...estiloInput(foco), color: value ? "#111827" : "#9ca3af" }}
+      >
+        <option value="" disabled>Seleccionar categoría</option>
+        {CATEGORIAS.map(c => (
+          <option key={c.value} value={c.value}>{c.emoji} {c.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+// ── Campo de texto ────────────────────────────────────────────────────────────
+function Campo({
+  label, name, value, onChange, placeholder, required,
+  type = "text", multiline, rows = 3, maxLength, hint,
+}: {
+  label: string; name: string; value: string; onChange: (val: string) => void;
+  placeholder?: string; required?: boolean; type?: string;
+  multiline?: boolean; rows?: number; maxLength?: number; hint?: string;
+}) {
+  const [foco, setFoco] = useState(false);
+  const [urlValida, setUrlValida] = useState<boolean | null>(null);
+
+  function validarUrl(val: string) {
+    if (type !== "url" || !val) { setUrlValida(null); return; }
+    try { new URL(val); setUrlValida(true); } catch { setUrlValida(false); }
+  }
+
+  const shared = {
+    id: name, value,
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (maxLength && e.target.value.length > maxLength) return;
+      onChange(e.target.value);
+    },
+    onFocus: () => setFoco(true),
+    onBlur:  (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => { setFoco(false); validarUrl(e.target.value); },
+    onKeyDown: (e: React.KeyboardEvent) => { if (!multiline && e.key === "Enter") e.preventDefault(); },
+    placeholder: placeholder ?? "",
+    className: CAMPO_BASE,
+    style: estiloInput(foco),
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <label htmlFor={name} className="text-sm font-semibold" style={{ color: "#374151" }}>
+          {label}
+          {required && <span title="Obligatorio" style={{ color: "#ef4444", marginLeft: 2 }}>*</span>}
+        </label>
+        <div className="flex items-center gap-2">
+          {type === "url" && urlValida !== null && (
+            urlValida
+              ? <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#22c55e" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+              : <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+          )}
+          {maxLength && (
+            <span className="text-xs" style={{ color: value.length >= maxLength * 0.9 ? "#f59e0b" : "#d1d5db" }}>
+              {value.length}/{maxLength}
+            </span>
+          )}
+        </div>
+      </div>
+      {multiline ? (
+        <textarea {...shared} rows={rows}
+          style={{ ...shared.style, resize: "none", minHeight: `${rows * 1.6 + 1.5}rem`, overflow: "hidden", paddingTop: "10px", paddingBottom: "10px" }}
+          onInput={e => { const el = e.currentTarget; el.style.height = "auto"; el.style.height = `${el.scrollHeight}px`; }}
+        />
+      ) : (
+        <input {...shared} type={type} style={{ ...shared.style, height: ALTURA_CAMPO }} />
+      )}
+      {hint && <p className="text-xs" style={{ color: "#9ca3af" }}>{hint}</p>}
+    </div>
+  );
+}
+
+// ── Modal principal ───────────────────────────────────────────────────────────
+export default function ServicioModal({ inicial, onGuardar, onCerrar }: Props) {
+  const editando = inicial !== null;
+
+  const [form, setForm] = useState<ServicioInput>({
+    titulo:      inicial?.titulo      ?? "",
+    descripcion: inicial?.descripcion ?? "",
+    categoria:   inicial?.categoria   ?? ("" as CategoriaServicio),
+    iconoUrl:    inicial?.iconoUrl    ?? "",
+    urlInfo:     inicial?.urlInfo     ?? "",
+    telefono:    inicial?.telefono    ?? "",
+    comoAcceder: inicial?.comoAcceder ?? "",
+  });
+
+  const [guardando,    setGuardando]    = useState(false);
+  const [error,        setError]        = useState<string | null>(null);
+  const [confirmSalir, setConfirmSalir] = useState(false);
+  const [toastVisible, setToastVisible] = useState(false);
+
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef   = useRef<HTMLDivElement>(null);
+
+  const estadoInicial: ServicioInput = {
+    titulo:      inicial?.titulo      ?? "",
+    descripcion: inicial?.descripcion ?? "",
+    categoria:   inicial?.categoria   ?? ("" as CategoriaServicio),
+    iconoUrl:    inicial?.iconoUrl    ?? "",
+    urlInfo:     inicial?.urlInfo     ?? "",
+    telefono:    inicial?.telefono    ?? "",
+    comoAcceder: inicial?.comoAcceder ?? "",
+  };
+  const hayCambios = JSON.stringify(form) !== JSON.stringify(estadoInicial);
+
+  const cerrarSeguro = useCallback(() => {
+    if (hayCambios && !guardando) { setConfirmSalir(true); return; }
+    onCerrar();
+  }, [hayCambios, guardando, onCerrar]);
+
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = prev; };
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") cerrarSeguro(); }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [cerrarSeguro]);
+
+  useEffect(() => {
+    const overlay = overlayRef.current;
+    const panel   = panelRef.current;
+    if (!overlay || !panel) return;
+    overlay.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 180, easing: "ease", fill: "forwards" });
+    panel.animate(
+      [{ opacity: 0, transform: "translateY(16px) scale(0.97)" }, { opacity: 1, transform: "translateY(0) scale(1)" }],
+      { duration: 220, easing: "cubic-bezier(0.34,1.20,0.64,1)", fill: "forwards" },
+    );
+  }, []);
+
+  function set(field: keyof ServicioInput, value: string | null) {
+    setForm(prev => ({ ...prev, [field]: value === "" ? null : value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.titulo?.trim() || !form.categoria) return;
+
+    setGuardando(true);
+    setError(null);
+    try {
+      await onGuardar({
+        titulo:      form.titulo.trim(),
+        descripcion: form.descripcion  || null,
+        categoria:   form.categoria,
+        iconoUrl:    form.iconoUrl     || null,
+        urlInfo:     form.urlInfo      || null,
+        telefono:    form.telefono     || null,
+        comoAcceder: form.comoAcceder  || null,
+      });
+      setToastVisible(true);
+      setTimeout(() => { setToastVisible(false); onCerrar(); }, 1800);
+    } catch (err) {
+      console.error("[ServicioModal]", err);
+      setError("No se pudo guardar el servicio. Inténtalo de nuevo.");
+      setGuardando(false);
+    }
+  }
+
+  return (
+    <>
+      {/* Toast */}
+      {toastVisible && createPortal(
+        <div style={{
+          position: "fixed", bottom: "28px", left: "50%", transform: "translateX(-50%)",
+          zIndex: 99999, background: "#111827", color: "#fff", borderRadius: "14px",
+          padding: "12px 20px", fontSize: "0.875rem", fontWeight: 600,
+          display: "flex", alignItems: "center", gap: "10px",
+          boxShadow: "0 8px 24px rgba(0,0,0,0.25)",
+          animation: "toast-in 0.25s cubic-bezier(0.34,1.20,0.64,1) both",
+        }}>
+          <style>{`@keyframes toast-in { from { opacity:0; transform:translateX(-50%) translateY(12px) } to { opacity:1; transform:translateX(-50%) translateY(0) } }`}</style>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#22c55e" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M20 6L9 17l-5-5"/>
+          </svg>
+          {editando ? "Cambios guardados" : "Servicio creado"}
+        </div>,
+        document.body
+      )}
+
+      <div ref={overlayRef} onClick={e => { if (e.target === overlayRef.current) cerrarSeguro(); }}
+        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+        style={{ background: "rgba(0,0,0,0.45)" }}
+      >
+        <div ref={panelRef}
+          className="w-full sm:max-w-lg rounded-t-3xl sm:rounded-2xl overflow-hidden flex flex-col"
+          style={{ background: "#f9fafb", maxHeight: "92dvh", boxShadow: "0 24px 56px rgba(0,0,0,0.18)" }}
+        >
+          {/* Cabecera */}
+          <div className="flex items-center justify-between px-5 sm:px-6 shrink-0"
+            style={{ paddingTop: "20px", paddingBottom: "20px", position: "relative", background: "var(--azul-egm)" }}
+          >
+            <div style={{ position: "absolute", inset: 0, overflow: "hidden" }}>
+              <Grainient
+                color1="#2A5298" color2="#1B3F7E" color3="#1040a0"
+                timeSpeed={0.18} warpStrength={1.2} warpFrequency={4.0}
+                warpSpeed={1.5} warpAmplitude={60} grainAmount={0.08}
+                contrast={1.3} saturation={1.1} zoom={0.85}
+                style={{ width: "100%", height: "100%", display: "block" }}
+              />
+            </div>
+            <h2 className="text-2xl font-bold" style={{ color: "#fff", position: "relative", zIndex: 1 }}>
+              {editando ? "Editar servicio" : "Nuevo servicio"}
+            </h2>
+            <div style={{ position: "relative", zIndex: 1 }}>
+              <CloseButton onClick={confirmSalir ? onCerrar : cerrarSeguro} />
+            </div>
+          </div>
+
+          {/* Barra confirmación salida */}
+          <div style={{
+            overflow: "hidden", maxHeight: confirmSalir ? "64px" : "0px",
+            opacity: confirmSalir ? 1 : 0,
+            transition: "max-height 0.22s ease, opacity 0.18s ease",
+            background: "#fffbeb", borderBottom: confirmSalir ? "1px solid rgba(245,158,11,0.20)" : "none",
+          }}>
+            <div className="flex items-center justify-between gap-3 px-5 sm:px-6 py-3">
+              <div className="flex items-center gap-2">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+                </svg>
+                <p className="text-sm font-medium" style={{ color: "#92400e" }}>Los cambios se perderán al salir</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="secondary" size="sm" onClick={() => setConfirmSalir(false)}>Seguir editando</Button>
+                <Button type="button" variant="danger" size="sm" onClick={onCerrar}>Salir</Button>
+              </div>
+            </div>
+          </div>
+
+          {/* Formulario */}
+          <form onSubmit={handleSubmit}
+            className="flex flex-col gap-4 px-5 sm:px-6 py-5 overflow-y-auto"
+            style={{ flex: 1, opacity: guardando ? 0.6 : 1, pointerEvents: guardando ? "none" : undefined, transition: "opacity 0.2s" }}
+          >
+            <Campo label="Título" name="titulo" value={form.titulo ?? ""} onChange={v => set("titulo", v)}
+              placeholder="Ej: Autobús lanzadera al área empresarial" required maxLength={80} />
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <CategoriaSelector value={form.categoria ?? ""} onChange={v => setForm(p => ({ ...p, categoria: v }))} />
+              <IconoPicker value={form.iconoUrl ?? ""} onChange={v => set("iconoUrl", v)} />
+            </div>
+
+            <Campo label="Descripción" name="descripcion" value={form.descripcion ?? ""} onChange={v => set("descripcion", v)}
+              placeholder="Breve descripción del servicio" multiline rows={2} />
+
+            <Campo label="Cómo acceder" name="comoAcceder" value={form.comoAcceder ?? ""} onChange={v => set("comoAcceder", v)}
+              placeholder="Ej: Solicita la tarjeta VAO en la oficina de EGM" multiline rows={2} />
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Campo label="URL de información" name="urlInfo" value={form.urlInfo ?? ""} onChange={v => set("urlInfo", v)}
+                placeholder="https://atalayas.com/..." type="url" />
+              <Campo label="Teléfono de contacto" name="telefono" value={form.telefono ?? ""} onChange={v => set("telefono", v)}
+                placeholder="Ej: 647 76 33 89" hint="Opcional" />
+            </div>
+
+            {error && (
+              <p className="text-sm text-center" style={{ color: "#ef4444" }}>{error}</p>
+            )}
+
+            <div className="flex gap-3 pt-1 pb-1">
+              <Button type="button" variant="secondary" className="flex-1" onClick={cerrarSeguro} disabled={guardando}>
+                Cancelar
+              </Button>
+              <Button type="submit" variant="primary" className="flex-1" disabled={guardando || !form.titulo?.trim() || !form.categoria}>
+                {guardando ? "Guardando…" : editando ? "Guardar cambios" : "Crear servicio"}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/lib/api/eventos.ts
+++ b/lib/api/eventos.ts
@@ -1,0 +1,36 @@
+import { API_URL, apiFetch } from "../api";
+import type { Evento, EventoInput } from "@/lib/types/eventos";
+
+export async function getEventos(): Promise<Evento[]> {
+  const res = await apiFetch(`${API_URL}/eventos`);
+  if (!res.ok) throw new Error("Error al obtener los eventos");
+  return res.json();
+}
+
+export async function crearEvento(data: EventoInput): Promise<Evento> {
+  const res = await apiFetch(`${API_URL}/eventos`, {
+    method:  "POST",
+    headers: { "Content-Type": "application/json" },
+    body:    JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error("Error al crear el evento");
+  return res.json();
+}
+
+export async function editarEvento(id: string, data: EventoInput): Promise<Evento> {
+  const res = await apiFetch(`${API_URL}/eventos/${id}`, {
+    method:  "PUT",
+    headers: { "Content-Type": "application/json" },
+    body:    JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error("Error al editar el evento");
+  return res.json();
+}
+
+export async function desactivarEvento(id: string): Promise<Evento> {
+  const res = await apiFetch(`${API_URL}/eventos/${id}/desactivar`, {
+    method: "PATCH",
+  });
+  if (!res.ok) throw new Error("Error al desactivar el evento");
+  return res.json();
+}

--- a/lib/api/servicios.ts
+++ b/lib/api/servicios.ts
@@ -1,52 +1,39 @@
 import { API_URL, apiFetch } from "../api";
-import type { Servicio, ServicioInput } from "@/lib/types/servicios";
+import type { Servicio, ServicioInput, CategoriaServicio } from "@/lib/types/servicios";
 
-export async function getServicios(): Promise<Servicio[]> {
-  const response = await apiFetch(`${API_URL}/servicios`);
-  if (!response.ok) {
-    throw new Error("Error al obtener los servicios");
-  }
-  return response.json();
+export async function getServicios(categoria?: CategoriaServicio): Promise<Servicio[]> {
+  const url = categoria
+    ? `${API_URL}/servicios?categoria=${categoria}`
+    : `${API_URL}/servicios`;
+  const res = await apiFetch(url);
+  if (!res.ok) throw new Error("Error al obtener los servicios");
+  return res.json();
 }
 
 export async function crearServicio(data: ServicioInput): Promise<Servicio> {
-  const response = await apiFetch(`${API_URL}/servicios`, {
-    method: "POST",
+  const res = await apiFetch(`${API_URL}/servicios`, {
+    method:  "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
+    body:    JSON.stringify(data),
   });
-  if (!response.ok) {
-    throw new Error("Error al crear el servicio");
-  }
-  return response.json();
+  if (!res.ok) throw new Error("Error al crear el servicio");
+  return res.json();
 }
 
 export async function editarServicio(id: string, data: ServicioInput): Promise<Servicio> {
-  const response = await apiFetch(`${API_URL}/servicios/${id}`, {
-    method: "PATCH",
+  const res = await apiFetch(`${API_URL}/servicios/${id}`, {
+    method:  "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
+    body:    JSON.stringify(data),
   });
-  if (!response.ok) {
-    throw new Error("Error al editar el servicio");
-  }
-  return response.json();
+  if (!res.ok) throw new Error("Error al editar el servicio");
+  return res.json();
 }
 
-export async function toggleServicio(id: string): Promise<void> {
-  const response = await apiFetch(`${API_URL}/servicios/${id}/toggle`, {
+export async function desactivarServicio(id: string): Promise<Servicio> {
+  const res = await apiFetch(`${API_URL}/servicios/${id}/desactivar`, {
     method: "PATCH",
   });
-  if (!response.ok) {
-    throw new Error("Error al cambiar el estado del servicio");
-  }
-}
-
-export async function eliminarServicio(id: string): Promise<void> {
-  const response = await apiFetch(`${API_URL}/servicios/${id}`, {
-    method: "DELETE",
-  });
-  if (!response.ok) {
-    throw new Error("Error al eliminar el servicio");
-  }
+  if (!res.ok) throw new Error("Error al desactivar el servicio");
+  return res.json();
 }

--- a/lib/types/eventos.ts
+++ b/lib/types/eventos.ts
@@ -1,0 +1,29 @@
+export type EstadoEvento = "PROXIMO" | "EN_CURSO" | "FINALIZADO" | "CANCELADO";
+
+export interface Evento {
+  eventoId:     string;
+  titulo:       string;
+  descripcion:  string | null;
+  fecha:        string;           // ISO date YYYY-MM-DD
+  horaInicio:   string | null;    // HH:mm
+  horaFin:      string | null;    // HH:mm
+  lugar:        string | null;
+  urlInfo:      string | null;
+  imagenUrl:    string | null;
+  estado:       EstadoEvento;
+  creadoPor:    string | null;
+  activo:       boolean;
+  creadoEn:     string;
+  actualizadoEn: string;
+}
+
+export interface EventoInput {
+  titulo:       string;
+  descripcion?: string | null;
+  fecha:        string;
+  horaInicio?:  string | null;
+  horaFin?:     string | null;
+  lugar?:       string | null;
+  urlInfo?:     string | null;
+  imagenUrl?:   string | null;
+}

--- a/lib/types/servicios.ts
+++ b/lib/types/servicios.ts
@@ -1,20 +1,26 @@
+export type CategoriaServicio = "MOVILIDAD" | "INSTALACIONES" | "INICIATIVAS" | "COMUNES";
+
 export interface Servicio {
-  servicioId: string;
-  nombre: string;
-  descripcion: string | null;
-  url: string | null;
-  activo: boolean;
-  icono: string | null;
-  orden: number;
-  creadoEn?: string;
-  actualizadoEn?: string;
+  servicioId:   string;
+  titulo:       string;
+  descripcion:  string | null;
+  categoria:    CategoriaServicio;
+  iconoUrl:     string | null;
+  urlInfo:      string | null;
+  telefono:     string | null;
+  comoAcceder:  string | null;
+  creadoPor:    string | null;
+  activo:       boolean;
+  creadoEn:     string;
+  actualizadoEn: string;
 }
 
 export interface ServicioInput {
-  nombre: string;
+  titulo:       string;
   descripcion?: string | null;
-  url?: string | null;
-  activo?: boolean;
-  icono?: string | null;
-  orden?: number;
+  categoria:    CategoriaServicio;
+  iconoUrl?:    string | null;
+  urlInfo?:     string | null;
+  telefono?:    string | null;
+  comoAcceder?: string | null;
 }


### PR DESCRIPTION
Servicios:
- Tipos y API actualizados (categoria, telefono, iconoUrl, sin fechaFin)
- ServicioModal con selector de categoría, teléfono, icono, confirmación salida
- Página con list-style agrupado por categoría (MOVILIDAD/INSTALACIONES/INICIATIVAS/COMUNES)
- Filas expandibles con detalle, enlace, teléfono y menú superadmin
- Skeleton, toasts, mock listo para conectar al backend

Eventos:
- Tipos y API (EstadoEvento, fecha, horaInicio, horaFin, lugar)
- Página con cards separadas en Próximos / Anteriores
- Badge de estado dinámico, bloque día/mes visual, empty state
- Skeleton, toasts, mock listo para conectar al backend