### PR TITLE
fix(perfil): autorizar Supabase Storage en next/image

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      // Supabase Storage (avatares, portadas de módulos, audio podcast, etc.)
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
+      // Backend de Render — sirve uploads legacy
+      {
+        protocol: "https",
+        hostname: "*.onrender.com",
+        pathname: "/uploads/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
El componente <Image> de Next.js bloquea por defecto hostnames externos. Tras el cambio del backend para subir avatares a Supabase Storage, las URLs devueltas (https://*.supabase.co/storage/v1/object/public/**) eran rechazadas con "Invalid src prop ... hostname is not configured".

Se añaden los remotePatterns necesarios:
- *.supabase.co para los uploads públicos (avatares, portadas, audio)
- *.onrender.com/uploads/** como fallback para avatares legacy