### PR TITLE
feat(documentos): gestión documental — UI admin y empleado 

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -23,6 +23,7 @@ import {
 import { getEstadisticasAdminEmpresa, type EstadisticasEmpresaResponse, type FiltrosEstadisticas } from "@/lib/api/estadisticas";
 import { exportStats, type ExportFormat, type StatsSection } from "@/lib/utils/statsExport";
 import GestionIncidencias from "@/components/pages/GestionIncidencias";
+import { DocumentosAdminTab } from "@/components/documentos/DocumentosAdminTab";
 import ExcelJS from "exceljs";
 
 const EMPTY_ANUNCIO: NoticiaInput = {
@@ -113,7 +114,7 @@ function AdminContent() {
   const searchParams = useSearchParams();
   const { usuario } = useAuth();
 
-  const [activeTab, setActiveTab] = useState<"empleados" | "anuncios" | "formaciones" | "incidencias" | "estadisticas">("empleados");
+  const [activeTab, setActiveTab] = useState<"empleados" | "anuncios" | "formaciones" | "incidencias" | "estadisticas" | "documentos">("empleados");
 
   const queryClient = useQueryClient();
 
@@ -258,6 +259,7 @@ function AdminContent() {
     if (tab === "anuncios") setActiveTab("anuncios");
     if (tab === "empleados") setActiveTab("empleados");
     if (tab === "estadisticas") setActiveTab("estadisticas");
+    if (tab === "documentos") setActiveTab("documentos");
     const editId = searchParams.get("edit");
     if (editId && formaciones.length > 0) {
       const f = formaciones.find((x) => x.moduloId === editId);
@@ -665,6 +667,17 @@ function AdminContent() {
         </svg>
       ),
     },
+    {
+      key: "documentos" as const,
+      label: "Documentos",
+      icon: (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="9" y1="15" x2="15" y2="15" />
+        </svg>
+      ),
+    },
   ];
 
   // Accent colors per modulo tipo for top strip
@@ -708,7 +721,7 @@ function AdminContent() {
         <div className="sm:hidden mb-8">
           <select
             value={activeTab}
-            onChange={(e) => setActiveTab(e.target.value as "empleados" | "anuncios" | "formaciones" | "incidencias" | "estadisticas")}
+            onChange={(e) => setActiveTab(e.target.value as "empleados" | "anuncios" | "formaciones" | "incidencias" | "estadisticas" | "documentos")}
             className="w-full rounded-xl px-4 py-3 text-sm font-semibold focus:outline-none"
             style={{
               border: "1px solid var(--gris-borde)",
@@ -721,6 +734,7 @@ function AdminContent() {
             <option value="formaciones">Módulos formativos</option>
             <option value="incidencias">Incidencias</option>
             <option value="estadisticas">Estadísticas</option>
+            <option value="documentos">Documentos</option>
           </select>
         </div>
 
@@ -1827,6 +1841,19 @@ function AdminContent() {
         {/* ── TAB INCIDENCIAS ── */}
         {activeTab === "incidencias" && (
           <GestionIncidencias empresaId={usuario?.empresaId} />
+        )}
+
+        {activeTab === "documentos" && usuario?.empresaId && (
+          <DocumentosAdminTab
+            empresaId={usuario.empresaId}
+            empleados={empleados.map((e) => ({
+              usuarioId: e.usuarioId,
+              nombre: e.nombre,
+              apellidos: e.apellidos,
+              departamento: e.departamento,
+            }))}
+            departamentos={DEPARTAMENTOS}
+          />
         )}
 
         {/* ── TAB ESTADÍSTICAS ── */}

--- a/app/dashboard/perfil/page.tsx
+++ b/app/dashboard/perfil/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useRouter, usePathname } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { API_URL, apiFetch } from "@/lib/api";
+import { MisDocumentos } from "@/components/documentos/MisDocumentos";
 import {
   Camera, Pencil, Check, X, Briefcase, Phone,
   Calendar, Clock, BookOpen, Award, ChevronRight, Building2, Mail,
@@ -1028,6 +1029,11 @@ export default function PerfilPage() {
         </div>
 
         </div>{/* fin sección formación */}
+
+{/* ── Mis documentos ── */}
+<div id="mis-documentos" className="scroll-mt-20">
+  <MisDocumentos />
+</div>
 
 {/* ── Buzón (izquierda) + Certificados/Configuración (derecha) ── */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 items-start">

--- a/components/documentos/DocumentosAdminTab.tsx
+++ b/components/documentos/DocumentosAdminTab.tsx
@@ -1,0 +1,566 @@
+"use client";
+
+// ============================================================
+// DocumentosAdminTab — listado y subida de documentos para admin
+// Se renderiza dentro del tab "Documentos" del panel de administración.
+// ============================================================
+
+import { useEffect, useState } from "react";
+import {
+  listarDocumentosEmpresa, subirDocumento, desactivarDocumento, listarAsignaciones,
+} from "@/lib/api/documentos";
+import {
+  type Documento, type AsignacionDetalle, type TipoDocumento, type SubirDocumentoInput,
+  TIPO_DOCUMENTO_LABEL, TIPO_DOCUMENTO_COLOR,
+} from "@/lib/types/documentos";
+import { FileText, Upload, Trash2, Eye, Check, X, AlertTriangle, Users, Building2 } from "lucide-react";
+import { IAButton } from "@/components/ui/IAButton";
+
+interface Props {
+  empresaId: string;
+  empleados: Array<{ usuarioId: string; nombre: string; apellidos: string; departamento: string | null }>;
+  departamentos: Array<{ id: string; label: string }>;
+}
+
+const TIPOS: TipoDocumento[] = ["NOMINA", "CONTRATO", "CERTIFICADO", "POLITICA", "OTRO"];
+
+export function DocumentosAdminTab({ empleados, departamentos }: Props) {
+  const [documentos, setDocumentos] = useState<Documento[]>([]);
+  const [cargando, setCargando] = useState(true);
+  const [showSubir, setShowSubir] = useState(false);
+  const [verAsignacionesDe, setVerAsignacionesDe] = useState<Documento | null>(null);
+  const [asignaciones, setAsignaciones] = useState<AsignacionDetalle[]>([]);
+  const [cargandoAsig, setCargandoAsig] = useState(false);
+  const [toast, setToast] = useState<{ tipo: "ok" | "error"; msg: string } | null>(null);
+
+  const cargar = async () => {
+    setCargando(true);
+    try {
+      const data = await listarDocumentosEmpresa();
+      setDocumentos(data);
+    } catch (e: any) {
+      setToast({ tipo: "error", msg: e?.message ?? "Error al cargar documentos" });
+    } finally {
+      setCargando(false);
+    }
+  };
+
+  useEffect(() => { cargar(); }, []);
+
+  const abrirAsignaciones = async (doc: Documento) => {
+    setVerAsignacionesDe(doc);
+    setCargandoAsig(true);
+    try {
+      const data = await listarAsignaciones(doc.documentoId);
+      setAsignaciones(data);
+    } catch {
+      setAsignaciones([]);
+    } finally {
+      setCargandoAsig(false);
+    }
+  };
+
+  const eliminarDoc = async (doc: Documento) => {
+    if (!confirm(`¿Eliminar el documento "${doc.titulo}"? Esta acción es irreversible para los empleados.`)) return;
+    try {
+      await desactivarDocumento(doc.documentoId);
+      setDocumentos((prev) => prev.filter((d) => d.documentoId !== doc.documentoId));
+      setToast({ tipo: "ok", msg: "Documento eliminado" });
+    } catch (e: any) {
+      setToast({ tipo: "error", msg: e?.message ?? "Error al eliminar" });
+    }
+  };
+
+  return (
+    <div className="animate-fadeIn">
+      {/* Cabecera */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-xl font-bold text-slate-800 flex items-center gap-2">
+            <FileText className="w-5 h-5 text-blue-700" />
+            Documentos
+          </h2>
+          <p className="text-sm text-slate-500 mt-1">
+            Sube documentos (nóminas, contratos, certificados...) y asígnalos a empleados o departamentos.
+          </p>
+        </div>
+        <button
+          onClick={() => setShowSubir(true)}
+          className="inline-flex items-center gap-2 text-sm font-semibold px-4 py-2.5 rounded-xl transition-colors"
+          style={{ background: "var(--azul-egm)", color: "white" }}
+        >
+          <Upload className="w-4 h-4" />
+          Subir documento
+        </button>
+      </div>
+
+      {/* Listado */}
+      {cargando ? (
+        <div className="flex items-center justify-center py-20">
+          <div className="w-8 h-8 border-2 rounded-full animate-spin"
+            style={{ borderColor: "var(--gris-borde)", borderTopColor: "var(--azul-egm)" }} />
+        </div>
+      ) : documentos.length === 0 ? (
+        <div className="bg-white rounded-2xl border border-slate-100 shadow-sm p-12 text-center">
+          <FileText className="w-12 h-12 text-slate-300 mx-auto mb-3" />
+          <p className="text-sm font-medium text-slate-600">Aún no hay documentos subidos</p>
+          <p className="text-xs text-slate-400 mt-1">Empieza subiendo uno con el botón de arriba.</p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 border-b border-slate-100">
+              <tr>
+                <th className="px-5 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Documento</th>
+                <th className="px-5 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Tipo</th>
+                <th className="px-5 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Subido</th>
+                <th className="px-5 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider">Asignaciones</th>
+                <th className="px-5 py-3 text-right text-xs font-semibold text-slate-500 uppercase tracking-wider">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {documentos.map((d) => {
+                const color = TIPO_DOCUMENTO_COLOR[d.tipo];
+                return (
+                  <tr key={d.documentoId} className="hover:bg-slate-50/50">
+                    <td className="px-5 py-4">
+                      <div className="flex items-start gap-3">
+                        <div className="w-9 h-9 rounded-lg bg-blue-50 flex items-center justify-center shrink-0">
+                          <FileText className="w-4 h-4 text-blue-600" />
+                        </div>
+                        <div>
+                          <p className="font-semibold text-slate-800">{d.titulo}</p>
+                          {d.descripcion && <p className="text-xs text-slate-500 mt-0.5">{d.descripcion}</p>}
+                          <p className="text-xs text-slate-400 mt-0.5">{d.archivoNombre}</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-5 py-4">
+                      <span className="inline-flex px-2.5 py-1 rounded-md text-xs font-semibold"
+                        style={{ background: color.bg, color: color.text }}>
+                        {TIPO_DOCUMENTO_LABEL[d.tipo]}
+                      </span>
+                      {d.requiereFirma && (
+                        <span className="block text-[10px] text-amber-600 font-semibold mt-1 uppercase tracking-wider">
+                          Requiere firma
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-xs text-slate-500">
+                      {new Date(d.fechaSubida).toLocaleDateString("es-ES", { day: "2-digit", month: "short", year: "numeric" })}
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="text-xs text-slate-600">
+                        <span className="font-semibold">{d.totalAsignados ?? 0}</span> asignados
+                        <span className="text-slate-400"> · </span>
+                        <span className="text-emerald-600 font-semibold">{d.totalVistos ?? 0}</span> vistos
+                        {d.requiereFirma && (
+                          <>
+                            <span className="text-slate-400"> · </span>
+                            <span className="text-violet-600 font-semibold">{d.totalFirmados ?? 0}</span> firmados
+                          </>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          onClick={() => abrirAsignaciones(d)}
+                          className="p-2 rounded-lg hover:bg-slate-100 text-slate-600"
+                          title="Ver detalle de asignaciones"
+                        >
+                          <Users className="w-4 h-4" />
+                        </button>
+                        <a
+                          href={d.archivoUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="p-2 rounded-lg hover:bg-slate-100 text-slate-600"
+                          title="Ver documento"
+                        >
+                          <Eye className="w-4 h-4" />
+                        </a>
+                        <button
+                          onClick={() => eliminarDoc(d)}
+                          className="p-2 rounded-lg hover:bg-red-50 text-red-500"
+                          title="Eliminar"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Modal subir */}
+      {showSubir && (
+        <ModalSubirDocumento
+          empleados={empleados}
+          departamentos={departamentos}
+          onCancel={() => setShowSubir(false)}
+          onUploaded={(d) => {
+            setDocumentos((prev) => [d, ...prev]);
+            setShowSubir(false);
+            setToast({ tipo: "ok", msg: "Documento subido correctamente" });
+          }}
+          onError={(msg) => setToast({ tipo: "error", msg })}
+        />
+      )}
+
+      {/* Modal asignaciones */}
+      {verAsignacionesDe && (
+        <ModalAsignaciones
+          documento={verAsignacionesDe}
+          asignaciones={asignaciones}
+          cargando={cargandoAsig}
+          onClose={() => { setVerAsignacionesDe(null); setAsignaciones([]); }}
+        />
+      )}
+
+      {/* Toast */}
+      {toast && (
+        <div
+          className="fixed bottom-6 left-1/2 z-300 flex items-center gap-2.5 px-5 py-3 rounded-2xl text-sm font-semibold shadow-xl"
+          style={{
+            transform: "translateX(-50%)",
+            background: toast.tipo === "ok"
+              ? "linear-gradient(135deg, #059669 0%, #10B981 100%)"
+              : "linear-gradient(135deg, #B91C1C 0%, #EF4444 100%)",
+            color: "#fff",
+            animation: "toastIn 0.3s cubic-bezier(0.34,1.56,0.64,1)",
+          }}
+          onAnimationEnd={() => setTimeout(() => setToast(null), 3000)}
+        >
+          {toast.tipo === "ok" ? <Check className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {toast.msg}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Modal: subir documento ─────────────────────────────────────────────────
+
+function ModalSubirDocumento({
+  empleados, departamentos, onCancel, onUploaded, onError,
+}: {
+  empleados: Props["empleados"];
+  departamentos: Props["departamentos"];
+  onCancel: () => void;
+  onUploaded: (d: Documento) => void;
+  onError: (msg: string) => void;
+}) {
+  const [file, setFile] = useState<File | null>(null);
+  const [titulo, setTitulo] = useState("");
+  const [descripcion, setDescripcion] = useState("");
+  const [tipo, setTipo] = useState<TipoDocumento>("NOMINA");
+  const [requiereFirma, setRequiereFirma] = useState(false);
+  const [notificar, setNotificar] = useState(true);
+  const [destino, setDestino] = useState<"todos" | "departamentos" | "empleados">("empleados");
+  const [dptosSel, setDptosSel] = useState<Set<string>>(new Set());
+  const [usersSel, setUsersSel] = useState<Set<string>>(new Set());
+  const [enviando, setEnviando] = useState(false);
+
+  const toggleSet = (s: Set<string>, v: string) => {
+    const ns = new Set(s);
+    if (ns.has(v)) ns.delete(v); else ns.add(v);
+    return ns;
+  };
+
+  const puedeEnviar = !!file && titulo.trim().length > 0 && (
+    destino === "todos" ||
+    (destino === "departamentos" && dptosSel.size > 0) ||
+    (destino === "empleados" && usersSel.size > 0)
+  );
+
+  const submit = async () => {
+    if (!puedeEnviar || !file) return;
+    setEnviando(true);
+    const input: SubirDocumentoInput = {
+      file,
+      titulo: titulo.trim(),
+      descripcion: descripcion.trim() || undefined,
+      tipo,
+      requiereFirma,
+      notificar,
+      asignarATodos: destino === "todos",
+      departamentos: destino === "departamentos" ? Array.from(dptosSel) : [],
+      usuariosIds: destino === "empleados" ? Array.from(usersSel) : [],
+    };
+    try {
+      const doc = await subirDocumento(input);
+      onUploaded(doc);
+    } catch (e: any) {
+      onError(e?.message ?? "No se pudo subir el documento");
+    } finally {
+      setEnviando(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-100 flex items-center justify-center p-4"
+      style={{ background: "rgba(15, 25, 35, 0.55)", backdropFilter: "blur(2px)" }}
+      onClick={onCancel}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl max-h-[88vh] overflow-hidden flex flex-col"
+      >
+        <div className="px-6 py-5 border-b border-slate-100 flex items-start justify-between">
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Nuevo documento</p>
+            <h3 className="text-xl font-bold text-slate-800">Subir y asignar</h3>
+          </div>
+          <button onClick={onCancel} className="w-8 h-8 rounded-lg hover:bg-slate-100 flex items-center justify-center text-slate-500">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="overflow-y-auto p-6 space-y-5">
+          {/* Archivo */}
+          <div>
+            <label className="text-xs font-semibold text-slate-600 uppercase tracking-wider mb-1.5 block">Archivo</label>
+            <label className="flex items-center justify-center gap-2 px-4 py-6 border-2 border-dashed border-slate-200 rounded-xl cursor-pointer hover:border-blue-400 hover:bg-blue-50/30 transition-colors">
+              <input
+                type="file"
+                accept="application/pdf,image/*"
+                className="hidden"
+                onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              />
+              {file ? (
+                <div className="flex items-center gap-2 text-slate-700">
+                  <FileText className="w-5 h-5 text-blue-600" />
+                  <span className="text-sm font-medium">{file.name}</span>
+                  <span className="text-xs text-slate-400">({(file.size / 1024).toFixed(0)} KB)</span>
+                </div>
+              ) : (
+                <div className="text-center">
+                  <Upload className="w-6 h-6 text-slate-400 mx-auto mb-1" />
+                  <p className="text-sm text-slate-600">Selecciona un archivo (PDF o imagen)</p>
+                  <p className="text-xs text-slate-400">Máximo 25 MB</p>
+                </div>
+              )}
+            </label>
+          </div>
+
+          {/* Título */}
+          <div>
+            <label className="text-xs font-semibold text-slate-600 uppercase tracking-wider mb-1.5 block">Título</label>
+            <input
+              type="text"
+              value={titulo}
+              onChange={(e) => setTitulo(e.target.value)}
+              placeholder="Ej: Nómina octubre 2026"
+              className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500"
+            />
+          </div>
+
+          {/* Descripción */}
+          <div>
+            <label className="text-xs font-semibold text-slate-600 uppercase tracking-wider mb-1.5 block">Descripción (opcional)</label>
+            <textarea
+              value={descripcion}
+              onChange={(e) => setDescripcion(e.target.value)}
+              rows={2}
+              placeholder="Comentario o instrucciones para el empleado"
+              className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500 resize-none"
+            />
+          </div>
+
+          {/* Tipo + firma + notificar */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="text-xs font-semibold text-slate-600 uppercase tracking-wider mb-1.5 block">Tipo</label>
+              <select
+                value={tipo}
+                onChange={(e) => setTipo(e.target.value as TipoDocumento)}
+                className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500"
+              >
+                {TIPOS.map((t) => (
+                  <option key={t} value={t}>{TIPO_DOCUMENTO_LABEL[t]}</option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2 pt-5">
+              <label className="flex items-center gap-2 text-sm text-slate-700 cursor-pointer">
+                <input type="checkbox" checked={requiereFirma} onChange={(e) => setRequiereFirma(e.target.checked)} className="accent-blue-600 w-4 h-4" />
+                Requiere firma
+              </label>
+              <label className="flex items-center gap-2 text-sm text-slate-700 cursor-pointer">
+                <input type="checkbox" checked={notificar} onChange={(e) => setNotificar(e.target.checked)} className="accent-blue-600 w-4 h-4" />
+                Notificar al empleado
+              </label>
+            </div>
+          </div>
+
+          {/* Asignación */}
+          <div>
+            <label className="text-xs font-semibold text-slate-600 uppercase tracking-wider mb-2 block">Asignar a</label>
+            <div className="flex gap-2 mb-3">
+              {([
+                { id: "empleados",      label: "Empleados",     icon: Users },
+                { id: "departamentos",  label: "Departamentos", icon: Building2 },
+                { id: "todos",          label: "Toda la empresa", icon: Users },
+              ] as const).map((opt) => {
+                const Icon = opt.icon;
+                const active = destino === opt.id;
+                return (
+                  <button
+                    key={opt.id}
+                    onClick={() => setDestino(opt.id)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors"
+                    style={{
+                      background: active ? "var(--azul-egm)" : "var(--gris-superficie)",
+                      color:      active ? "white" : "var(--texto-primario)",
+                    }}
+                  >
+                    <Icon className="w-3.5 h-3.5" />
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+
+            {destino === "empleados" && (
+              <div className="max-h-48 overflow-y-auto border border-slate-200 rounded-lg p-2 bg-slate-50/50">
+                {empleados.length === 0 ? (
+                  <p className="text-xs text-slate-400 text-center py-4">No hay empleados</p>
+                ) : empleados.map((e) => (
+                  <label key={e.usuarioId} className="flex items-center gap-2 px-2 py-1.5 hover:bg-white rounded cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={usersSel.has(e.usuarioId)}
+                      onChange={() => setUsersSel((s) => toggleSet(s, e.usuarioId))}
+                      className="accent-blue-600 w-4 h-4"
+                    />
+                    <span className="text-sm text-slate-700">{e.nombre} {e.apellidos}</span>
+                    {e.departamento && <span className="text-xs text-slate-400">({e.departamento})</span>}
+                  </label>
+                ))}
+              </div>
+            )}
+
+            {destino === "departamentos" && (
+              <div className="flex flex-wrap gap-2">
+                {departamentos.map((d) => {
+                  const sel = dptosSel.has(d.id);
+                  return (
+                    <button
+                      key={d.id}
+                      onClick={() => setDptosSel((s) => toggleSet(s, d.id))}
+                      className="px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors"
+                      style={{
+                        background:  sel ? "var(--azul-egm)" : "white",
+                        color:       sel ? "white" : "var(--texto-primario)",
+                        borderColor: sel ? "var(--azul-egm)" : "var(--gris-borde)",
+                      }}
+                    >
+                      {d.label}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            {destino === "todos" && (
+              <p className="text-xs text-slate-500 bg-amber-50 border border-amber-100 rounded-lg p-3">
+                <AlertTriangle className="w-3.5 h-3.5 inline mr-1 -mt-0.5 text-amber-600" />
+                El documento se asignará a todos los empleados activos de la empresa.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-slate-100 flex items-center justify-end gap-2">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100 rounded-lg"
+          >
+            Cancelar
+          </button>
+          <IAButton size="md" onClick={submit} loading={enviando} loadingLabel="Subiendo..." disabled={!puedeEnviar}>
+            Subir y asignar
+          </IAButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Modal: detalle de asignaciones ─────────────────────────────────────────
+
+function ModalAsignaciones({
+  documento, asignaciones, cargando, onClose,
+}: {
+  documento: Documento;
+  asignaciones: AsignacionDetalle[];
+  cargando: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-100 flex items-center justify-center p-4"
+      style={{ background: "rgba(15, 25, 35, 0.55)", backdropFilter: "blur(2px)" }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl max-h-[80vh] overflow-hidden flex flex-col"
+      >
+        <div className="px-6 py-5 border-b border-slate-100 flex items-start justify-between">
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Asignaciones</p>
+            <h3 className="text-xl font-bold text-slate-800">{documento.titulo}</h3>
+          </div>
+          <button onClick={onClose} className="w-8 h-8 rounded-lg hover:bg-slate-100 flex items-center justify-center text-slate-500">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="overflow-y-auto p-6">
+          {cargando ? (
+            <div className="flex items-center justify-center py-10">
+              <div className="w-6 h-6 border-2 rounded-full animate-spin"
+                style={{ borderColor: "var(--gris-borde)", borderTopColor: "var(--azul-egm)" }} />
+            </div>
+          ) : asignaciones.length === 0 ? (
+            <p className="text-sm text-slate-400 text-center py-8">Sin asignaciones</p>
+          ) : (
+            <ul className="space-y-2">
+              {asignaciones.map((a) => (
+                <li key={a.asignacionId} className="flex items-center justify-between py-2 px-3 rounded-lg bg-slate-50">
+                  <div>
+                    <p className="text-sm font-medium text-slate-700">{a.nombre} {a.apellidos}</p>
+                    {a.departamento && <p className="text-xs text-slate-400">{a.departamento}</p>}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {a.visto ? (
+                      <span className="inline-flex items-center gap-1 text-xs text-emerald-700 font-semibold">
+                        <Check className="w-3.5 h-3.5" />
+                        Visto
+                      </span>
+                    ) : (
+                      <span className="text-xs text-slate-400">Pendiente</span>
+                    )}
+                    {documento.requiereFirma && a.firmado && (
+                      <span className="inline-flex items-center gap-1 text-xs text-violet-700 font-semibold">
+                        <Check className="w-3.5 h-3.5" />
+                        Firmado
+                      </span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/documentos/MisDocumentos.tsx
+++ b/components/documentos/MisDocumentos.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+// ============================================================
+// MisDocumentos — sección del perfil del empleado con sus
+// documentos asignados (nóminas, certificados, etc.).
+// ============================================================
+
+import { useEffect, useMemo, useState } from "react";
+import { listarMisDocumentos, marcarDocumentoVisto } from "@/lib/api/documentos";
+import {
+  type Documento, type TipoDocumento,
+  TIPO_DOCUMENTO_LABEL, TIPO_DOCUMENTO_COLOR,
+} from "@/lib/types/documentos";
+import { FileText, Download, Eye, Check, ClipboardSignature } from "lucide-react";
+
+type Filtro = "todos" | "pendientes" | "firmados" | TipoDocumento;
+
+export function MisDocumentos() {
+  const [documentos, setDocumentos] = useState<Documento[]>([]);
+  const [cargando, setCargando] = useState(true);
+  const [filtro, setFiltro] = useState<Filtro>("todos");
+
+  useEffect(() => {
+    listarMisDocumentos()
+      .then(setDocumentos)
+      .catch(() => setDocumentos([]))
+      .finally(() => setCargando(false));
+  }, []);
+
+  const verDocumento = async (d: Documento) => {
+    // Marcar visto en BD (no bloqueamos la navegación si falla)
+    if (!d.visto) {
+      marcarDocumentoVisto(d.documentoId).catch(() => null);
+      setDocumentos((prev) => prev.map((x) =>
+        x.documentoId === d.documentoId ? { ...x, visto: true, fechaVisto: new Date().toISOString() } : x
+      ));
+    }
+    window.open(d.archivoUrl, "_blank", "noopener,noreferrer");
+  };
+
+  const filtrados = useMemo(() => {
+    switch (filtro) {
+      case "todos":      return documentos;
+      case "pendientes": return documentos.filter((d) => !d.visto || (d.requiereFirma && !d.firmado));
+      case "firmados":   return documentos.filter((d) => d.firmado);
+      default:           return documentos.filter((d) => d.tipo === filtro);
+    }
+  }, [documentos, filtro]);
+
+  const contadorPendientes = documentos.filter((d) => !d.visto || (d.requiereFirma && !d.firmado)).length;
+
+  return (
+    <section className="bg-white rounded-2xl border border-slate-100 shadow-sm p-6">
+      <div className="flex items-center justify-between mb-5">
+        <div>
+          <h2 className="text-lg font-bold text-slate-800 flex items-center gap-2">
+            <FileText className="w-5 h-5 text-blue-700" />
+            Mis documentos
+          </h2>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Documentos asignados por tu empresa (nóminas, certificados, contratos...)
+          </p>
+        </div>
+        {contadorPendientes > 0 && (
+          <span className="inline-flex items-center gap-1 text-xs font-semibold px-3 py-1 rounded-full bg-amber-100 text-amber-700">
+            {contadorPendientes} pendiente{contadorPendientes !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {/* Filtros */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        {(["todos", "pendientes", "firmados", "NOMINA", "CONTRATO", "CERTIFICADO", "POLITICA", "OTRO"] as Filtro[]).map((f) => {
+          const label = f === "todos" ? "Todos"
+            : f === "pendientes" ? "Pendientes"
+            : f === "firmados"   ? "Firmados"
+            : TIPO_DOCUMENTO_LABEL[f as TipoDocumento];
+          const active = filtro === f;
+          return (
+            <button
+              key={f}
+              onClick={() => setFiltro(f)}
+              className="px-3 py-1.5 rounded-full text-xs font-semibold transition-colors"
+              style={{
+                background: active ? "var(--azul-egm)" : "var(--gris-superficie)",
+                color:      active ? "white" : "var(--texto-primario)",
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Lista */}
+      {cargando ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="w-6 h-6 border-2 rounded-full animate-spin"
+            style={{ borderColor: "var(--gris-borde)", borderTopColor: "var(--azul-egm)" }} />
+        </div>
+      ) : filtrados.length === 0 ? (
+        <div className="text-center py-10">
+          <FileText className="w-10 h-10 text-slate-300 mx-auto mb-2" />
+          <p className="text-sm text-slate-500">
+            {filtro === "todos" ? "Aún no tienes documentos asignados" : "No hay documentos con este filtro"}
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {filtrados.map((d) => {
+            const color = TIPO_DOCUMENTO_COLOR[d.tipo];
+            return (
+              <li key={d.documentoId} className="border border-slate-100 rounded-xl p-4 hover:border-blue-200 hover:bg-blue-50/20 transition-colors">
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-blue-50 flex items-center justify-center shrink-0">
+                    <FileText className="w-5 h-5 text-blue-600" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
+                      <span className="inline-flex px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider"
+                        style={{ background: color.bg, color: color.text }}>
+                        {TIPO_DOCUMENTO_LABEL[d.tipo]}
+                      </span>
+                      {!d.visto && (
+                        <span className="inline-flex px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider bg-blue-100 text-blue-700">
+                          Nuevo
+                        </span>
+                      )}
+                      {d.requiereFirma && !d.firmado && (
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider bg-amber-100 text-amber-700">
+                          <ClipboardSignature className="w-3 h-3" />
+                          Pendiente firma
+                        </span>
+                      )}
+                      {d.firmado && (
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider bg-emerald-100 text-emerald-700">
+                          <Check className="w-3 h-3" />
+                          Firmado
+                        </span>
+                      )}
+                    </div>
+                    <p className="font-semibold text-slate-800 truncate">{d.titulo}</p>
+                    {d.descripcion && <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">{d.descripcion}</p>}
+                    <p className="text-[11px] text-slate-400 mt-1">
+                      Asignado el {new Date(d.fechaSubida).toLocaleDateString("es-ES", { day: "2-digit", month: "short", year: "numeric" })}
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-1.5 shrink-0">
+                    <button
+                      onClick={() => verDocumento(d)}
+                      className="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors"
+                      style={{ background: "var(--azul-egm)", color: "white" }}
+                    >
+                      <Eye className="w-3.5 h-3.5" />
+                      Ver
+                    </button>
+                    <a
+                      href={d.archivoUrl}
+                      download={d.archivoNombre}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50"
+                    >
+                      <Download className="w-3.5 h-3.5" />
+                      Descargar
+                    </a>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/lib/api/documentos.ts
+++ b/lib/api/documentos.ts
@@ -1,0 +1,61 @@
+import { API_URL, apiFetch } from "../api";
+import type { Documento, AsignacionDetalle, SubirDocumentoInput } from "../types/documentos";
+
+// ── ADMIN ──────────────────────────────────────────────────────────────────
+
+export async function subirDocumento(input: SubirDocumentoInput): Promise<Documento> {
+  const fd = new FormData();
+  fd.append("file", input.file);
+  fd.append("titulo", input.titulo);
+  if (input.descripcion) fd.append("descripcion", input.descripcion);
+  fd.append("tipo", input.tipo);
+  fd.append("requiereFirma", String(input.requiereFirma));
+  fd.append("asignarATodos", String(input.asignarATodos));
+  fd.append("notificar", String(input.notificar));
+  for (const id of input.usuariosIds ?? []) fd.append("usuariosIds", id);
+  for (const d of input.departamentos ?? []) fd.append("departamentos", d);
+
+  const res = await apiFetch(`${API_URL}/documentos`, {
+    method: "POST",
+    body: fd,
+  });
+  if (!res.ok) {
+    const msg = await res.text().catch(() => "");
+    throw new Error(msg || "No se pudo subir el documento");
+  }
+  return res.json();
+}
+
+export async function listarDocumentosEmpresa(): Promise<Documento[]> {
+  const res = await apiFetch(`${API_URL}/documentos`);
+  if (!res.ok) throw new Error("Error al cargar documentos");
+  return res.json();
+}
+
+export async function listarAsignaciones(documentoId: string): Promise<AsignacionDetalle[]> {
+  const res = await apiFetch(`${API_URL}/documentos/${documentoId}/asignaciones`);
+  if (!res.ok) throw new Error("Error al cargar asignaciones");
+  return res.json();
+}
+
+export async function desactivarDocumento(documentoId: string): Promise<void> {
+  const res = await apiFetch(`${API_URL}/documentos/${documentoId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw new Error("Error al eliminar documento");
+}
+
+// ── EMPLEADO ───────────────────────────────────────────────────────────────
+
+export async function listarMisDocumentos(): Promise<Documento[]> {
+  const res = await apiFetch(`${API_URL}/documentos/me`);
+  if (!res.ok) throw new Error("Error al cargar tus documentos");
+  return res.json();
+}
+
+export async function marcarDocumentoVisto(documentoId: string): Promise<void> {
+  const res = await apiFetch(`${API_URL}/documentos/me/${documentoId}/visto`, {
+    method: "POST",
+  });
+  if (!res.ok) throw new Error("Error al marcar visto");
+}

--- a/lib/types/documentos.ts
+++ b/lib/types/documentos.ts
@@ -1,0 +1,79 @@
+// Tipos para gestión documental
+
+export type TipoDocumento =
+  | "NOMINA"
+  | "CONTRATO"
+  | "CERTIFICADO"
+  | "POLITICA"
+  | "OTRO";
+
+export const TIPO_DOCUMENTO_LABEL: Record<TipoDocumento, string> = {
+  NOMINA:      "Nómina",
+  CONTRATO:    "Contrato",
+  CERTIFICADO: "Certificado",
+  POLITICA:    "Política",
+  OTRO:        "Otro",
+};
+
+export const TIPO_DOCUMENTO_COLOR: Record<TipoDocumento, { bg: string; text: string }> = {
+  NOMINA:      { bg: "#DBEAFE", text: "#1D4ED8" },
+  CONTRATO:    { bg: "#EDE9FE", text: "#6B21A8" },
+  CERTIFICADO: { bg: "#D1FAE5", text: "#065F46" },
+  POLITICA:    { bg: "#FEF3E2", text: "#92400E" },
+  OTRO:        { bg: "#F3F4F6", text: "#374151" },
+};
+
+export interface Documento {
+  documentoId: string;
+  empresaId: string;
+  titulo: string;
+  descripcion?: string | null;
+  tipo: TipoDocumento;
+  archivoUrl: string;
+  archivoNombre: string;
+  mimeType?: string | null;
+  tamanoBytes?: number | null;
+  subidoPor: string;
+  subidoPorNombre?: string | null;
+  requiereFirma: boolean;
+  activo: boolean;
+  fechaSubida: string;
+
+  // Solo en /documentos/me
+  asignacionId?: string;
+  visto?: boolean;
+  fechaVisto?: string | null;
+  firmado?: boolean;
+  fechaFirma?: string | null;
+  firmaUrl?: string | null;
+
+  // Solo en /documentos (admin)
+  totalAsignados?: number;
+  totalVistos?: number;
+  totalFirmados?: number;
+}
+
+export interface AsignacionDetalle {
+  asignacionId: string;
+  usuarioId: string;
+  nombre: string;
+  apellidos: string;
+  departamento?: string | null;
+  fechaAsignacion: string;
+  visto: boolean;
+  fechaVisto?: string | null;
+  firmado: boolean;
+  fechaFirma?: string | null;
+}
+
+export interface SubirDocumentoInput {
+  titulo: string;
+  descripcion?: string;
+  tipo: TipoDocumento;
+  requiereFirma: boolean;
+  asignarATodos: boolean;
+  usuariosIds?: string[];
+  departamentos?: string[];
+  notificar: boolean;
+  file: File;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -323,7 +322,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
       "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -614,7 +612,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -637,7 +634,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -660,7 +656,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -677,7 +672,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -694,7 +688,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -711,7 +704,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -728,7 +720,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -745,7 +736,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -762,7 +752,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -779,7 +768,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -796,7 +784,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -813,7 +800,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -830,7 +816,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -853,7 +838,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -876,7 +860,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -899,7 +882,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -922,7 +904,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -945,7 +926,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -968,7 +948,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -991,7 +970,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1014,7 +992,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1034,7 +1011,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1054,7 +1030,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1074,7 +1049,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2450,7 +2424,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2532,7 +2505,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -3058,7 +3030,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3566,7 +3537,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4500,7 +4470,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4686,7 +4655,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5405,8 +5373,7 @@
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
       "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
-      "peer": true
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -7737,7 +7704,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7747,7 +7713,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7768,15 +7733,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7873,8 +7836,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8700,7 +8662,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8881,7 +8842,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9335,7 +9295,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Frontend que consume los nuevos endpoints /api/v1/documentos.

Admin (nuevo tab "Documentos" en /dashboard/admin):
- Listado con tipo, fecha, contadores (asignados / vistos / firmados)
- Modal de subida con título, descripción, tipo, requiereFirma, notificación y selector de destino (empleados específicos, departamentos o toda la empresa)
- Modal de detalle de asignaciones (estado por empleado)
- Acciones: ver, descargar, eliminar (soft delete)

Empleado (sección "Mis documentos" en /dashboard/perfil):
- Listado con badges (Nuevo / Pendiente firma / Firmado)
- Filtros: todos · pendientes · firmados · por tipo
- Contador de pendientes en la cabecera
- Al pulsar "Ver" se abre la URL y se marca como visto automáticamente
- Botón de descarga directa

Nuevos archivos:
- lib/types/documentos.ts
- lib/api/documentos.ts
- components/documentos/DocumentosAdminTab.tsx
- components/documentos/MisDocumentos.tsx