### PR TITLE
feat: menú móvil con animación GSAP y cruz fija en header

### DIFF
--- a/app/(public)/noticias/[id]/page.tsx
+++ b/app/(public)/noticias/[id]/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useLayoutEffect, useState, useRef } from "react";
+import { gsap } from "gsap";
 import Link from "next/link";
 import Image from "next/image";
 import { useParams } from "next/navigation";
 import logo from "@/public/logo.webp";
 import type { Noticia, Comunicado } from "@/lib/types/noticias";
-import StaggeredMenu from "@/components/ui/StaggeredMenu";
-import type { StaggeredMenuHandle } from "@/components/ui/StaggeredMenu";
 
 const API_URL =
   process.env.NEXT_PUBLIC_API_URL ??
@@ -97,7 +96,32 @@ export default function NoticiaDetallePage() {
   const [notFound, setNotFound] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const staggeredMenuRef = useRef<StaggeredMenuHandle>(null);
+  const menuPanelRef = useRef<HTMLDivElement>(null);
+  const menuOverlayRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (menuPanelRef.current) gsap.set(menuPanelRef.current, { xPercent: 100 });
+    if (menuOverlayRef.current) gsap.set(menuOverlayRef.current, { opacity: 0, pointerEvents: "none" });
+  }, []);
+
+  const abrirMenu = () => {
+    setMobileMenuOpen(true);
+    const panel = menuPanelRef.current;
+    const overlay = menuOverlayRef.current;
+    if (!panel || !overlay) return;
+    gsap.set(overlay, { pointerEvents: "auto" });
+    gsap.to(overlay, { opacity: 1, duration: 0.3, ease: "power2.out" });
+    gsap.to(panel, { xPercent: 0, duration: 0.45, ease: "power4.out" });
+  };
+
+  const cerrarMenu = () => {
+    const panel = menuPanelRef.current;
+    const overlay = menuOverlayRef.current;
+    if (!panel || !overlay) return;
+    const tl = gsap.timeline({ onComplete: () => setMobileMenuOpen(false) });
+    tl.to(panel, { xPercent: 100, duration: 0.35, ease: "power3.in" });
+    tl.to(overlay, { opacity: 0, duration: 0.25, ease: "power2.in", onComplete: () => { gsap.set(overlay, { pointerEvents: "none" }); } }, 0);
+  };
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 20);
@@ -201,33 +225,34 @@ export default function NoticiaDetallePage() {
         style={{ background: "rgba(0,0,0,0.45)", backdropFilter: "blur(12px)" }}
       >
         <Link href="/"><Image src={logo} alt="Atalayas EGM" className="h-10 w-auto brightness-0 invert" /></Link>
-        <button
-          className="flex flex-col justify-center items-center gap-[5px] p-2"
-          onClick={() => { staggeredMenuRef.current?.toggle(); setMobileMenuOpen((v) => !v); }}
-          aria-label="Menú"
-        >
-          <span className="block w-6 h-0.5 rounded bg-white transition-all duration-300" />
-          <span className="block w-6 h-0.5 rounded bg-white transition-all duration-300" />
-          <span className="block w-6 h-0.5 rounded bg-white transition-all duration-300" />
+        <button className="p-1 flex items-center justify-center" onClick={abrirMenu} aria-label="Abrir menú">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round">
+            <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
         </button>
       </div>
 
-      <StaggeredMenu
-        ref={staggeredMenuRef}
-        position="right"
-        colors={["#1B3F7E", "#0d1b2e"]}
-        accentColor="#A3B535"
-        displayItemNumbering={true}
-        closeOnClickAway={true}
-        onMenuClose={() => setMobileMenuOpen(false)}
-        items={[
-          { label: "Inicio",        ariaLabel: "Ir al inicio",       link: "/" },
-          { label: "Noticias",      ariaLabel: "Noticias",           link: "/noticias" },
-          { label: "Comunidad",     ariaLabel: "Ir a Comunidad",     link: "/#comunidad" },
-          { label: "Colaboradores", ariaLabel: "Ir a Colaboradores", link: "/#colaboradores" },
-          { label: "Entrar",        ariaLabel: "Iniciar sesión",     link: "/login" },
-        ]}
-      />
+      {/* Mobile menu panel */}
+      <div className="md:hidden">
+        <div ref={menuOverlayRef} onClick={cerrarMenu} className="fixed inset-0 z-[57]" style={{ background: "rgba(0,0,0,0.4)", backdropFilter: "blur(4px)" }} />
+        <div ref={menuPanelRef} className="fixed top-0 right-0 h-full z-[58] flex flex-col" style={{ width: "100%", background: "#fff" }}>
+          <div className="flex items-center justify-between px-6 py-5" style={{ borderBottom: "1px solid rgba(0,0,0,0.08)" }}>
+            <Image src={logo} alt="Atalayas EGM" className="h-10 w-auto" />
+            <button onClick={cerrarMenu} aria-label="Cerrar menú" className="p-1">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" strokeWidth="2.5" strokeLinecap="round">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+          <div className="flex flex-col px-6 py-8 gap-1">
+            <Link href="/" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Inicio</Link>
+            <Link href="/noticias" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Noticias</Link>
+            <a href="/#comunidad" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Comunidad</a>
+            <a href="/#colaboradores" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Colaboradores</a>
+            <Link href="/login" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3 mt-2" style={{ color: "var(--azul-egm)" }}>Entrar →</Link>
+          </div>
+        </div>
+      </div>
 
       {/* ── Contenido ── */}
       {loading && (

--- a/app/(public)/noticias/page.tsx
+++ b/app/(public)/noticias/page.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import React, { useEffect, useState, useMemo, useRef } from "react";
+import React, { useEffect, useLayoutEffect, useState, useMemo, useRef } from "react";
+import { gsap } from "gsap";
 import Link from "next/link";
 import Image from "next/image";
 import logo from "@/public/logo.webp";
 import type { Noticia, Comunicado } from "@/lib/types/noticias";
-import StaggeredMenu from "@/components/ui/StaggeredMenu";
-import type { StaggeredMenuHandle } from "@/components/ui/StaggeredMenu";
 
 const API_URL =
   process.env.NEXT_PUBLIC_API_URL ??
@@ -498,7 +497,32 @@ export default function NoticiasPublicasPage() {
   const [search,        setSearch]        = useState("");
   const [mobileMenuOpen,  setMobileMenuOpen]  = useState(false);
   const [scrolled,        setScrolled]        = useState(false);
-  const staggeredMenuRef = useRef<StaggeredMenuHandle>(null);
+  const menuPanelRef = useRef<HTMLDivElement>(null);
+  const menuOverlayRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (menuPanelRef.current) gsap.set(menuPanelRef.current, { xPercent: 100 });
+    if (menuOverlayRef.current) gsap.set(menuOverlayRef.current, { opacity: 0, pointerEvents: "none" });
+  }, []);
+
+  const abrirMenu = () => {
+    setMobileMenuOpen(true);
+    const panel = menuPanelRef.current;
+    const overlay = menuOverlayRef.current;
+    if (!panel || !overlay) return;
+    gsap.set(overlay, { pointerEvents: "auto" });
+    gsap.to(overlay, { opacity: 1, duration: 0.3, ease: "power2.out" });
+    gsap.to(panel, { xPercent: 0, duration: 0.45, ease: "power4.out" });
+  };
+
+  const cerrarMenu = () => {
+    const panel = menuPanelRef.current;
+    const overlay = menuOverlayRef.current;
+    if (!panel || !overlay) return;
+    const tl = gsap.timeline({ onComplete: () => setMobileMenuOpen(false) });
+    tl.to(panel, { xPercent: 100, duration: 0.35, ease: "power3.in" });
+    tl.to(overlay, { opacity: 0, duration: 0.25, ease: "power2.in", onComplete: () => { gsap.set(overlay, { pointerEvents: "none" }); } }, 0);
+  };
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 20);
@@ -606,15 +630,10 @@ export default function NoticiasPublicasPage() {
           <Link href="/">
             <Image src={logo} alt="Atalayas EGM" className="h-10 w-auto brightness-0 invert" />
           </Link>
-          <button
-            className="flex flex-col justify-center items-center gap-[5px] p-2"
-            onClick={() => { staggeredMenuRef.current?.toggle(); setMobileMenuOpen((v) => !v); }}
-            aria-label={mobileMenuOpen ? "Cerrar menú" : "Abrir menú"}
-            aria-expanded={mobileMenuOpen}
-          >
-            <span className={`block w-6 h-0.5 rounded transition-all duration-300 ${mobileMenuOpen ? "rotate-45 translate-y-[7px] bg-white" : "bg-white"}`} />
-            <span className={`block w-6 h-0.5 rounded transition-all duration-300 ${mobileMenuOpen ? "opacity-0 bg-white" : "bg-white"}`} />
-            <span className={`block w-6 h-0.5 rounded transition-all duration-300 ${mobileMenuOpen ? "-rotate-45 -translate-y-[7px] bg-white" : "bg-white"}`} />
+          <button className="p-1 flex items-center justify-center" onClick={abrirMenu} aria-label="Abrir menú">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
           </button>
         </div>
 
@@ -636,23 +655,27 @@ export default function NoticiasPublicasPage() {
 
       </section>
 
-      {/* Mobile StaggeredMenu */}
-      <StaggeredMenu
-        ref={staggeredMenuRef}
-        position="right"
-        colors={["#1B3F7E", "#0d1b2e"]}
-        accentColor="#A3B535"
-        displayItemNumbering={true}
-        closeOnClickAway={true}
-        onMenuClose={() => setMobileMenuOpen(false)}
-        items={[
-          { label: "Inicio",        ariaLabel: "Ir al inicio",       link: "/" },
-          { label: "Noticias",      ariaLabel: "Noticias",           link: "/noticias" },
-          { label: "Comunidad",     ariaLabel: "Ir a Comunidad",     link: "/#comunidad" },
-          { label: "Colaboradores", ariaLabel: "Ir a Colaboradores", link: "/#colaboradores" },
-          { label: "Entrar",        ariaLabel: "Iniciar sesión",     link: "/login" },
-        ]}
-      />
+      {/* Mobile menu panel */}
+      <div className="md:hidden">
+        <div ref={menuOverlayRef} onClick={cerrarMenu} className="fixed inset-0 z-[57]" style={{ background: "rgba(0,0,0,0.4)", backdropFilter: "blur(4px)" }} />
+        <div ref={menuPanelRef} className="fixed top-0 right-0 h-full z-[58] flex flex-col" style={{ width: "100%", background: "#fff" }}>
+          <div className="flex items-center justify-between px-6 py-5" style={{ borderBottom: "1px solid rgba(0,0,0,0.08)" }}>
+            <Image src={logo} alt="Atalayas EGM" className="h-10 w-auto" />
+            <button onClick={cerrarMenu} aria-label="Cerrar menú" className="p-1">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" strokeWidth="2.5" strokeLinecap="round">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+          <div className="flex flex-col px-6 py-8 gap-1">
+            <Link href="/" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Inicio</Link>
+            <Link href="/noticias" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Noticias</Link>
+            <a href="/#comunidad" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Comunidad</a>
+            <a href="/#colaboradores" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Colaboradores</a>
+            <Link href="/login" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3 mt-2" style={{ color: "var(--azul-egm)" }}>Entrar →</Link>
+          </div>
+        </div>
+      </div>
 
       {/* ── Filters bar ──────────────────────────────────────────────────── */}
       <div

--- a/components/pages/Invitado.tsx
+++ b/components/pages/Invitado.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState, useRef, useMemo } from "react";
-import type { StaggeredMenuHandle } from "@/components/ui/StaggeredMenu";
+import { useEffect, useState, useRef, useMemo, useLayoutEffect } from "react";
+import { gsap } from "gsap";
 import Link from "next/link";
 import Image from "next/image";
 import logo from "@/public/logo.webp";
@@ -9,7 +9,6 @@ import { API_URL } from "@/lib/api";
 import { Playfair_Display } from "next/font/google";
 import LogoLoop from "@/components/ui/LogoLoop";
 import FooterCTA from "@/components/ui/FooterCTA";
-import StaggeredMenu from "@/components/ui/StaggeredMenu";
 import {
   GraduationCap, BookOpen, Network,
   FlaskConical, Sprout, Building2,
@@ -119,9 +118,41 @@ const comunidadItems = [
 
 
 export default function Invitado() {
+  const [menuAbierto, setMenuAbierto] = useState(false);
+  const menuPanelRef = useRef<HTMLDivElement>(null);
+  const menuOverlayRef = useRef<HTMLDivElement>(null);
+  const menuItemsRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (menuPanelRef.current) gsap.set(menuPanelRef.current, { xPercent: 100 });
+    if (menuOverlayRef.current) gsap.set(menuOverlayRef.current, { opacity: 0, pointerEvents: "none" });
+  }, []);
+
+  const abrirMenu = () => {
+    setMenuAbierto(true);
+    const panel = menuPanelRef.current;
+    const overlay = menuOverlayRef.current;
+    const items = menuItemsRef.current ? Array.from(menuItemsRef.current.children) as HTMLElement[] : [];
+    if (!panel || !overlay) return;
+    gsap.set(items, { xPercent: 40, opacity: 0 });
+    gsap.set(overlay, { pointerEvents: "auto" });
+    const tl = gsap.timeline();
+    tl.to(overlay, { opacity: 1, duration: 0.3, ease: "power2.out" });
+    tl.to(panel, { xPercent: 0, duration: 0.45, ease: "power4.out" }, 0);
+    tl.to(items, { xPercent: 0, opacity: 1, duration: 0.5, ease: "power3.out", stagger: 0.07 }, 0.2);
+  };
+
+  const cerrarMenu = () => {
+    const panel = menuPanelRef.current;
+    const overlay = menuOverlayRef.current;
+    if (!panel || !overlay) return;
+    const tl = gsap.timeline({ onComplete: () => setMenuAbierto(false) });
+    tl.to(panel, { xPercent: 100, duration: 0.35, ease: "power3.in" });
+    tl.to(overlay, { opacity: 0, duration: 0.25, ease: "power2.in", onComplete: () => { gsap.set(overlay, { pointerEvents: "none" }); } }, 0);
+  };
+
   const [comunicados, setComunicados] = useState<Comunicado[]>([]);
   const [loadingComunicados, setLoadingComunicados] = useState(true);
-  const [menuAbierto, setMenuAbierto] = useState(false);
   const [todosLosComunicados, setTodosLosComunicados] = useState<Comunicado[]>([]);
   const [todosLosAnuncios, setTodosLosAnuncios] = useState<Noticia[]>([]);
   const [loadingNoticias, setLoadingNoticias] = useState(true);
@@ -246,45 +277,21 @@ export default function Invitado() {
         </nav>
 
         {/* Mobile nav */}
-        <div className="md:hidden fixed top-0 left-0 right-0 z-50 w-full px-6 py-5 flex items-center justify-between transition-all duration-300" style={{ background: scrolled ? "rgba(0,0,0,0.45)" : "transparent", backdropFilter: scrolled ? "blur(12px)" : "none" }}>
+        <div className="md:hidden fixed top-0 left-0 right-0 z-[56] w-full px-6 py-5 flex items-center justify-between transition-all duration-300" style={{ background: scrolled ? "rgba(0,0,0,0.45)" : "transparent", backdropFilter: scrolled ? "blur(12px)" : "none" }}>
           <Link href="/">
             <Image src={logo} alt="Atalayas EGM" className="h-10 w-auto brightness-0 invert" />
           </Link>
-          {/* Mobile hamburger */}
-          <button
-            className="p-2 flex items-center justify-center outline-none focus:outline-none"
-            onClick={() => setMenuAbierto(prev => !prev)}
-            onMouseDown={(e) => e.preventDefault()}
-            aria-label={menuAbierto ? "Cerrar menú" : "Abrir menú"}
-          >
-            {menuAbierto ? (
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round">
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
-              </svg>
-            ) : (
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round">
-                <line x1="3" y1="6" x2="21" y2="6" />
-                <line x1="3" y1="12" x2="21" y2="12" />
-                <line x1="3" y1="18" x2="21" y2="18" />
-              </svg>
-            )}
+          <button onClick={abrirMenu} aria-label="Abrir menú" className="p-1 flex items-center justify-center">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
           </button>
         </div>
 
-        {/* Mobile menu */}
-        {menuAbierto && (
-          <div className="md:hidden relative z-20 px-6 pb-6 flex flex-col" style={{ background: "rgba(0,0,0,0.85)" }}>
-            <Link href="/noticias" onClick={() => setMenuAbierto(false)} className="text-sm py-3 text-white/80" style={{ borderBottom: "1px solid rgba(255,255,255,0.1)" }}>Noticias</Link>
-            <a href="#comunidad" onClick={() => setMenuAbierto(false)} className="text-sm py-3 text-white/80" style={{ borderBottom: "1px solid rgba(255,255,255,0.1)" }}>Comunidad</a>
-            <a href="#colaboradores" onClick={() => setMenuAbierto(false)} className="text-sm py-3 text-white/80" style={{ borderBottom: "1px solid rgba(255,255,255,0.1)" }}>Colaboradores</a>
-            <Link href="/login" onClick={() => setMenuAbierto(false)} className="text-sm font-semibold py-3 text-white">Entrar</Link>
-          </div>
-        )}
 
-        <div className="relative z-10 flex-1 flex flex-col items-center justify-center text-center px-6 pt-40 pb-40">
+        <div className="relative z-10 flex-1 flex flex-col items-center justify-center text-center px-6 pt-24 sm:pt-40 pb-20 sm:pb-40">
           <h1
-            className="text-7xl sm:text-[6rem] md:text-[10rem] text-white leading-[0.9] max-w-7xl font-normal animate-fade-rise"
+            className="text-4xl sm:text-6xl md:text-[7rem] lg:text-[10rem] text-white leading-[0.9] max-w-7xl font-normal animate-fade-rise"
             style={{ fontFamily: "'Instrument Serif', serif", letterSpacing: "-2.46px" }}
           >
             Atalayas Área Empresarial.
@@ -294,10 +301,10 @@ export default function Invitado() {
           </p>
           <Link
             href="/login"
-            className="liquid-glass rounded-full px-14 py-5 text-xl text-white mt-12 hover:scale-[1.03] transition-transform animate-fade-rise-delay-2 inline-flex items-center justify-center"
+            className="liquid-glass rounded-full px-8 sm:px-14 py-3 sm:py-5 text-base sm:text-xl text-white mt-8 sm:mt-12 hover:scale-[1.03] transition-transform animate-fade-rise-delay-2 inline-flex items-center justify-center"
             style={{ background: "rgba(59, 130, 246, 0.25)" }}
           >
-            Iniciar Sesión
+            Iniciar sesión
           </Link>
         </div>
       </section>
@@ -524,9 +531,9 @@ export default function Invitado() {
         </div>
 
         {/* Layout: lista centrada con margen */}
-        <div className="relative w-full px-6 sm:px-20 lg:px-36 xl:px-48">
+        <div className="relative w-full px-6 sm:px-16 lg:px-36 xl:px-48">
           {/* Título */}
-          <h2 className="text-4xl sm:text-5xl font-bold mb-10 text-center" style={{ color: "#111827", maxWidth: 800 }}>
+          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-8 sm:mb-10 text-center" style={{ color: "#111827", maxWidth: 800 }}>
             Nuestra Comunidad
           </h2>
           {/* Lista en dos columnas */}
@@ -571,6 +578,41 @@ export default function Invitado() {
 
       <Colaboradores />
       <FooterCTA />
+
+      {/* Mobile menu panel */}
+      <div className="md:hidden">
+        {/* Overlay */}
+        <div
+          ref={menuOverlayRef}
+          onClick={cerrarMenu}
+          className="fixed inset-0 z-[57]"
+          style={{ background: "rgba(0,0,0,0.4)", backdropFilter: "blur(4px)" }}
+        />
+        {/* Panel */}
+        <div
+          ref={menuPanelRef}
+          className="fixed top-0 right-0 h-full z-[58] flex flex-col"
+          style={{ width: "100%", background: "#fff" }}
+        >
+          {/* Cabecera del panel */}
+          <div className="flex items-center justify-between px-6 py-5" style={{ borderBottom: "1px solid rgba(0,0,0,0.08)" }}>
+            <Image src={logo} alt="Atalayas EGM" className="h-10 w-auto" />
+            <button onClick={cerrarMenu} aria-label="Cerrar menú" className="p-1">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="black" strokeWidth="2.5" strokeLinecap="round">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+          {/* Items */}
+          <div ref={menuItemsRef} className="flex flex-col px-6 py-8 gap-1">
+            <Link href="/" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Inicio</Link>
+            <Link href="/noticias" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Noticias</Link>
+            <a href="#comunidad" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Comunidad</a>
+            <a href="#colaboradores" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3" style={{ color: "#111", borderBottom: "1px solid rgba(0,0,0,0.07)" }}>Colaboradores</a>
+            <Link href="/login" onClick={cerrarMenu} className="text-3xl font-bold uppercase tracking-tight py-3 mt-2" style={{ color: "var(--azul-egm)" }}>Entrar →</Link>
+          </div>
+        </div>
+      </div>
 
     </div>
   );

--- a/components/ui/StaggeredMenu.tsx
+++ b/components/ui/StaggeredMenu.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import React, {
-  useCallback, useImperativeHandle, useLayoutEffect, useRef, useState, forwardRef
-} from 'react';
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { gsap } from 'gsap';
 
 export interface StaggeredMenuItem {
@@ -10,35 +8,47 @@ export interface StaggeredMenuItem {
   ariaLabel: string;
   link: string;
 }
-
-export interface StaggeredMenuHandle {
-  toggle: () => void;
-  openMenu: () => void;
-  closeMenu: () => void;
-  isOpen: () => boolean;
+export interface StaggeredMenuSocialItem {
+  label: string;
+  link: string;
 }
-
 export interface StaggeredMenuProps {
   position?: 'left' | 'right';
   colors?: string[];
   items?: StaggeredMenuItem[];
+  socialItems?: StaggeredMenuSocialItem[];
+  displaySocials?: boolean;
   displayItemNumbering?: boolean;
+  className?: string;
+  logoUrl?: string;
+  menuButtonColor?: string;
+  openMenuButtonColor?: string;
   accentColor?: string;
+  isFixed: boolean;
+  changeMenuColorOnOpen?: boolean;
   closeOnClickAway?: boolean;
   onMenuOpen?: () => void;
   onMenuClose?: () => void;
 }
 
-const StaggeredMenu = forwardRef<StaggeredMenuHandle, StaggeredMenuProps>(({
+export const StaggeredMenu: React.FC<StaggeredMenuProps> = ({
   position = 'right',
-  colors = ['#1B3F7E', '#0d1b2e'],
+  colors = ['#B497CF', '#5227FF'],
   items = [],
+  socialItems = [],
+  displaySocials = true,
   displayItemNumbering = true,
-  accentColor = '#A3B535',
+  className,
+  logoUrl,
+  menuButtonColor = '#fff',
+  openMenuButtonColor = '#fff',
+  changeMenuColorOnOpen = true,
+  accentColor = '#5227FF',
+  isFixed = false,
   closeOnClickAway = true,
   onMenuOpen,
-  onMenuClose,
-}, ref) => {
+  onMenuClose
+}: StaggeredMenuProps) => {
   const [open, setOpen] = useState(false);
   const openRef = useRef(false);
 
@@ -46,16 +56,34 @@ const StaggeredMenu = forwardRef<StaggeredMenuHandle, StaggeredMenuProps>(({
   const preLayersRef = useRef<HTMLDivElement | null>(null);
   const preLayerElsRef = useRef<HTMLElement[]>([]);
 
+  const plusHRef = useRef<HTMLSpanElement | null>(null);
+  const plusVRef = useRef<HTMLSpanElement | null>(null);
+  const iconRef = useRef<HTMLSpanElement | null>(null);
+
+  const textInnerRef = useRef<HTMLSpanElement | null>(null);
+  const textWrapRef = useRef<HTMLSpanElement | null>(null);
+  const [textLines, setTextLines] = useState<string[]>(['Menu', 'Close']);
+
   const openTlRef = useRef<gsap.core.Timeline | null>(null);
   const closeTweenRef = useRef<gsap.core.Tween | null>(null);
-  const itemEntranceTweenRef = useRef<gsap.core.Tween | null>(null);
+  const spinTweenRef = useRef<gsap.core.Timeline | null>(null);
+  const textCycleAnimRef = useRef<gsap.core.Tween | null>(null);
+  const colorTweenRef = useRef<gsap.core.Tween | null>(null);
+
+  const toggleBtnRef = useRef<HTMLButtonElement | null>(null);
   const busyRef = useRef(false);
+
+  const itemEntranceTweenRef = useRef<gsap.core.Tween | null>(null);
 
   useLayoutEffect(() => {
     const ctx = gsap.context(() => {
       const panel = panelRef.current;
       const preContainer = preLayersRef.current;
-      if (!panel) return;
+
+      const icon = iconRef.current;
+      const textInner = textInnerRef.current;
+
+      if (!panel || !icon || !textInner) return;
 
       let preLayers: HTMLElement[] = [];
       if (preContainer) {
@@ -65,10 +93,18 @@ const StaggeredMenu = forwardRef<StaggeredMenuHandle, StaggeredMenuProps>(({
 
       const offscreen = position === 'left' ? -100 : 100;
       gsap.set([panel, ...preLayers], { xPercent: offscreen, opacity: 1 });
-      if (preContainer) gsap.set(preContainer, { xPercent: 0, opacity: 1 });
+      if (preContainer) {
+        gsap.set(preContainer, { xPercent: 0, opacity: 1 });
+      }
+
+      gsap.set(icon, { rotate: 0, transformOrigin: '50% 50%' });
+
+      gsap.set(textInner, { yPercent: 0 });
+
+      if (toggleBtnRef.current) gsap.set(toggleBtnRef.current, { color: menuButtonColor });
     });
     return () => ctx.revert();
-  }, [position]);
+  }, [menuButtonColor, position]);
 
   const buildOpenTimeline = useCallback(() => {
     const panel = panelRef.current;
@@ -76,17 +112,27 @@ const StaggeredMenu = forwardRef<StaggeredMenuHandle, StaggeredMenuProps>(({
     if (!panel) return null;
 
     openTlRef.current?.kill();
-    if (closeTweenRef.current) { closeTweenRef.current.kill(); closeTweenRef.current = null; }
+    if (closeTweenRef.current) {
+      closeTweenRef.current.kill();
+      closeTweenRef.current = null;
+    }
     itemEntranceTweenRef.current?.kill();
 
     const itemEls = Array.from(panel.querySelectorAll('.sm-panel-itemLabel')) as HTMLElement[];
-    const numberEls = Array.from(panel.querySelectorAll('.sm-panel-list[data-numbering] .sm-panel-item')) as HTMLElement[];
+    const numberEls = Array.from(
+      panel.querySelectorAll('.sm-panel-list[data-numbering] .sm-panel-item')
+    ) as HTMLElement[];
+    const socialTitle = panel.querySelector('.sm-socials-title') as HTMLElement | null;
+    const socialLinks = Array.from(panel.querySelectorAll('.sm-socials-link')) as HTMLElement[];
 
     const offscreen = position === 'left' ? -100 : 100;
-    const layerStates = layers.map((el) => ({ el, start: offscreen }));
+    const layerStates = layers.map(el => ({ el, start: offscreen }));
+    const panelStart = offscreen;
 
     if (itemEls.length) gsap.set(itemEls, { yPercent: 140, rotate: 10 });
     if (numberEls.length) gsap.set(numberEls, { ['--sm-num-opacity' as any]: 0 });
+    if (socialTitle) gsap.set(socialTitle, { opacity: 0 });
+    if (socialLinks.length) gsap.set(socialLinks, { y: 25, opacity: 0 });
 
     const tl = gsap.timeline({ paused: true });
 
@@ -98,13 +144,42 @@ const StaggeredMenu = forwardRef<StaggeredMenuHandle, StaggeredMenuProps>(({
     const panelInsertTime = lastTime + (layerStates.length ? 0.08 : 0);
     const panelDuration = 0.65;
 
-    tl.fromTo(panel, { xPercent: offscreen }, { xPercent: 0, duration: panelDuration, ease: 'power4.out' }, panelInsertTime);
+    tl.fromTo(
+      panel,
+      { xPercent: panelStart },
+      { xPercent: 0, duration: panelDuration, ease: 'power4.out' },
+      panelInsertTime
+    );
 
     if (itemEls.length) {
       const itemsStart = panelInsertTime + panelDuration * 0.15;
-      tl.to(itemEls, { yPercent: 0, rotate: 0, duration: 1, ease: 'power4.out', stagger: { each: 0.1, from: 'start' } }, itemsStart);
+      tl.to(
+        itemEls,
+        { yPercent: 0, rotate: 0, duration: 1, ease: 'power4.out', stagger: { each: 0.1, from: 'start' } },
+        itemsStart
+      );
       if (numberEls.length) {
-        tl.to(numberEls, { duration: 0.6, ease: 'power2.out', ['--sm-num-opacity' as any]: 1, stagger: { each: 0.08, from: 'start' } }, itemsStart + 0.1);
+        tl.to(
+          numberEls,
+          { duration: 0.6, ease: 'power2.out', ['--sm-num-opacity' as any]: 1, stagger: { each: 0.08, from: 'start' } },
+          itemsStart + 0.1
+        );
+      }
+    }
+
+    if (socialTitle || socialLinks.length) {
+      const socialsStart = panelInsertTime + panelDuration * 0.4;
+      if (socialTitle) tl.to(socialTitle, { opacity: 1, duration: 0.5, ease: 'power2.out' }, socialsStart);
+      if (socialLinks.length) {
+        tl.to(
+          socialLinks,
+          {
+            y: 0, opacity: 1, duration: 0.55, ease: 'power3.out',
+            stagger: { each: 0.08, from: 'start' },
+            onComplete: () => { gsap.set(socialLinks, { clearProps: 'opacity' }); }
+          },
+          socialsStart + 0.04
+        );
       }
     }
 
@@ -119,7 +194,9 @@ const StaggeredMenu = forwardRef<StaggeredMenuHandle, StaggeredMenuProps>(({
     if (tl) {
       tl.eventCallback('onComplete', () => { busyRef.current = false; });
       tl.play(0);
-    } else { busyRef.current = false; }
+    } else {
+      busyRef.current = false;
+    }
   }, [buildOpenTimeline]);
 
   const playClose = useCallback(() => {
@@ -141,51 +218,125 @@ const StaggeredMenu = forwardRef<StaggeredMenuHandle, StaggeredMenuProps>(({
         if (itemEls.length) gsap.set(itemEls, { yPercent: 140, rotate: 10 });
         const numberEls = Array.from(panel.querySelectorAll('.sm-panel-list[data-numbering] .sm-panel-item')) as HTMLElement[];
         if (numberEls.length) gsap.set(numberEls, { ['--sm-num-opacity' as any]: 0 });
+        const socialTitle = panel.querySelector('.sm-socials-title') as HTMLElement | null;
+        const socialLinks = Array.from(panel.querySelectorAll('.sm-socials-link')) as HTMLElement[];
+        if (socialTitle) gsap.set(socialTitle, { opacity: 0 });
+        if (socialLinks.length) gsap.set(socialLinks, { y: 25, opacity: 0 });
         busyRef.current = false;
       }
     });
   }, [position]);
 
-  const doOpen = useCallback(() => {
-    openRef.current = true;
-    setOpen(true);
-    onMenuOpen?.();
-    playOpen();
-  }, [playOpen, onMenuOpen]);
+  const animateIcon = useCallback((opening: boolean) => {
+    const icon = iconRef.current;
+    if (!icon) return;
+    spinTweenRef.current?.kill();
+    if (opening) {
+      spinTweenRef.current = gsap.timeline({ defaults: { ease: 'power4.out' } })
+        .fromTo(icon, { rotate: 0, scale: 0.7, opacity: 0.4 }, { rotate: 90, scale: 1, opacity: 1, duration: 0.45 });
+    } else {
+      spinTweenRef.current = gsap.timeline({ defaults: { ease: 'power3.inOut' } })
+        .to(icon, { rotate: 0, scale: 1, opacity: 1, duration: 0.35 });
+    }
+  }, []);
 
-  const doClose = useCallback(() => {
-    openRef.current = false;
-    setOpen(false);
-    onMenuClose?.();
-    playClose();
-  }, [playClose, onMenuClose]);
+  const animateColor = useCallback((opening: boolean) => {
+    const btn = toggleBtnRef.current;
+    if (!btn) return;
+    colorTweenRef.current?.kill();
+    if (changeMenuColorOnOpen) {
+      const targetColor = opening ? openMenuButtonColor : menuButtonColor;
+      colorTweenRef.current = gsap.to(btn, { color: targetColor, delay: 0.18, duration: 0.3, ease: 'power2.out' });
+    } else {
+      gsap.set(btn, { color: menuButtonColor });
+    }
+  }, [openMenuButtonColor, menuButtonColor, changeMenuColorOnOpen]);
 
-  const doToggle = useCallback(() => {
-    if (openRef.current) doClose(); else doOpen();
-  }, [doOpen, doClose]);
+  React.useEffect(() => {
+    if (toggleBtnRef.current) {
+      if (changeMenuColorOnOpen) {
+        const targetColor = openRef.current ? openMenuButtonColor : menuButtonColor;
+        gsap.set(toggleBtnRef.current, { color: targetColor });
+      } else {
+        gsap.set(toggleBtnRef.current, { color: menuButtonColor });
+      }
+    }
+  }, [changeMenuColorOnOpen, menuButtonColor, openMenuButtonColor]);
 
-  // Exponer métodos al padre via ref
-  useImperativeHandle(ref, () => ({
-    toggle: doToggle,
-    openMenu: doOpen,
-    closeMenu: doClose,
-    isOpen: () => openRef.current,
-  }), [doToggle, doOpen, doClose]);
+  const animateText = useCallback((opening: boolean) => {
+    const inner = textInnerRef.current;
+    if (!inner) return;
+    textCycleAnimRef.current?.kill();
+    const currentLabel = opening ? 'Menu' : 'Close';
+    const targetLabel = opening ? 'Close' : 'Menu';
+    const cycles = 3;
+    const seq: string[] = [currentLabel];
+    let last = currentLabel;
+    for (let i = 0; i < cycles; i++) {
+      last = last === 'Menu' ? 'Close' : 'Menu';
+      seq.push(last);
+    }
+    if (last !== targetLabel) seq.push(targetLabel);
+    seq.push(targetLabel);
+    setTextLines(seq);
+    gsap.set(inner, { yPercent: 0 });
+    const lineCount = seq.length;
+    const finalShift = ((lineCount - 1) / lineCount) * 100;
+    textCycleAnimRef.current = gsap.to(inner, {
+      yPercent: -finalShift,
+      duration: 0.5 + lineCount * 0.07,
+      ease: 'power4.out'
+    });
+  }, []);
 
-  // Cerrar al hacer click fuera
+  const toggleMenu = useCallback(() => {
+    const target = !openRef.current;
+    openRef.current = target;
+    setOpen(target);
+    if (target) {
+      onMenuOpen?.();
+      playOpen();
+    } else {
+      onMenuClose?.();
+      playClose();
+    }
+    animateIcon(target);
+    animateColor(target);
+    animateText(target);
+  }, [playOpen, playClose, animateIcon, animateColor, animateText, onMenuOpen, onMenuClose]);
+
+  const closeMenu = useCallback(() => {
+    if (openRef.current) {
+      openRef.current = false;
+      setOpen(false);
+      onMenuClose?.();
+      playClose();
+      animateIcon(false);
+      animateColor(false);
+      animateText(false);
+    }
+  }, [playClose, animateIcon, animateColor, animateText, onMenuClose]);
+
   React.useEffect(() => {
     if (!closeOnClickAway || !open) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (panelRef.current && !panelRef.current.contains(e.target as Node)) doClose();
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(event.target as Node) &&
+        toggleBtnRef.current &&
+        !toggleBtnRef.current.contains(event.target as Node)
+      ) {
+        closeMenu();
+      }
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [closeOnClickAway, open, doClose]);
+  }, [closeOnClickAway, open, closeMenu]);
 
   return (
-    <div className="sm-scope fixed inset-0 z-50 pointer-events-none" aria-hidden={!open}>
+    <div className={`sm-scope z-[55] ${isFixed ? 'fixed top-0 left-0 w-screen h-screen overflow-hidden pointer-events-none' : 'w-full h-full'}`}>
       <div
-        className="staggered-menu-wrapper relative w-full h-full"
+        className={(className ? className + ' ' : '') + 'staggered-menu-wrapper pointer-events-none relative w-full h-full z-[55]'}
         style={accentColor ? ({ ['--sm-accent' as any]: accentColor } as React.CSSProperties) : undefined}
         data-position={position}
         data-open={open || undefined}
@@ -193,7 +344,7 @@ const StaggeredMenu = forwardRef<StaggeredMenuHandle, StaggeredMenuProps>(({
         {/* Pre-layers */}
         <div ref={preLayersRef} className="sm-prelayers absolute top-0 right-0 bottom-0 pointer-events-none z-[5]" aria-hidden="true">
           {(() => {
-            const raw = colors && colors.length ? colors.slice(0, 4) : ['#1B3F7E', '#0d1b2e'];
+            const raw = colors && colors.length ? colors.slice(0, 4) : ['#1e1e22', '#35353c'];
             let arr = [...raw];
             if (arr.length >= 3) { const mid = Math.floor(arr.length / 2); arr.splice(mid, 1); }
             return arr.map((c, i) => (
@@ -202,49 +353,99 @@ const StaggeredMenu = forwardRef<StaggeredMenuHandle, StaggeredMenuProps>(({
           })()}
         </div>
 
+        {/* Toggle button — always visible, fixed top-right */}
+        <div className="sm-toggle-wrap absolute top-0 right-0 z-[60] pointer-events-auto flex items-center" style={{ height: '80px', paddingRight: '1.5rem' }}>
+          <button
+            ref={toggleBtnRef}
+            className="sm-toggle relative inline-flex items-center gap-[0.5rem] bg-transparent border-0 cursor-pointer font-medium leading-none overflow-visible"
+            aria-label={open ? 'Cerrar menú' : 'Abrir menú'}
+            aria-expanded={open}
+            aria-controls="staggered-menu-panel"
+            onClick={toggleMenu}
+            type="button"
+          >
+            <span
+              ref={iconRef}
+              className="sm-icon relative shrink-0 inline-flex items-center justify-center will-change-transform"
+              aria-hidden="true"
+              style={{ transformOrigin: '50% 50%' }}
+            >
+              <span ref={plusHRef} style={{ display: 'none' }} />
+              <span ref={plusVRef} style={{ display: 'none' }} />
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </span>
+          </button>
+        </div>
+
         {/* Panel */}
         <aside
           id="staggered-menu-panel"
           ref={panelRef}
           className="staggered-menu-panel absolute top-0 right-0 h-full bg-white flex flex-col overflow-y-auto z-10 pointer-events-auto"
-          style={{ padding: '5rem 2rem 2rem 2rem' }}
+          style={{ padding: '6em 2em 2em 2em' }}
           aria-hidden={!open}
         >
-          <ul className="sm-panel-list list-none m-0 p-0 flex flex-col gap-2" role="list" data-numbering={displayItemNumbering || undefined}>
-            {items.map((it, idx) => (
-              <li className="sm-panel-itemWrap relative overflow-hidden leading-none" key={it.label + idx}>
-                <a
-                  className="sm-panel-item relative text-black font-semibold cursor-pointer leading-none tracking-[-2px] uppercase inline-block no-underline"
-                  style={{ fontSize: 'clamp(2.2rem, 10vw, 3.5rem)', paddingRight: '1.4em' }}
-                  href={it.link}
-                  aria-label={it.ariaLabel}
-                  data-index={idx + 1}
-                  onClick={doClose}
-                >
-                  <span className="sm-panel-itemLabel inline-block will-change-transform" style={{ transformOrigin: '50% 100%' }}>{it.label}</span>
-                </a>
-              </li>
-            ))}
-          </ul>
+          <div className="sm-panel-inner flex-1 flex flex-col gap-5">
+            <ul className="sm-panel-list list-none m-0 p-0 flex flex-col gap-2" role="list" data-numbering={displayItemNumbering || undefined}>
+              {items && items.length ? items.map((it, idx) => (
+                <li className="sm-panel-itemWrap relative overflow-hidden leading-none" key={it.label + idx}>
+                  <a
+                    className="sm-panel-item relative text-black font-semibold cursor-pointer leading-none tracking-[-2px] uppercase inline-block no-underline"
+                    style={{ fontSize: 'clamp(2.2rem, 10vw, 3.5rem)', paddingRight: '1.4em' }}
+                    href={it.link}
+                    aria-label={it.ariaLabel}
+                    data-index={idx + 1}
+                    onClick={closeMenu}
+                  >
+                    <span className="sm-panel-itemLabel inline-block will-change-transform" style={{ transformOrigin: '50% 100%' }}>{it.label}</span>
+                  </a>
+                </li>
+              )) : null}
+            </ul>
+
+            {displaySocials && socialItems && socialItems.length > 0 && (
+              <div className="sm-socials mt-auto pt-8 flex flex-col gap-3" aria-label="Social links">
+                <h3 className="sm-socials-title m-0 text-base font-medium" style={{ color: 'var(--sm-accent)' }}>Socials</h3>
+                <ul className="sm-socials-list list-none m-0 p-0 flex flex-row items-center gap-4 flex-wrap" role="list">
+                  {socialItems.map((s, i) => (
+                    <li key={s.label + i}>
+                      <a href={s.link} target="_blank" rel="noopener noreferrer" className="sm-socials-link text-[1.2rem] font-medium text-[#111] no-underline inline-block py-[2px]">{s.label}</a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
         </aside>
       </div>
 
       <style>{`
 .sm-scope .staggered-menu-panel { position: absolute; top: 0; right: 0; width: 100%; height: 100%; }
-@media (min-width: 480px) { .sm-scope .staggered-menu-panel { width: clamp(280px, 75vw, 420px); } }
+@media (min-width: 480px) { .sm-scope .staggered-menu-panel { width: clamp(280px, 75vw, 440px); } }
 .sm-scope .sm-prelayers { position: absolute; top: 0; right: 0; bottom: 0; width: 100%; }
-@media (min-width: 480px) { .sm-scope .sm-prelayers { width: clamp(280px, 75vw, 420px); } }
+@media (min-width: 480px) { .sm-scope .sm-prelayers { width: clamp(280px, 75vw, 440px); } }
 .sm-scope .sm-prelayer { position: absolute; top: 0; right: 0; height: 100%; width: 100%; }
+.sm-scope .sm-toggle { font-size: 1rem; font-weight: 600; letter-spacing: 0.02em; }
+.sm-scope .sm-toggle-textWrap { margin-right: 0.2em; }
+.sm-scope .sm-toggle-textInner { display: flex; flex-direction: column; line-height: 1; }
+.sm-scope .sm-toggle-line { display: block; height: 1em; line-height: 1; }
+.sm-scope .sm-icon { will-change: transform; }
+.sm-scope .sm-icon-line { will-change: transform; }
 .sm-scope .sm-panel-itemWrap { position: relative; overflow: hidden; line-height: 1; }
 .sm-scope .sm-panel-item { color: #000; display: inline-block; text-decoration: none; transition: color 0.2s; }
 .sm-scope .sm-panel-item:hover { color: var(--sm-accent, #A3B535); }
 .sm-scope .sm-panel-itemLabel { display: inline-block; will-change: transform; }
 .sm-scope .sm-panel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; counter-reset: smItem; }
 .sm-scope .sm-panel-list[data-numbering] .sm-panel-item::after { counter-increment: smItem; content: counter(smItem, decimal-leading-zero); position: absolute; top: 0.1em; right: 3.2em; font-size: 13px; font-weight: 400; color: var(--sm-accent, #A3B535); letter-spacing: 0; pointer-events: none; user-select: none; opacity: var(--sm-num-opacity, 0); }
+.sm-scope .sm-socials-link { transition: color 0.2s; }
+.sm-scope .sm-socials-link:hover { color: var(--sm-accent, #A3B535); }
       `}</style>
     </div>
   );
-});
+};
 
-StaggeredMenu.displayName = 'StaggeredMenu';
+// Keep default export for backward compatibility
 export default StaggeredMenu;


### PR DESCRIPTION
- Reemplaza StaggeredMenu por menú propio con panel deslizante desde la derecha
- Cruz (✕) fija en header alineada con el logo, visible al hacer scroll
- Panel blanco con items animados en stagger via GSAP
- Overlay con blur al abrir el menú
- Actualiza StaggeredMenu.tsx con nueva versión del componente