### PR TITLE
design-system: align tokens with HTML reference

### DIFF
--- a/app/dashboard/formacion/[moduloId]/page.tsx
+++ b/app/dashboard/formacion/[moduloId]/page.tsx
@@ -438,7 +438,7 @@ export default function Page() {
                 <button
                   onClick={() => router.push("/dashboard/formacion")}
                   className="w-full py-3 rounded-xl text-sm font-bold transition-all"
-                  style={{ background: "linear-gradient(135deg,var(--azul-egm),#A3B535)", color: "#fff", boxShadow: "0 4px 12px rgba(0,82,204,0.3)" }}>
+                  style={{ background: "linear-gradient(135deg,var(--azul-egm),var(--verde-oliva-hover))", color: "#fff", boxShadow: "0 4px 12px rgba(0,82,204,0.3)" }}>
                   Volver a mis formaciones
                 </button>
                 <button

--- a/app/dashboard/perfil/page.tsx
+++ b/app/dashboard/perfil/page.tsx
@@ -573,7 +573,7 @@ export default function PerfilPage() {
                     fontWeight:           700,
                     fontSize:             "clamp(2.2rem, 5vw, 3.5rem)",
                     lineHeight:           1.05,
-                    backgroundImage:      "linear-gradient(90deg, #ffffff, #A3B535, #ffffff)",
+                    backgroundImage:      "linear-gradient(90deg, #ffffff, var(--verde-oliva-hover), #ffffff)",
                     backgroundSize:       "300% auto",
                     WebkitBackgroundClip: "text",
                     WebkitTextFillColor:  "transparent",
@@ -906,7 +906,7 @@ export default function PerfilPage() {
               <svg viewBox="0 0 36 36" className="w-full h-full" style={{ transform: "rotate(-90deg)" }}>
                 <path fill="none" strokeWidth="2.5" stroke="rgba(255,255,255,0.12)"
                   d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" />
-                <path fill="none" strokeWidth="2.5" stroke="#A3B535" strokeLinecap="round"
+                <path fill="none" strokeWidth="2.5" stroke="var(--verde-oliva-hover)" strokeLinecap="round"
                   strokeDasharray={`${pctOnboarding}, 100`}
                   d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" />
               </svg>

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,65 +16,103 @@ body::-webkit-scrollbar,
 }
 
 :root {
-  /* ── Azul EGM ── */
+  /* ════════════════════════════════════════════
+     MARCA PRINCIPAL
+  ════════════════════════════════════════════ */
+
+  /* Azul EGM */
   --azul-egm:         #1B3F7E;
   --azul-egm-hover:   #2A5298;
-  --azul-egm-profundo:#1040a0;
+  --azul-egm-profundo:#1040A0;
   --azul-egm-light:   #E8EEF8;
 
-  /* ── Azul acción (tabs, noticias, formularios) ── */
+  /* Azul acción (tabs, formularios, noticias) */
   --azul-accion:      #2563EB;
   --azul-accion-hover:#1D4ED8;
   --azul-accion-light:#EFF6FF;
 
-  /* ── Verde oliva ── */
+  /* Lima — color de acento de marca (badges, eyebrow, highlights) */
+  --lima:             #9DC429;
+  --lima-hover:       #B8C94A;
+  --lima-light:       #EEF2D0;
+
+  /* Verde oliva — formaciones, módulos, comunicados */
   --verde-oliva:      #8B9A2D;
   --verde-oliva-hover:#A3B535;
   --verde-oliva-light:#EEF2D0;
 
-  /* ── Marino ── */
+  /* Marino oscuro */
   --marino:           #0D1B2E;
 
-  /* ── Blancos y grises de superficie ── */
+  /* ════════════════════════════════════════════
+     SUPERFICIES
+  ════════════════════════════════════════════ */
   --blanco:           #FFFFFF;
-  --gris-panel:       #f9fafb;
-  --gris-pagina:      #F5F6F8;
+  --gris-pagina:      #F4F5F7;
+  --gris-panel:       #F9FAFB;
   --gris-superficie:  #EDEEF1;
-  --gris-borde:       #C8CDD8;
+  --gris-borde:       #C8CDD8;               /* border visible — inputs, forms, cards */
+  --surface-border:   rgba(0, 0, 0, 0.08);   /* border sutil — dividers, secciones   */
 
-  /* ── Texto ── */
+  /* ════════════════════════════════════════════
+     TEXTO
+  ════════════════════════════════════════════ */
   --texto-primario:   #0F1923;
   --texto-secundario: #3D4A5C;
   --texto-muted:      #6B7A8D;
   --texto-label:      #374151;
-  --texto-placeholder:#9ca3af;
+  --texto-placeholder:#9CA3AF;
 
-  /* ── Estados ── */
-  --exito:            #2D7D4E;
-  --exito-light:      #D4EDDA;
-  --error:            #C84B31;
+  /* ════════════════════════════════════════════
+     ESTADOS SEMÁNTICOS
+  ════════════════════════════════════════════ */
+  --exito:            #2D8653;
+  --exito-light:      #E8F5EE;
+  --error:            #C0392B;
   --error-light:      #FDECEA;
-  --advertencia:      #B07D1A;
-  --advertencia-light:#FFF3CD;
-  --info:             #5B7FA6;
-  --info-light:       #E3ECF5;
+  --advertencia:      #D97706;
+  --advertencia-light:#FEF3E2;
+  --info:             #1B3F7E;
+  --info-light:       #E8EEF8;
 
-  /* ── Overlay ── */
+  /* ════════════════════════════════════════════
+     IA (índigo)
+  ════════════════════════════════════════════ */
+  --ia:               #4F46E5;
+  --ia-hover:         #4338CA;
+  --ia-light:         #EEF2FF;
+  --ia-glow:          rgba(79, 70, 229, 0.18);
+  --ia-usuario:       #1E40AF;
+
+  /* ════════════════════════════════════════════
+     OVERLAY
+  ════════════════════════════════════════════ */
   --overlay:          rgba(0, 0, 0, 0.45);
 
-  /* ── Radios ── */
-  --radius-btn:       12px;
-  --radius-card:      16px;
-  --radius-modal:     24px;
+  /* ════════════════════════════════════════════
+     RADIOS DE BORDE
+  ════════════════════════════════════════════ */
+  --radius-sm:        8px;    /* badges, inputs, tooltips        */
+  --radius-md:        12px;   /* botones, items de lista         */
+  --radius-lg:        16px;   /* cards, paneles                  */
+  --radius-xl:        24px;   /* modales                         */
+  --radius-full:      50%;    /* avatares, dots                  */
 
-  /* ── IA (índigo) ── */
-  --ia:           #4F46E5;
-  --ia-hover:     #4338CA;
-  --ia-light:     #EEF2FF;
-  --ia-glow:      rgba(79, 70, 229, 0.18);
-  --ia-usuario:   #1E40AF;
+  /* Aliases semánticos (compatibilidad interna) */
+  --radius-btn:       var(--radius-md);
+  --radius-card:      var(--radius-lg);
+  --radius-modal:     var(--radius-xl);
 
-  /* ── Easings ── */
+  /* ════════════════════════════════════════════
+     DURACIONES
+  ════════════════════════════════════════════ */
+  --dur-fast:         150ms;
+  --dur-medium:       250ms;
+  --dur-slow:         400ms;
+
+  /* ════════════════════════════════════════════
+     EASINGS
+  ════════════════════════════════════════════ */
   --ease-spring:      cubic-bezier(0.34, 1.20, 0.64, 1);
   --ease-out:         cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -83,7 +121,7 @@ body::-webkit-scrollbar,
 .card {
   background:    var(--blanco);
   border-radius: var(--radius-card);
-  border:        1px solid var(--gris-borde);
+  border:        1px solid var(--surface-border);
   box-shadow:    0 1px 4px rgba(0, 0, 0, 0.06);
 }
 

--- a/components/pages/Empleado.tsx
+++ b/components/pages/Empleado.tsx
@@ -354,7 +354,7 @@ export default function Empleado() {
 
           {/* Texto + barra */}
           <div className="flex-1 min-w-0 relative z-10">
-            <p className="text-[11px] font-bold uppercase tracking-[0.15em] mb-0.5" style={{ color: "#A3B535" }}>
+            <p className="text-[11px] font-bold uppercase tracking-[0.15em] mb-0.5" style={{ color: "var(--verde-oliva-hover)" }}>
               Proceso de incorporación
             </p>
             <p className="text-sm sm:text-base font-semibold text-white mb-2">
@@ -363,7 +363,7 @@ export default function Empleado() {
             <div className="flex items-center gap-3">
               <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: "rgba(255,255,255,0.12)" }}>
                 <div className="h-full rounded-full transition-all duration-700"
-                  style={{ width: "35%", background: "linear-gradient(90deg, var(--azul-egm) 0%, #A3B535 100%)" }} />
+                  style={{ width: "35%", background: "linear-gradient(90deg, var(--azul-egm) 0%, var(--verde-oliva-hover) 100%)" }} />
               </div>
               <span className="text-xs font-semibold tabular-nums shrink-0" style={{ color: "rgba(255,255,255,0.5)" }}>
                 35%
@@ -374,7 +374,7 @@ export default function Empleado() {
           {/* CTA desktop */}
           <div
             className="shrink-0 hidden sm:flex items-center gap-2 px-4 py-2 rounded-xl relative z-10"
-            style={{ background: "#A3B535", color: "#fff" }}
+            style={{ background: "var(--verde-oliva-hover)", color: "#fff" }}
           >
             <span className="text-sm font-semibold">Continuar</span>
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -627,7 +627,7 @@ export default function Empleado() {
 
               <div className="relative z-10 p-6 flex flex-col h-full" style={{ minHeight: "200px" }}>
                 <div className="flex items-start justify-between mb-auto">
-                  <span className="text-xs font-bold uppercase tracking-widest px-2.5 py-1 rounded-full" style={{ background: "rgba(163,181,53,0.2)", color: "#A3B535" }}>
+                  <span className="text-xs font-bold uppercase tracking-widest px-2.5 py-1 rounded-full" style={{ background: "rgba(163,181,53,0.2)", color: "var(--verde-oliva-hover)" }}>
                     Próximo evento
                   </span>
                   <div className="text-right">
@@ -662,7 +662,7 @@ export default function Empleado() {
                 <Link
                   href="/dashboard/eventos"
                   className="mt-5 self-start text-xs font-semibold px-4 py-2 rounded-xl transition-opacity hover:opacity-80 inline-flex items-center gap-1.5"
-                  style={{ background: "#A3B535", color: "#fff", textDecoration: "none" }}
+                  style={{ background: "var(--verde-oliva-hover)", color: "#fff", textDecoration: "none" }}
                 >
                   Ver evento
                   <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>


### PR DESCRIPTION
- Add --lima / --lima-hover / --lima-light (#9DC429) as brand accent, separate from --verde-oliva (formaciones)
- Fix semantic state colors to match design system HTML: --exito #2D8653, --exito-light #E8F5EE --error #C0392B, --error-light #FDECEA --advertencia #D97706, --advertencia-light #FEF3E2 --info #1B3F7E, --info-light #E8EEF8
- Align --gris-pagina to #F4F5F7 (was #F5F6F8)
- Add --surface-border rgba(0,0,0,0.08) for subtle dividers
- Add canonical radius scale: --radius-sm/md/lg/xl/full (--radius-btn/card/modal kept as aliases for compatibility)
- Add duration tokens: --dur-fast/medium/slow
- Fix hardcoded #A3B535 → var(--verde-oliva-hover) in Empleado.tsx (5), perfil/page.tsx (2), formacion/[moduloId]/page.tsx (1)