### PR TITLE
fix(routing): corregir acceso por roles y notificaciones por rol

### DIFF
--- a/app/dashboard/configuracion/page.tsx
+++ b/app/dashboard/configuracion/page.tsx
@@ -209,14 +209,14 @@ export default function ConfiguracionPage() {
 
                 {/* Contraseña actual */}
                 <div className="flex flex-col gap-2">
-                  <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-start justify-between gap-3">
                     <label className={`${labelClass} shrink-0`} style={{ color: "var(--texto-muted)" }}>Contraseña actual</label>
                     {!resetSent ? (
                       <button
                         type="button"
                         onClick={handleSolicitarReset}
                         disabled={resetLoading}
-                        className="text-xs font-medium transition-opacity hover:opacity-70 cursor-pointer text-right"
+                        className="text-xs font-medium transition-opacity hover:opacity-70 cursor-pointer text-right p-0 leading-none"
                         style={{ color: "var(--azul-egm)" }}
                       >
                         {resetLoading ? "Enviando…" : "Recuperar contraseña"}
@@ -325,10 +325,30 @@ export default function ConfiguracionPage() {
                 </p>
               </div>
               <div className="mx-6" style={{ borderBottom: "1px solid var(--gris-borde)" }} />
-              <ToggleRow label="Nuevo módulo disponible"  description="Cuando se publica un nuevo módulo de formación" checked={prefs.notifNuevoModulo}      onChange={(v) => updatePref("notifNuevoModulo", v)} />
-              <ToggleRow label="Módulo completado"        description="Confirmación cuando terminas un módulo"         checked={prefs.notifModuloCompletado}  onChange={(v) => updatePref("notifModuloCompletado", v)} />
-              <ToggleRow label="Nuevos comunicados"       description="Cuando tu empresa publica un comunicado"        checked={prefs.notifComunicado}        onChange={(v) => updatePref("notifComunicado", v)} />
-              <ToggleRow label="Recordatorio pendientes"  description="Si tienes notificaciones sin leer"              checked={prefs.notifPendiente}         onChange={(v) => updatePref("notifPendiente", v)} separator={false} />
+
+              {/* Superadmin */}
+              {usuario?.codigoRol === "ROLE_ADMIN" && (<>
+                <ToggleRow label="Nueva empresa registrada" description="Cuando una nueva empresa se une a la plataforma"  checked={prefs.notifNuevoModulo}      onChange={(v) => updatePref("notifNuevoModulo", v)} />
+                <ToggleRow label="Suscripción por vencer"   description="Cuando la suscripción de una empresa está próxima a expirar" checked={prefs.notifModuloCompletado} onChange={(v) => updatePref("notifModuloCompletado", v)} />
+                <ToggleRow label="Empresa inactiva"         description="Cuando una empresa lleva más de 30 días sin actividad" checked={prefs.notifComunicado}     onChange={(v) => updatePref("notifComunicado", v)} />
+                <ToggleRow label="Solicitudes pendientes"   description="Cuando hay solicitudes de empresas sin revisar"    checked={prefs.notifPendiente}         onChange={(v) => updatePref("notifPendiente", v)} separator={false} />
+              </>)}
+
+              {/* Admin empresa */}
+              {usuario?.codigoRol === "ROLE_ADMIN_EMPRESA" && (<>
+                <ToggleRow label="Nuevo módulo disponible"    description="Cuando se publica un nuevo módulo de formación"       checked={prefs.notifNuevoModulo}      onChange={(v) => updatePref("notifNuevoModulo", v)} />
+                <ToggleRow label="Empleado completa módulo"   description="Cuando un empleado de tu empresa termina un módulo"   checked={prefs.notifModuloCompletado}  onChange={(v) => updatePref("notifModuloCompletado", v)} />
+                <ToggleRow label="Nuevos comunicados"         description="Cuando recibes un comunicado de la plataforma"        checked={prefs.notifComunicado}        onChange={(v) => updatePref("notifComunicado", v)} />
+                <ToggleRow label="Recordatorio pendientes"    description="Si tienes notificaciones sin revisar"                 checked={prefs.notifPendiente}         onChange={(v) => updatePref("notifPendiente", v)} separator={false} />
+              </>)}
+
+              {/* Empleado */}
+              {(!usuario?.codigoRol || usuario.codigoRol === "ROLE_EMPLEADO") && (<>
+                <ToggleRow label="Nuevo módulo disponible"  description="Cuando se publica un nuevo módulo de formación" checked={prefs.notifNuevoModulo}      onChange={(v) => updatePref("notifNuevoModulo", v)} />
+                <ToggleRow label="Módulo completado"        description="Confirmación cuando terminas un módulo"         checked={prefs.notifModuloCompletado}  onChange={(v) => updatePref("notifModuloCompletado", v)} />
+                <ToggleRow label="Nuevos comunicados"       description="Cuando tu empresa publica un comunicado"        checked={prefs.notifComunicado}        onChange={(v) => updatePref("notifComunicado", v)} />
+                <ToggleRow label="Recordatorio pendientes"  description="Si tienes notificaciones sin leer"              checked={prefs.notifPendiente}         onChange={(v) => updatePref("notifPendiente", v)} separator={false} />
+              </>)}
             </div>
           </section>
         </div>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { API_URL, apiFetch } from "@/lib/api";
 import Header from "@/components/Header";
@@ -11,6 +11,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const { usuario, guardarUsuario } = useAuth();
   const [verificando, setVerificando] = useState(true);
   const router = useRouter();
+  const pathname = usePathname();
 
   // Verificamos sesión activa contra el endpoint correcto
   useEffect(() => {
@@ -43,12 +44,12 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     }
   }, [verificando, usuario]);
 
-  // Redirigimos al superadmin a su propio panel — no al dashboard de empresas
+  // Redirigimos al superadmin al panel principal solo si está en la raíz del dashboard
   useEffect(() => {
-    if (!verificando && usuario?.codigoRol === "ROLE_ADMIN") {
+    if (!verificando && usuario?.codigoRol === "ROLE_ADMIN" && pathname === "/dashboard") {
       router.replace("/superadmin");
     }
-  }, [verificando, usuario]);
+  }, [verificando, usuario, pathname]);
 
   // Pantalla de verificación mientras comprobamos la sesión
   if (verificando) {
@@ -74,7 +75,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   }
 
   // Mientras redirige no renderizamos nada
-  if (!usuario || usuario.codigoRol === "INVITADO" || usuario.codigoRol === "ROLE_ADMIN") return null;
+  if (!usuario || usuario.codigoRol === "INVITADO" || (usuario.codigoRol === "ROLE_ADMIN" && pathname === "/dashboard")) return null;
 
   return (
     <div className="min-h-screen overflow-x-hidden" style={{ background: "var(--gris-pagina)" }}>

--- a/app/superadmin/layout.tsx
+++ b/app/superadmin/layout.tsx
@@ -16,7 +16,7 @@ export default function SuperAdminLayout({ children }: { children: React.ReactNo
 
   // Solo ROLE_ADMIN puede acceder al panel de superadmin
   React.useEffect(() => {
-    if (usuario !== undefined && usuario?.codigoRol !== "ROLE_ADMIN") {
+    if (usuario !== undefined && usuario !== null && usuario.codigoRol !== "ROLE_ADMIN") {
       router.replace("/dashboard");
     }
   }, [usuario]);


### PR DESCRIPTION
- Dashboard layout: ROLE_ADMIN solo redirige a /superadmin desde /dashboard raíz, no desde subrutas (configuración, perfil, etc.)
- Superadmin layout: añadir usuario !== null al guard para evitar bucle infinito durante la carga inicial del AuthContext
- Configuración: notificaciones diferenciadas por rol · Superadmin: Nueva empresa, Suscripción por vencer, Empresa inactiva, Solicitudes pendientes · Admin empresa: Nuevo módulo, Empleado completa módulo, Comunicados, Pendientes · Empleado: las 4 notificaciones originales
- Responsive: items-start en label/link de contraseña actual