### PR TITLE
fix(auth): eliminar parche localStorage para avatarUrl y bannerUrl

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -40,9 +40,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUsuario(nuevoUsuario);
     if (nuevoUsuario) {
       console.log("[AuthContext] Usuario guardado:", nuevoUsuario.nombre);
-      // Persistir bannerUrl y avatarUrl para que sobrevivan al cierre de sesión y vuelta
-      if (nuevoUsuario.bannerUrl) localStorage.setItem("cachedBannerUrl", nuevoUsuario.bannerUrl);
-      if (nuevoUsuario.avatarUrl)  localStorage.setItem("cachedAvatarUrl", nuevoUsuario.avatarUrl);
     }
   }, []);
 
@@ -71,10 +68,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         await logout();
         return;
       }
-
-      // Recuperar imágenes cacheadas si el backend no las devuelve
-      if (!userData.bannerUrl) userData.bannerUrl = localStorage.getItem("cachedBannerUrl") ?? undefined;
-      if (!userData.avatarUrl)  userData.avatarUrl  = localStorage.getItem("cachedAvatarUrl")  ?? undefined;
 
       setUsuario(userData);
     } catch (err) {


### PR DESCRIPTION
La URL del avatar ahora sobrevive a reinicios del backend y se sincroniza entre dispositivos, sin depender de un caché local del navegador.