### PR TITLE
fix(chatbot): eliminar propiedad border duplicada en estilo del FAB

### DIFF
--- a/components/ui/ChatbotIA.tsx
+++ b/components/ui/ChatbotIA.tsx
@@ -866,7 +866,6 @@ export default function ChatbotIA() {
             height: `${FAB_SIZE}px`,
             borderRadius: "50%",
             background: C.gradientFab,
-            border: "none",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",


### PR DESCRIPTION
El objeto de estilo del botón flotante del chatbot tenía dos propiedades 'border' (una "none" y otra "1.5px solid..."), lo que hacía fallar el build de TypeScript con "An object literal cannot have multiple properties with the same name". Se mantiene solo la del borde sutil, que es la que realmente queremos.