### PR TITLE
feat(admin): mejoras UX completas en tab empleados — responsive, tabl…

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "motion/react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Suspense } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -9,7 +11,10 @@ import { getNoticias, crearNoticia, editarNoticia, desactivarNoticia } from "@/l
 import { getModulos } from "@/lib/api/modulos";
 import { getProgresoEmpresa } from "@/lib/api/progreso";
 import { QK } from "@/lib/queryKeys";
-import { ChartNoAxesCombined, Check, ChevronDown, ChevronRight, Download, FileText, LibraryBig, Megaphone, Newspaper, Plus, RefreshCw, SlidersHorizontal, TriangleAlert, Upload, Users, X } from "lucide-react";
+import { BarChart3, Check, ChevronDown, ChevronLeft, ChevronRight, Download, Eye, EyeOff, FileText, GraduationCap, LibraryBig, Megaphone, Plus, RefreshCw, Search, SlidersHorizontal, TriangleAlert, Upload, Users, X } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { IconButton } from "@/components/ui/IconButton";
+import Grainient from "@/components/ui/Grainient";
 import FormAnuncio from "@/components/ui/FormAnuncio";
 import type { Noticia, NoticiaInput } from "@/lib/types/noticias";
 import type { Modulo } from "@/lib/types/modulos";
@@ -115,6 +120,7 @@ function AdminContent() {
   const { usuario } = useAuth();
 
   const [activeTab, setActiveTab] = useState<"empleados" | "anuncios" | "formaciones" | "incidencias" | "estadisticas" | "documentos">("empleados");
+  const [tabMenuOpen, setTabMenuOpen] = useState(false);
 
   const queryClient = useQueryClient();
 
@@ -157,11 +163,23 @@ function AdminContent() {
 
   // ── Pagination ───────────────────────────────────────────────────────────────
   const PAGE_SIZE = 25;
+  const PAGE_SIZE_MOBILE = 10;
   const [empPage, setEmpPage] = useState(0);
-  const [progPage, setProgPage] = useState(0);
+
+  // Resetear página al cruzar el breakpoint md (768px) para evitar slices vacíos
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    const handler = () => setEmpPage(0);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // ── Filtros empleados ────────────────────────────────────────────────────────
+  const [empSearch, setEmpSearch] = useState("");
 
   // ── UI state ─────────────────────────────────────────────────────────────────
   const [showFormEmpleado, setShowFormEmpleado] = useState(false);
+
   const [formEmpleado, setFormEmpleado] = useState<NuevoEmpleadoForm>(EMPTY_EMPLEADO);
   const [guardandoEmpleado, setGuardandoEmpleado] = useState(false);
   const [errorEmpleado, setErrorEmpleado] = useState<string | null>(null);
@@ -171,7 +189,23 @@ function AdminContent() {
 
   const inputImportRef = useRef<HTMLInputElement>(null);
   const [importando, setImportando] = useState(false);
+  const [exportando, setExportando] = useState(false);
   const [importResult, setImportResult] = useState<{ ok: number; errors: string[] } | null>(null);
+
+  // ── Scroll lock — modal y slide-over ─────────────────────────────────────────
+  useEffect(() => {
+    if (showFormEmpleado || !!empleadoSeleccionado) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => { document.body.style.overflow = prev; };
+    }
+  }, [showFormEmpleado, empleadoSeleccionado]);
+  const [toast, setToast] = useState<{ msg: string; tipo: "ok" | "error" } | null>(null);
+
+  const mostrarToast = (msg: string, tipo: "ok" | "error" = "ok") => {
+    setToast({ msg, tipo });
+    setTimeout(() => setToast(null), 3500);
+  };
 
   const [showFormAnuncio, setShowFormAnuncio] = useState(false);
   const [editando, setEditando] = useState<Noticia | null>(null);
@@ -244,7 +278,6 @@ function AdminContent() {
   };
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
-  const [toast, setToast] = useState<string | null>(null);
   const [showBorradores, setShowBorradores] = useState(true);
 
   useEffect(() => {
@@ -393,12 +426,6 @@ function AdminContent() {
     } catch { }
   };
 
-  function mostrarToast(msg: string) {
-    setToast(msg);
-    setTimeout(() => setToast(null), 3200);
-  }
-
-
   function abrirCrear() {
     setInitialForm({
       titulo: "", contenido: "", esGlobal: false, empresaId: usuario?.empresaId ?? null, imagenUrl: null,
@@ -518,6 +545,7 @@ function AdminContent() {
   }
 
   const exportarEmpleadosExcel = async () => {
+    setExportando(true);
     const workbook = new ExcelJS.Workbook();
     const worksheet = workbook.addWorksheet("Empleados");
 
@@ -564,6 +592,8 @@ function AdminContent() {
     a.download = `empleados_${fecha}.xlsx`;
     a.click();
     window.URL.revokeObjectURL(url);
+    setExportando(false);
+    mostrarToast(`Excel exportado con ${empleados.length} empleados`);
   };
 
   const importarEmpleados = async (file: File) => {
@@ -611,51 +641,69 @@ function AdminContent() {
     setImportando(false);
     setImportResult({ ok, errors: errores });
     queryClient.invalidateQueries({ queryKey: QK.empleados(usuario?.empresaId) });
+    if (errores.length === 0) {
+      mostrarToast(`${ok} empleado${ok !== 1 ? "s" : ""} importado${ok !== 1 ? "s" : ""} correctamente`);
+    } else if (ok > 0) {
+      mostrarToast(`${ok} importado${ok !== 1 ? "s" : ""}, ${errores.length} con error`, "error");
+    } else {
+      mostrarToast("Error al importar el archivo", "error");
+    }
   };
 
+  // ── Ordenación tabla desktop ─────────────────────────────────────────────────
+  type EmpSortCol = "nombre" | "puesto" | "departamento" | "perfil" | "estado" | null;
+  const [empSort, setEmpSort] = useState<{ col: EmpSortCol; dir: "asc" | "desc" }>({ col: null, dir: "asc" });
+
+  const toggleEmpSort = (col: Exclude<EmpSortCol, null>) => {
+    setEmpSort(prev =>
+      prev.col === col
+        ? { col, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { col, dir: "asc" }
+    );
+    setEmpPage(0);
+  };
+
+  const resetEmpSort = () => { setEmpSort({ col: null, dir: "asc" }); setEmpPage(0); };
+
+  // ── Empleados filtrados + ordenados (frontend) ───────────────────────────────
+  const empleadosFiltrados = (() => {
+    const q = empSearch.toLowerCase();
+    const filtered = empleados.filter((e) =>
+      !q || [e.nombre, e.apellidos, e.email, e.puestoTrabajo ?? ""].some((v) => v.toLowerCase().includes(q))
+    );
+    if (!empSort.col) return filtered;
+    const dir = empSort.dir === "asc" ? 1 : -1;
+    return [...filtered].sort((a, b) => {
+      switch (empSort.col) {
+        case "nombre":
+          return dir * `${a.nombre} ${a.apellidos}`.localeCompare(`${b.nombre} ${b.apellidos}`, "es");
+        case "puesto":
+          return dir * (a.puestoTrabajo ?? "").localeCompare(b.puestoTrabajo ?? "", "es");
+        case "departamento": {
+          const da = DEPARTAMENTOS.find(d => d.id === a.departamento)?.label ?? "";
+          const db = DEPARTAMENTOS.find(d => d.id === b.departamento)?.label ?? "";
+          return dir * da.localeCompare(db, "es");
+        }
+        case "perfil": {
+          const pa = a.codigoRol === "ROLE_ADMIN_EMPRESA" ? 0 : 1;
+          const pb = b.codigoRol === "ROLE_ADMIN_EMPRESA" ? 0 : 1;
+          return dir * (pa - pb);
+        }
+        case "estado":
+          return dir * ((a.activo ? 0 : 1) - (b.activo ? 0 : 1));
+        default:
+          return 0;
+      }
+    });
+  })();
+
   const tabs = [
-    {
-      key: "empleados" as const,
-      label: "Empleados",
-      icon: (
-        <Users />
-      ),
-    },
-    {
-      key: "anuncios" as const,
-      label: "Anuncios",
-      icon: (
-        <Newspaper />
-      ),
-    },
-    {
-      key: "formaciones" as const,
-      label: "Módulos formativos",
-      icon: (
-        <LibraryBig />
-      ),
-    },
-    {
-      key: "incidencias" as const,
-      label: "Incidencias",
-      icon: (
-        <TriangleAlert />
-      ),
-    },
-    {
-      key: "estadisticas" as const,
-      label: "Estadísticas",
-      icon: (
-        <ChartNoAxesCombined />
-      ),
-    },
-    {
-      key: "documentos" as const,
-      label: "Documentos",
-      icon: (
-        <FileText />
-      ),
-    },
+    { key: "empleados"   as const, label: "Empleados",         icon: <Users size={20} />,         accent: "#1B3F7E" },
+    { key: "incidencias" as const, label: "Incidencias",        icon: <TriangleAlert size={20} />, accent: "#B45309" },
+    { key: "anuncios"    as const, label: "Anuncios",           icon: <Megaphone size={20} />,     accent: "#0A8A96" },
+    { key: "formaciones" as const, label: "Módulos formativos", icon: <GraduationCap size={20} />, accent: "#7B4A85" },
+    { key: "estadisticas"as const, label: "Estadísticas",       icon: <BarChart3 size={20} />,     accent: "#2D8653" },
+    { key: "documentos"  as const, label: "Documentos",         icon: <FileText size={20} />,      accent: "#4E6D7E" },
   ];
 
   // Accent colors per modulo tipo for top strip
@@ -672,186 +720,323 @@ function AdminContent() {
       <DashboardHero
         prefijo="Panel de "
         titulo="Administración"
-        imagenFondo="/background-formacion-empleado.webp"
+        imagenFondo="/background-admin.webp"
       />
 
       <div className="px-10 lg:px-16 pt-10 pb-16">
-        {/* Tabs — desktop (pill style) */}
-        <div className="hidden sm:flex gap-2 mb-10 p-1 rounded-2xl w-fit"
-          style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-          {tabs.map((tab) => (
-            <button
-              key={tab.key}
-              onClick={() => setActiveTab(tab.key)}
-              className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold transition-all"
-              style={{
-                background: activeTab === tab.key ? "var(--azul-egm)" : "transparent",
-                color: activeTab === tab.key ? "white" : "var(--texto-muted)",
-              }}
-            >
-              {tab.icon}
-              {tab.label}
-            </button>
-          ))}
+        {/* Tabs — desktop */}
+        <div className="hidden sm:block mb-8"
+          style={{ borderBottom: "1px solid var(--gris-borde)" }}>
+          <div className="flex gap-1">
+            {tabs.map((tab) => {
+              const isActive = activeTab === tab.key;
+              return (
+                <motion.button
+                  key={tab.key}
+                  onClick={() => setActiveTab(tab.key)}
+                  className="relative flex items-center gap-2 px-5 py-3 text-base font-semibold focus:outline-none"
+                  animate={{ color: isActive ? tab.accent : "var(--texto-muted)" }}
+                  transition={{ duration: 0.18 }}
+                  style={{ background: "transparent", border: "none", cursor: "pointer" }}
+                  whileHover={{ color: isActive ? tab.accent : "var(--texto-primario)" }}
+                >
+                  {tab.icon}
+                  {tab.label}
+                  {isActive && (
+                    <motion.div
+                      layoutId="admin-tab-underline"
+                      style={{
+                        position: "absolute",
+                        bottom: -1,
+                        left: 0,
+                        right: 0,
+                        height: 2,
+                        borderRadius: 2,
+                        background: tab.accent,
+                      }}
+                      transition={{ type: "spring", stiffness: 380, damping: 32 }}
+                    />
+                  )}
+                </motion.button>
+              );
+            })}
+          </div>
         </div>
 
-        {/* Tabs — móvil (selector) */}
-        <div className="sm:hidden mb-8">
-          <select
-            value={activeTab}
-            onChange={(e) => setActiveTab(e.target.value as "empleados" | "anuncios" | "formaciones" | "incidencias" | "estadisticas" | "documentos")}
-            className="w-full rounded-xl px-4 py-3 text-sm font-semibold focus:outline-none"
-            style={{
-              border: "1px solid var(--gris-borde)",
-              background: "var(--blanco)",
-              color: "var(--texto-primario)",
-            }}
-          >
-            <option value="empleados">Empleados</option>
-            <option value="anuncios">Anuncios</option>
-            <option value="formaciones">Módulos formativos</option>
-            <option value="incidencias">Incidencias</option>
-            <option value="estadisticas">Estadísticas</option>
-            <option value="documentos">Documentos</option>
-          </select>
+        {/* Tabs — móvil (selector compacto con dropdown) */}
+        <div className="sm:hidden mb-6 relative">
+          {/* Botón selector — muestra tab activo */}
+          {(() => {
+            const activeTabData = tabs.find(t => t.key === activeTab)!;
+            return (
+              <motion.button
+                onClick={() => setTabMenuOpen(o => !o)}
+                whileTap={{ scale: 0.98 }}
+                className="w-full flex items-center gap-3 px-4 py-3.5 rounded-2xl focus:outline-none"
+                style={{
+                  background: "var(--blanco)",
+                  border: `1.5px solid ${tabMenuOpen ? activeTabData.accent : "var(--gris-borde)"}`,
+                  cursor: "pointer",
+                  transition: "border-color 0.18s",
+                }}
+              >
+                {/* Icono con color de acento */}
+                <span style={{ color: activeTabData.accent }}>
+                  {React.cloneElement(activeTabData.icon, { size: 20 })}
+                </span>
+                <span className="flex-1 text-left text-sm font-bold" style={{ color: "var(--texto-primario)" }}>
+                  {activeTabData.label}
+                </span>
+                <motion.span
+                  animate={{ rotate: tabMenuOpen ? 180 : 0 }}
+                  transition={{ duration: 0.2 }}
+                  style={{ color: "var(--texto-muted)", display: "flex" }}
+                >
+                  <ChevronDown size={18} />
+                </motion.span>
+              </motion.button>
+            );
+          })()}
+
+          {/* Dropdown de opciones */}
+          <AnimatePresence>
+            {tabMenuOpen && (
+              <motion.div
+                initial={{ opacity: 0, y: -6, scale: 0.97 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: -6, scale: 0.97 }}
+                transition={{ duration: 0.18, ease: [0.34, 1.2, 0.64, 1] }}
+                className="absolute top-full left-0 right-0 mt-2 rounded-2xl overflow-hidden z-30"
+                style={{
+                  background: "var(--blanco)",
+                  border: "1px solid var(--surface-border)",
+                  boxShadow: "0 8px 32px rgba(0,0,0,0.12)",
+                }}
+              >
+                {tabs.map((tab, idx) => {
+                  const isActive = activeTab === tab.key;
+                  return (
+                    <motion.button
+                      key={tab.key}
+                      onClick={() => { setActiveTab(tab.key); setTabMenuOpen(false); }}
+                      whileTap={{ scale: 0.98 }}
+                      className="w-full flex items-center gap-3 px-4 py-3.5 text-sm font-semibold focus:outline-none"
+                      style={{
+                        background: isActive ? tab.accent + "12" : "transparent",
+                        borderBottom: idx < tabs.length - 1 ? "1px solid var(--surface-border)" : "none",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <span style={{ color: isActive ? tab.accent : "var(--texto-muted)" }}>
+                        {React.cloneElement(tab.icon, { size: 18 })}
+                      </span>
+                      <span style={{ color: isActive ? tab.accent : "var(--texto-primario)" }}>
+                        {tab.label}
+                      </span>
+                      {isActive && (
+                        <span className="ml-auto w-2 h-2 rounded-full shrink-0" style={{ background: tab.accent }} />
+                      )}
+                    </motion.button>
+                  );
+                })}
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
+
+        {/* ── Contenido de tabs con animación ── */}
+        <AnimatePresence mode="wait">
+        <motion.div
+          key={activeTab}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -6 }}
+          transition={{ duration: 0.18, ease: "easeOut" }}
+        >
 
         {/* ── TAB EMPLEADOS ── */}
         {activeTab === "empleados" && (
           <div className="relative">
-            {/* Header */}
-            <div className="flex items-start justify-between mb-8">
-              <div>
-                <h1 style={{ fontFamily: "var(--font-raleway), sans-serif", fontWeight: 800, fontSize: "clamp(1.6rem, 2.5vw, 2.2rem)", color: "var(--texto-primario)", letterSpacing: "-0.02em", lineHeight: 1.1 }}>
-                  Empleados
-                </h1>
-                <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
-                  {empleados.length} persona{empleados.length !== 1 ? "s" : ""} en tu empresa
-                </p>
-              </div>
-              <div className="flex gap-3">
-                <input ref={inputImportRef} type="file" accept=".xlsx,.xls,.csv" className="hidden"
-                  onChange={(e) => { const f = e.target.files?.[0]; if (f) importarEmpleados(f); }} />
-                <button
-                  onClick={() => inputImportRef.current?.click()}
-                  disabled={importando}
-                  className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50"
-                  style={{ background: "var(--blanco)", color: "var(--azul-egm)", border: "1.5px solid var(--azul-egm)" }}
-                  onMouseEnter={(e) => { e.currentTarget.style.background = "var(--azul-egm-light)"; }}
-                  onMouseLeave={(e) => { e.currentTarget.style.background = "var(--blanco)"; }}
-                >
-                  <Upload size={14} />
-                  {importando ? "Importando..." : "Importar Excel"}
-                </button>
-                <button
-                  onClick={exportarEmpleadosExcel}
-                  disabled={empleados.length === 0}
-                  className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50"
-                  style={{ background: "var(--verde-oliva)", color: "var(--blanco)" }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = "#15803d")}
-                  onMouseLeave={(e) => (e.currentTarget.style.background = "var(--verde-oliva)")}
-                >
-                  <Download size={14} />
-                  Exportar Excel
-                </button>
-                <button
-                  onClick={() => { setShowFormEmpleado(true); setErrorEmpleado(null); }}
-                  className="flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors"
-                  style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--azul-egm-hover)")}
-                  onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
-                >
-                  <Plus size={14} />
-                  Añadir empleado
-                </button>
-              </div>
+            {/* Título */}
+            <div className="mb-8 text-center sm:text-left">
+              <h1 style={{ fontFamily: "var(--font-raleway), sans-serif", fontWeight: 800, fontSize: "clamp(1.6rem, 2.5vw, 2.2rem)", color: "var(--texto-primario)", letterSpacing: "-0.02em", lineHeight: 1.1 }}>
+                Gestión de equipo
+              </h1>
+              <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
+                {empleados.length} persona{empleados.length !== 1 ? "s" : ""}
+                {empleados.filter(e => !e.activo).length > 0 && (
+                  <span style={{ color: "var(--error)", fontWeight: 600 }}>
+                    {" "}· {empleados.filter(e => !e.activo).length} inactiva{empleados.filter(e => !e.activo).length !== 1 ? "s" : ""}
+                  </span>
+                )}
+              </p>
             </div>
 
-            {/* Formulario nuevo empleado - Diseño simple */}
+            {/* ── Modal nuevo empleado ── */}
+            <AnimatePresence>
             {showFormEmpleado && (
-              <div className="fixed inset-0 flex items-center justify-center z-50" style={{ background: "rgba(0,0,0,0.5)" }} onClick={() => setShowFormEmpleado(false)}>
-                <div className="bg-white rounded-2xl w-full max-w-lg mx-4 overflow-hidden" onClick={(e) => e.stopPropagation()}>
-                  {/* Header */}
-                  <div className="px-6 py-5" style={{ background: "linear-gradient(135deg, #1b3f7e, #0d1b2e)" }}>
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <h3 className="text-white text-2xl font-bold">Añadir nuevo empleado</h3>
-                        <p className="text-white text-sm opacity-70 mt-1">Crea una cuenta para un nuevo miembro</p>
-                      </div>
-                      <button onClick={() => setShowFormEmpleado(false)} className="w-8 h-8 rounded-full bg-white flex items-center justify-center text-gray-800 font-bold hover:bg-gray-200 transition-colors">
-                        ×
-                      </button>
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+                style={{ background: "var(--overlay, rgba(0,0,0,0.45))" }}
+                onClick={() => { if (!guardandoEmpleado) { setShowFormEmpleado(false); setErrorEmpleado(null); } }}
+              >
+                <motion.div
+                  initial={{ opacity: 0, y: 28, scale: 0.96 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: 16, scale: 0.97 }}
+                  transition={{ duration: 0.26, ease: [0.34, 1.15, 0.64, 1] }}
+                  className="w-full sm:max-w-lg rounded-t-3xl sm:rounded-2xl overflow-hidden flex flex-col"
+                  style={{ background: "var(--gris-panel)", maxHeight: "92dvh", boxShadow: "0 24px 56px rgba(0,0,0,0.18)" }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {/* Cabecera */}
+                  <div className="flex items-center justify-between px-5 sm:px-6 shrink-0"
+                    style={{ paddingTop: "20px", paddingBottom: "20px", position: "relative", background: "#2563EB" }}>
+                    <div style={{ position: "absolute", inset: 0, overflow: "hidden" }}>
+                      <Grainient
+                        color1="#1B3F7E" color2="#2563EB" color3="#1D4ED8"
+                        timeSpeed={0.18} warpStrength={1.2} warpFrequency={4.0}
+                        warpSpeed={1.5} warpAmplitude={60} grainAmount={0.08}
+                        contrast={1.3} saturation={1.1} zoom={0.85}
+                        style={{ width: "100%", height: "100%", display: "block" }}
+                      />
+                    </div>
+                    <h2 className="text-2xl font-bold" style={{ color: "#ffffff", position: "relative", zIndex: 1 }}>
+                      Nuevo empleado
+                    </h2>
+                    <div style={{ position: "relative", zIndex: 1 }}>
+                      <IconButton variant="glass" label="Cerrar" onClick={() => { setShowFormEmpleado(false); setErrorEmpleado(null); }} />
                     </div>
                   </div>
 
-                  {/* Formulario */}
-                  <form onSubmit={(e) => { e.preventDefault(); if (formEmpleado.nombre.trim() && formEmpleado.email.trim() && formEmpleado.password.trim()) handleCrearEmpleado(); }} className="p-8 space-y-4">
-                    <div>
-                      <label className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Nombre *</label>
-                      <input type="text" value={formEmpleado.nombre} onChange={(e) => setFormEmpleado({ ...formEmpleado, nombre: e.target.value })}
-                        className="w-full rounded-xl px-4 py-3 border border-gray-300 focus:outline-none focus:border-blue-400" placeholder="María" />
+                  {/* Formulario scrollable */}
+                  <form
+                    id="form-nuevo-empleado"
+                    onSubmit={(e) => { e.preventDefault(); if (formEmpleado.nombre.trim() && formEmpleado.email.trim() && formEmpleado.password.trim()) handleCrearEmpleado(); }}
+                    className="flex flex-col gap-4 px-5 sm:px-6 py-5 overflow-y-auto"
+                    style={{ flex: 1, opacity: guardandoEmpleado ? 0.6 : 1, pointerEvents: guardandoEmpleado ? "none" : undefined, transition: "opacity 0.2s ease" }}
+                  >
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      {/* Nombre */}
+                      <EmpCampo label="Nombre" required placeholder="María"
+                        value={formEmpleado.nombre} onChange={(v) => setFormEmpleado({ ...formEmpleado, nombre: v })} />
+                      {/* Apellidos */}
+                      <EmpCampo label="Apellidos" placeholder="García López"
+                        value={formEmpleado.apellidos} onChange={(v) => setFormEmpleado({ ...formEmpleado, apellidos: v })} />
                     </div>
-                    <div>
-                      <label className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Apellidos</label>
-                      <input type="text" value={formEmpleado.apellidos} onChange={(e) => setFormEmpleado({ ...formEmpleado, apellidos: e.target.value })}
-                        className="w-full rounded-xl px-4 py-3 border border-gray-300 focus:outline-none focus:border-blue-400" placeholder="García López" />
-                    </div>
-                    <div>
-                      <label className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Email *</label>
-                      <input type="email" value={formEmpleado.email} onChange={(e) => setFormEmpleado({ ...formEmpleado, email: e.target.value })}
-                        className="w-full rounded-xl px-4 py-3 border border-gray-300 focus:outline-none focus:border-blue-400" placeholder="m.garcia@empresa.com" />
-                    </div>
-                    <div>
-                      <label className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Contraseña inicial *</label>
-                      <input type="password" value={formEmpleado.password} onChange={(e) => setFormEmpleado({ ...formEmpleado, password: e.target.value })}
-                        className="w-full rounded-xl px-4 py-3 border border-gray-300 focus:outline-none focus:border-blue-400" placeholder="Mínimo 8 caracteres" />
-                    </div>
-                    <div>
-                      <label className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Puesto de trabajo</label>
-                      <input type="text" value={formEmpleado.puestoTrabajo} onChange={(e) => setFormEmpleado({ ...formEmpleado, puestoTrabajo: e.target.value })}
-                        className="w-full rounded-xl px-4 py-3 border border-gray-300 focus:outline-none focus:border-blue-400" placeholder="Ej: Técnico de producción" />
-                    </div>
-                    <div>
-                      <label className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Departamento</label>
-                      <select value={formEmpleado.departamento} onChange={(e) => setFormEmpleado({ ...formEmpleado, departamento: e.target.value })}
-                        className="w-full rounded-xl px-4 py-3 border border-gray-300 focus:outline-none focus:border-blue-400">
-                        <option value="">Sin departamento</option>
-                        <option value="PRODUCCION">Producción</option>
-                        <option value="RRHH">RRHH</option>
-                        <option value="LOGISTICA">Logística</option>
-                        <option value="CALIDAD">Calidad</option>
-                        <option value="MANTENIMIENTO">Mantenimiento</option>
-                        <option value="VENTAS">Ventas</option>
-                        <option value="ADMINISTRACION">Administración</option>
-                        <option value="IT">IT</option>
-                        <option value="SEGURIDAD">Seguridad</option>
-                        <option value="FORMACION">Formación</option>
-                      </select>
+                    {/* Email */}
+                    <EmpCampo label="Email" required type="email" placeholder="m.garcia@empresa.com"
+                      value={formEmpleado.email} onChange={(v) => setFormEmpleado({ ...formEmpleado, email: v })} />
+                    {/* Contraseña */}
+                    <EmpCampo label="Contraseña inicial" required type="password" placeholder="Mínimo 8 caracteres"
+                      hint="El empleado podrá cambiarla en su primer acceso"
+                      value={formEmpleado.password} onChange={(v) => setFormEmpleado({ ...formEmpleado, password: v })} />
+                    {/* Divisor secciones */}
+                    <div style={{ borderTop: "1px solid rgba(0,0,0,0.07)", margin: "2px 0" }} />
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      {/* Puesto */}
+                      <EmpCampo label="Puesto de trabajo" placeholder="Ej: Técnico de producción"
+                        value={formEmpleado.puestoTrabajo} onChange={(v) => setFormEmpleado({ ...formEmpleado, puestoTrabajo: v })} />
+                      {/* Departamento */}
+                      <EmpSelect
+                        label="Departamento"
+                        value={formEmpleado.departamento}
+                        onChange={(v) => setFormEmpleado({ ...formEmpleado, departamento: v })}
+                        options={DEPARTAMENTOS}
+                      />
                     </div>
                     {errorEmpleado && (
-                      <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl text-xs">
+                      <p className="text-xs px-3 py-2 rounded-lg" style={{ background: "rgba(239,68,68,0.07)", color: "var(--error)" }}>
                         {errorEmpleado}
-                      </div>
+                      </p>
                     )}
-                    <div className="flex gap-3 pt-4 border-t border-gray-200">
-                      <button type="button" onClick={() => setShowFormEmpleado(false)}
-                        className="flex-1 px-5 py-2.5 rounded-xl text-sm font-medium border border-gray-300 bg-gray-50">
-                        Cancelar
-                      </button>
-                      <button type="submit" disabled={guardandoEmpleado}
-                        className="flex-1 px-5 py-2.5 rounded-xl text-sm font-semibold bg-blue-600 text-white disabled:opacity-50">
-                        {guardandoEmpleado ? <span className="loading-dots">Creando</span> : "Crear empleado"}
-                      </button>
-                    </div>
                   </form>
-                </div>
-              </div>
-            )}
 
-            {/* Layout tabla + drawer */}
-            <div className="flex gap-6">
-              <div className="rounded-2xl overflow-hidden flex-1 min-w-0"
-                style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
+                  {/* Footer */}
+                  <div className="flex flex-col sm:flex-row sm:justify-end gap-2.5 px-5 sm:px-6 py-4 shrink-0"
+                    style={{ borderTop: "1px solid rgba(0,0,0,0.07)", background: "#ffffff", paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}>
+                    <Button type="button" variant="secondary" className="w-full sm:w-auto order-2 sm:order-1"
+                      onClick={() => { setShowFormEmpleado(false); setErrorEmpleado(null); }} disabled={guardandoEmpleado}>
+                      Cancelar
+                    </Button>
+                    <Button type="submit" form="form-nuevo-empleado" className="w-full sm:w-auto order-1 sm:order-2"
+                      disabled={guardandoEmpleado || !formEmpleado.nombre.trim() || !formEmpleado.email.trim() || !formEmpleado.password.trim()}>
+                      {guardandoEmpleado ? "Creando…" : "Crear empleado"}
+                    </Button>
+                  </div>
+                </motion.div>
+              </motion.div>
+            )}
+            </AnimatePresence>
+
+            {/* Barra de herramientas */}
+            <div className="flex flex-col sm:flex-row sm:items-start gap-3 mb-8">
+              {/* Buscador */}
+              <div className="flex flex-col w-full sm:w-64 shrink-0" style={{ minHeight: 48 }}>
+                <div className="relative">
+                  <span className="absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none" style={{ color: "var(--texto-muted)" }}>
+                    <Search size={15} />
+                  </span>
+                  <input
+                    type="text"
+                    placeholder="Buscar empleado…"
+                    value={empSearch}
+                    onChange={(e) => { setEmpSearch(e.target.value); setEmpPage(0); }}
+                    className="w-full pl-9 pr-8 py-2.5 text-sm rounded-xl outline-none transition-colors"
+                    style={{ background: "var(--blanco)", border: "1.5px solid var(--gris-borde)", color: "var(--texto-primario)" }}
+                    onFocus={(e) => (e.currentTarget.style.borderColor = "var(--tab-empleados)")}
+                    onBlur={(e) => (e.currentTarget.style.borderColor = "var(--gris-borde)")}
+                  />
+                  {empSearch && (
+                    <button
+                      onClick={() => { setEmpSearch(""); setEmpPage(0); }}
+                      className="absolute right-2.5 top-1/2 -translate-y-1/2 flex items-center justify-center rounded-full transition-colors"
+                      style={{ color: "var(--texto-muted)", background: "none", border: "none", cursor: "pointer", padding: 2 }}
+                    >
+                      <X size={13} strokeWidth={2.5} />
+                    </button>
+                  )}
+                </div>
+                <p className="text-xs pl-1 mt-1.5 transition-opacity duration-150"
+                  style={{ color: "var(--texto-muted)", opacity: empSearch ? 1 : 0, pointerEvents: empSearch ? "auto" : "none" }}>
+                  {empleadosFiltrados.length === 0
+                    ? "Sin resultados"
+                    : `${empleadosFiltrados.length} resultado${empleadosFiltrados.length !== 1 ? "s" : ""} para "${empSearch}"`}
+                </p>
+              </div>
+
+              {/* Botones */}
+              <div className="flex items-center gap-2 sm:ml-auto w-full sm:w-auto">
+                <input ref={inputImportRef} type="file" accept=".xlsx,.xls,.csv" className="hidden"
+                  onChange={(e) => { const f = e.target.files?.[0]; if (f) importarEmpleados(f); }} />
+                <Button variant="primary" size="md" disabled={importando} onClick={() => inputImportRef.current?.click()}
+                  style={{ background: "#16a34a", border: "1px solid rgba(255,255,255,0.18)", flexShrink: 0 }}>
+                  {importando
+                    ? <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                    : <><Upload size={15} /><span className="hidden sm:inline">&nbsp;Importar Excel</span></>}
+                </Button>
+                <Button variant="primary" size="md" disabled={exportando || empleados.length === 0} onClick={exportarEmpleadosExcel}
+                  style={{ background: "#16a34a", border: "1px solid rgba(255,255,255,0.18)", flexShrink: 0 }}>
+                  {exportando
+                    ? <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                    : <><Download size={15} /><span className="hidden sm:inline">&nbsp;Exportar Excel</span></>}
+                </Button>
+                <Button variant="primary" size="md" className="flex-1 sm:flex-none" onClick={() => { setShowFormEmpleado(true); setErrorEmpleado(null); }}>
+                  <Plus size={15} />
+                  <span className="hidden sm:inline">Añadir empleado</span>
+                  <span className="sm:hidden">Añadir</span>
+                </Button>
+              </div>
+            </div>
+
+            {/* Tabla — ocupa todo el ancho */}
+            <div>
+              <div className="rounded-2xl overflow-hidden"
+                style={{ background: "var(--blanco)", border: "1px solid var(--surface-border)" }}>
                 {cargandoEmpleados ? (
                   <div className="flex items-center justify-center py-20">
                     <div className="w-6 h-6 border-2 rounded-full animate-spin"
@@ -871,29 +1056,101 @@ function AdminContent() {
                       Añadir el primero →
                     </button>
                   </div>
+                ) : empleadosFiltrados.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-16 text-center">
+                    <div className="w-12 h-12 rounded-2xl flex items-center justify-center mb-4"
+                      style={{ background: "var(--gris-pagina)" }}>
+                      <Users size={22} color="var(--texto-muted)" strokeWidth={1.5} />
+                    </div>
+                    <p className="text-sm font-medium" style={{ color: "var(--texto-primario)" }}>Sin resultados</p>
+                    <p className="text-xs mt-1 mb-4" style={{ color: "var(--texto-muted)" }}>Ningún empleado coincide con tu búsqueda</p>
+                    <button onClick={() => { setEmpSearch(""); }}
+                      className="text-xs font-semibold px-4 py-2 rounded-xl"
+                      style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                      Limpiar filtros
+                    </button>
+                  </div>
                 ) : (
                   <>
                     {/* Vista desktop — tabla */}
                     <div className="hidden md:block">
-                      <table className="w-full">
+                      <table className="w-full table-fixed">
+                        <colgroup>
+                          <col style={{ width: "30%" }} />
+                          <col style={{ width: "19%" }} />
+                          <col style={{ width: "19%" }} />
+                          <col style={{ width: "14%" }} />
+                          <col style={{ width: "12%" }} />
+                          <col style={{ width: "48px" }} />
+                        </colgroup>
                         <thead>
-                          <tr style={{ background: "var(--gris-pagina)", borderBottom: "1px solid var(--gris-borde)" }}>
-                            {["Empleado", "Puesto", "Departamento", "Rol", "Alta", "Estado"].map((h) => (
-                              <th key={h} className="text-left py-3.5 px-5 text-xs font-bold uppercase tracking-wider"
-                                style={{ color: "var(--texto-muted)" }}>{h}</th>
+                          <tr style={{ background: "var(--azul-egm-light)", borderBottom: "1px solid var(--surface-border)" }}>
+                            {([
+                              { label: "Empleado",     col: "nombre"       as EmpSortCol, pad: "pl-14 pr-6" },
+                              { label: "Puesto",       col: "puesto"        as EmpSortCol, pad: "px-6"       },
+                              { label: "Departamento", col: "departamento"  as EmpSortCol, pad: "px-6"       },
+                              { label: "Perfil",       col: "perfil"        as EmpSortCol, pad: "px-6"       },
+                              { label: "Estado",       col: "estado"        as EmpSortCol, pad: "pl-6 pr-6"  },
+                            ]).map(({ label, col, pad }) => (
+                              <th key={label} className={`text-left py-3.5 ${pad}`} style={{ color: "var(--azul-egm)" }}>
+                                <button
+                                  onClick={() => toggleEmpSort(col!)}
+                                  className="inline-flex items-center gap-1 focus:outline-none select-none uppercase tracking-wider text-sm font-bold"
+                                  style={{ cursor: "pointer", background: "none", border: "none", padding: 0, color: "inherit", fontFamily: "inherit" }}
+                                >
+                                  {label}
+                                  <span style={{
+                                    opacity: empSort.col === col ? 1 : 0.25,
+                                    transition: "opacity 0.15s, transform 0.2s",
+                                    display: "flex",
+                                    transform: empSort.col === col && empSort.dir === "asc" ? "rotate(180deg)" : "rotate(0deg)",
+                                  }}>
+                                    <ChevronDown size={13} strokeWidth={2.5} />
+                                  </span>
+                                </button>
+                              </th>
                             ))}
-                            <th className="py-3.5 px-5" />
+                            <th className="py-3.5 pr-3 text-right">
+                              <motion.button
+                                animate={{ opacity: empSort.col ? 1 : 0, scale: empSort.col ? 1 : 0.75 }}
+                                transition={{ type: "spring", stiffness: 400, damping: 28 }}
+                                onClick={resetEmpSort}
+                                title="Quitar orden"
+                                className="inline-flex items-center justify-center focus:outline-none"
+                                style={{
+                                  width: 30, height: 30, borderRadius: "50%",
+                                  background: "rgba(255,255,255,0.52)",
+                                  border: "1px solid rgba(255,255,255,0.80)",
+                                  backdropFilter: "blur(10px)",
+                                  WebkitBackdropFilter: "blur(10px)",
+                                  boxShadow: "0 2px 8px rgba(27,63,126,0.18)",
+                                  color: "var(--azul-egm)",
+                                  cursor: empSort.col ? "pointer" : "default",
+                                  flexShrink: 0,
+                                  pointerEvents: empSort.col ? "auto" : "none",
+                                }}
+                              >
+                                <RefreshCw size={14} strokeWidth={2.3} />
+                              </motion.button>
+                            </th>
                           </tr>
                         </thead>
-                        <tbody>
-                          {empleados.slice(empPage * PAGE_SIZE, (empPage + 1) * PAGE_SIZE).map((e, idx) => (
-                            <tr
+                        <AnimatePresence mode="wait">
+                        <tbody key={empPage}>
+                          {empleadosFiltrados.slice(empPage * PAGE_SIZE, (empPage + 1) * PAGE_SIZE).map((e, idx) => (
+                            <motion.tr
                               key={e.usuarioId}
-                              className="cursor-pointer transition-colors"
+                              initial={{ opacity: 0, y: 6 }}
+                              animate={{ opacity: 1, y: 0 }}
+                              transition={{ duration: 0.18, delay: idx * 0.04, ease: "easeOut" }}
+                              className="cursor-pointer"
                               style={{
-                                borderBottom: idx < Math.min(empleados.length, PAGE_SIZE) - 1 ? "1px solid var(--gris-borde)" : "none",
+                                borderBottom: idx < Math.min(empleadosFiltrados.length, PAGE_SIZE) - 1 ? "1px solid var(--surface-border)" : "none",
+                                borderLeft: empleadoSeleccionado?.usuarioId === e.usuarioId ? "3px solid var(--azul-egm)" : "3px solid transparent",
                                 background: empleadoSeleccionado?.usuarioId === e.usuarioId
-                                  ? "var(--azul-egm-light)" : "transparent",
+                                  ? "var(--azul-egm-light)"
+                                  : idx % 2 === 0 ? "#ffffff" : "#fafbfc",
+                                transition: "border-left-color 0.15s, background 0.15s",
                               }}
                               onClick={() => setEmpleadoSeleccionado(
                                 empleadoSeleccionado?.usuarioId === e.usuarioId ? null : e
@@ -904,142 +1161,193 @@ function AdminContent() {
                               }}
                               onMouseLeave={(el) => {
                                 if (empleadoSeleccionado?.usuarioId !== e.usuarioId)
-                                  el.currentTarget.style.background = "transparent";
+                                  el.currentTarget.style.background = idx % 2 === 0 ? "#ffffff" : "#fafbfc";
                               }}
                             >
-                              <td className="py-4 px-5">
+                              <td className="py-3.5 pl-14 pr-6">
                                 <div className="flex items-center gap-3">
-                                  <div className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold shrink-0"
-                                    style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                                  <div className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold shrink-0 transition-all duration-150"
+                                    style={{
+                                      background: "var(--azul-egm-light)",
+                                      color: "var(--azul-egm)",
+                                      outline: empleadoSeleccionado?.usuarioId === e.usuarioId ? "2px solid var(--azul-egm)" : "2px solid transparent",
+                                      outlineOffset: "2px",
+                                    }}>
                                     {getInitials(e.nombre, e.apellidos)}
                                   </div>
                                   <div>
-                                    <p className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
+                                    <p className="text-base font-semibold" style={{ color: "var(--texto-primario)" }}>
                                       {e.nombre} {e.apellidos}
                                     </p>
-                                    <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>{e.email}</p>
+                                    <p className="text-sm mt-0.5" style={{ color: "var(--texto-muted)" }}>{e.email}</p>
                                   </div>
                                 </div>
                               </td>
-                              <td className="py-4 px-5 text-sm" style={{ color: "var(--texto-secundario)" }}>
-                                {e.puestoTrabajo ?? "—"}
+                              <td className="py-3.5 px-6 text-base" style={{ color: "var(--texto-secundario)" }}>
+                                {e.puestoTrabajo ?? <span style={{ color: "var(--texto-muted)" }}>—</span>}
                               </td>
-                              <td className="py-4 px-5">
+                              <td className="py-3.5 px-6">
                                 {e.departamento ? (
-                                  <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
-                                    style={{ background: "#fffbeb", color: "#d97706" }}>
+                                  <span className="text-xs font-semibold px-3 py-1 rounded-full"
+                                    style={{ background: "rgba(10,138,150,0.10)", color: "#0A8A96" }}>
                                     {DEPARTAMENTOS.find((d) => d.id === e.departamento)?.label ?? e.departamento}
                                   </span>
                                 ) : (
-                                  <span className="text-sm" style={{ color: "var(--texto-muted)" }}>—</span>
+                                  <span className="text-base" style={{ color: "var(--texto-muted)" }}>—</span>
                                 )}
                               </td>
-                              <td className="py-4 px-5">
-                                <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
+                              <td className="py-3.5 px-6">
+                                <span className="text-xs font-semibold px-3 py-1 rounded-full"
                                   style={e.codigoRol === "ROLE_ADMIN_EMPRESA"
                                     ? { background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }
                                     : { background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                                  {e.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Admin" : "Empleado"}
+                                  {e.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Administrador" : "Empleado"}
                                 </span>
                               </td>
-                              <td className="py-4 px-5 text-sm" style={{ color: "var(--texto-muted)" }}>
-                                {formatFecha(e.fechaRegistro)}
-                              </td>
-                              <td className="py-4 px-5">
-                                <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
+                              <td className="py-3.5 pl-6 pr-6">
+                                <span className="text-xs font-semibold px-3 py-1 rounded-full"
                                   style={e.activo
                                     ? { background: "var(--exito-light)", color: "var(--exito)" }
                                     : { background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
                                   {e.activo ? "Activo" : "Inactivo"}
                                 </span>
                               </td>
-                              <td className="py-4 px-5 text-right">
-                                <ChevronRight size={16} className="ml-auto" strokeWidth={1.5} style={{ color: "var(--gris-borde)" }} />
-                              </td>
-                            </tr>
+                              <td />
+                            </motion.tr>
                           ))}
                         </tbody>
+                        </AnimatePresence>
                       </table>
                       {/* Paginación desktop empleados */}
-                      {empleados.length > PAGE_SIZE && (
-                        <div className="flex items-center justify-between px-5 py-3" style={{ borderTop: "1px solid var(--gris-borde)" }}>
-                          <span className="text-xs" style={{ color: "var(--texto-muted)" }}>
-                            {empPage * PAGE_SIZE + 1}–{Math.min((empPage + 1) * PAGE_SIZE, empleados.length)} de {empleados.length}
-                          </span>
-                          <div className="flex gap-2">
-                            <button onClick={() => setEmpPage(p => Math.max(0, p - 1))} disabled={empPage === 0}
-                              className="px-3 py-1.5 rounded-lg text-xs font-semibold disabled:opacity-40"
-                              style={{ background: "var(--gris-pagina)", color: "var(--texto-primario)" }}>← Anterior</button>
-                            <button onClick={() => setEmpPage(p => p + 1)} disabled={(empPage + 1) * PAGE_SIZE >= empleados.length}
-                              className="px-3 py-1.5 rounded-lg text-xs font-semibold disabled:opacity-40"
-                              style={{ background: "var(--gris-pagina)", color: "var(--texto-primario)" }}>Siguiente →</button>
+                      {empleadosFiltrados.length > PAGE_SIZE && (() => {
+                        const totalPages = Math.ceil(empleadosFiltrados.length / PAGE_SIZE);
+                        const pages = Array.from({ length: totalPages }, (_, i) => i);
+                        return (
+                          <div className="flex items-center justify-center gap-1 px-5 py-4" style={{ borderTop: "1px solid var(--surface-border)" }}>
+                            {/* Botón anterior */}
+                            <motion.button
+                              onClick={() => setEmpPage(p => Math.max(0, p - 1))}
+                              disabled={empPage === 0}
+                              whileHover={empPage !== 0 ? { scale: 1.05 } : {}}
+                              whileTap={empPage !== 0 ? { scale: 0.95 } : {}}
+                              className="flex items-center gap-1.5 px-3 h-9 rounded-xl text-sm font-semibold disabled:opacity-30"
+                              style={{ background: "var(--gris-superficie)", color: "var(--texto-secundario)", border: "1px solid var(--surface-border)", cursor: empPage === 0 ? "default" : "pointer" }}
+                            >
+                              <ChevronLeft size={15} strokeWidth={2} />
+                              Anterior
+                            </motion.button>
+
+                            {/* Números */}
+                            <div className="flex items-center gap-1 mx-1">
+                              {pages.map(p => (
+                                <motion.button
+                                  key={p}
+                                  onClick={() => setEmpPage(p)}
+                                  whileHover={p !== empPage ? { scale: 1.08, background: "var(--gris-superficie)" } : {}}
+                                  whileTap={{ scale: 0.92 }}
+                                  animate={p === empPage
+                                    ? { background: "#1B3F7E", color: "#ffffff" }
+                                    : { background: "transparent", color: "var(--texto-secundario)" }
+                                  }
+                                  transition={{ duration: 0.18, ease: [0.34, 1.2, 0.64, 1] }}
+                                  className="w-9 h-9 rounded-xl text-sm font-semibold"
+                                  style={{ border: p === empPage ? "none" : "1px solid transparent", cursor: "pointer" }}
+                                >{p + 1}</motion.button>
+                              ))}
+                            </div>
+
+                            {/* Botón siguiente */}
+                            <motion.button
+                              onClick={() => setEmpPage(p => p + 1)}
+                              disabled={(empPage + 1) * PAGE_SIZE >= empleadosFiltrados.length}
+                              whileHover={(empPage + 1) * PAGE_SIZE < empleadosFiltrados.length ? { scale: 1.05 } : {}}
+                              whileTap={(empPage + 1) * PAGE_SIZE < empleadosFiltrados.length ? { scale: 0.95 } : {}}
+                              className="flex items-center gap-1.5 px-3 h-9 rounded-xl text-sm font-semibold disabled:opacity-30"
+                              style={{ background: "var(--gris-superficie)", color: "var(--texto-secundario)", border: "1px solid var(--surface-border)", cursor: (empPage + 1) * PAGE_SIZE >= empleadosFiltrados.length ? "default" : "pointer" }}
+                            >
+                              Siguiente
+                              <ChevronRight size={15} strokeWidth={2} />
+                            </motion.button>
                           </div>
-                        </div>
-                      )}
+                        );
+                      })()}
                     </div>
 
                     {/* Vista móvil — tarjetas */}
-                    <div className="md:hidden flex flex-col divide-y"
-                      style={{ borderColor: "var(--gris-borde)" }}>
-                      {empleados.slice(empPage * PAGE_SIZE, (empPage + 1) * PAGE_SIZE).map((e) => (
-                        <div
+                    <div className="md:hidden flex flex-col">
+                      {empleadosFiltrados.slice(empPage * PAGE_SIZE_MOBILE, (empPage + 1) * PAGE_SIZE_MOBILE).map((e, idx) => {
+                        const isSelected = empleadoSeleccionado?.usuarioId === e.usuarioId;
+                        return (
+                        <motion.div
                           key={e.usuarioId}
-                          className="px-5 py-4 flex items-center justify-between gap-3 cursor-pointer"
-                          onClick={() => setEmpleadoSeleccionado(
-                            empleadoSeleccionado?.usuarioId === e.usuarioId ? null : e
-                          )}
+                          initial={{ opacity: 0, y: 6 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{ duration: 0.18, delay: idx * 0.04, ease: "easeOut" }}
+                          className="flex items-center gap-3 cursor-pointer"
+                          onClick={() => setEmpleadoSeleccionado(isSelected ? null : e)}
                           style={{
-                            background: empleadoSeleccionado?.usuarioId === e.usuarioId
-                              ? "var(--azul-egm-light)" : "transparent"
+                            padding: "12px 16px",
+                            borderBottom: idx < Math.min(empleadosFiltrados.length, PAGE_SIZE_MOBILE) - 1 ? "1px solid var(--surface-border)" : "none",
+                            borderLeft: `3px solid ${isSelected ? "var(--azul-egm)" : "transparent"}`,
+                            background: isSelected ? "var(--azul-egm-light)" : idx % 2 === 0 ? "#ffffff" : "#fafbfc",
+                            transition: "border-left-color 0.15s, background 0.15s",
                           }}
                         >
-                          <div className="flex items-center gap-3 min-w-0">
-                            <div className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold shrink-0"
-                              style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                          {/* Avatar con dot de estado */}
+                          <div className="relative shrink-0">
+                            <div className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold"
+                              style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)", border: "2px solid var(--azul-egm)" }}>
                               {getInitials(e.nombre, e.apellidos)}
                             </div>
-                            <div className="min-w-0">
-                              <p className="text-sm font-semibold truncate" style={{ color: "var(--texto-primario)" }}>
+                            <span className="absolute bottom-0 right-0 w-3 h-3 rounded-full border-2 border-white"
+                              style={{ background: e.activo ? "var(--exito)" : "var(--texto-muted)" }} />
+                          </div>
+
+                          {/* Info */}
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <p className="text-sm font-semibold truncate min-w-0 flex-1" style={{ color: "var(--texto-primario)" }}>
                                 {e.nombre} {e.apellidos}
                               </p>
-                              <p className="text-xs truncate" style={{ color: "var(--texto-muted)" }}>{e.email}</p>
-                              {e.puestoTrabajo && (
-                                <p className="text-xs mt-0.5" style={{ color: "var(--texto-secundario)" }}>
-                                  {e.puestoTrabajo}
-                                </p>
-                              )}
+                              <span className="text-xs font-semibold shrink-0 px-2 py-0.5 rounded-full"
+                                style={e.codigoRol === "ROLE_ADMIN_EMPRESA"
+                                  ? { background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }
+                                  : { background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                                {e.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Admin" : "Emp."}
+                              </span>
                             </div>
+                            <p className="text-xs truncate mt-0.5" style={{ color: "var(--texto-muted)" }}>
+                              {e.puestoTrabajo ? `${e.puestoTrabajo} · ${e.email}` : e.email}
+                            </p>
                           </div>
-                          <div className="flex flex-col items-end gap-1.5 shrink-0">
-                            <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
-                              style={e.codigoRol === "ROLE_ADMIN_EMPRESA"
-                                ? { background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }
-                                : { background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                              {e.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Admin" : "Empleado"}
-                            </span>
-                            <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
-                              style={e.activo
-                                ? { background: "var(--exito-light)", color: "var(--exito)" }
-                                : { background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
-                              {e.activo ? "Activo" : "Inactivo"}
-                            </span>
-                          </div>
-                        </div>
-                      ))}
+
+                          {/* Chevron */}
+                          <ChevronRight size={16} strokeWidth={2} style={{ color: "var(--texto-muted)", flexShrink: 0, opacity: isSelected ? 1 : 0.4 }} />
+                        </motion.div>
+                        );
+                      })}
                       {/* Paginación móvil empleados */}
-                      {empleados.length > PAGE_SIZE && (
-                        <div className="flex items-center justify-between px-5 py-3" style={{ borderTop: "1px solid var(--gris-borde)" }}>
-                          <span className="text-xs" style={{ color: "var(--texto-muted)" }}>
-                            {empPage * PAGE_SIZE + 1}–{Math.min((empPage + 1) * PAGE_SIZE, empleados.length)} de {empleados.length}
+                      {empleadosFiltrados.length > PAGE_SIZE_MOBILE && (
+                        <div className="flex items-center justify-center gap-2 px-5 py-4" style={{ borderTop: "1px solid var(--surface-border)" }}>
+                          <motion.button
+                            onClick={() => setEmpPage(p => Math.max(0, p - 1))}
+                            disabled={empPage === 0}
+                            whileHover={empPage !== 0 ? { scale: 1.05 } : {}}
+                            whileTap={empPage !== 0 ? { scale: 0.95 } : {}}
+                            className="flex items-center gap-1.5 px-3 h-9 rounded-xl text-sm font-semibold disabled:opacity-30"
+                            style={{ background: "var(--gris-superficie)", color: "var(--texto-secundario)", border: "1px solid var(--surface-border)", cursor: empPage === 0 ? "default" : "pointer" }}
+                          ><ChevronLeft size={15} strokeWidth={2} /></motion.button>
+                          <span className="text-sm font-semibold px-2" style={{ color: "var(--texto-secundario)" }}>
+                            {empPage + 1} / {Math.ceil(empleadosFiltrados.length / PAGE_SIZE_MOBILE)}
                           </span>
-                          <div className="flex gap-2">
-                            <button onClick={() => setEmpPage(p => Math.max(0, p - 1))} disabled={empPage === 0}
-                              className="px-3 py-1.5 rounded-lg text-xs font-semibold disabled:opacity-40"
-                              style={{ background: "var(--gris-pagina)", color: "var(--texto-primario)" }}>←</button>
-                            <button onClick={() => setEmpPage(p => p + 1)} disabled={(empPage + 1) * PAGE_SIZE >= empleados.length}
-                              className="px-3 py-1.5 rounded-lg text-xs font-semibold disabled:opacity-40"
-                              style={{ background: "var(--gris-pagina)", color: "var(--texto-primario)" }}>→</button>
-                          </div>
+                          <motion.button
+                            onClick={() => setEmpPage(p => p + 1)}
+                            disabled={(empPage + 1) * PAGE_SIZE_MOBILE >= empleadosFiltrados.length}
+                            whileHover={(empPage + 1) * PAGE_SIZE_MOBILE < empleadosFiltrados.length ? { scale: 1.05 } : {}}
+                            whileTap={(empPage + 1) * PAGE_SIZE_MOBILE < empleadosFiltrados.length ? { scale: 0.95 } : {}}
+                            className="flex items-center gap-1.5 px-3 h-9 rounded-xl text-sm font-semibold disabled:opacity-30"
+                            style={{ background: "var(--gris-superficie)", color: "var(--texto-secundario)", border: "1px solid var(--surface-border)", cursor: (empPage + 1) * PAGE_SIZE_MOBILE >= empleadosFiltrados.length ? "default" : "pointer" }}
+                          ><ChevronRight size={15} strokeWidth={2} /></motion.button>
                         </div>
                       )}
                     </div>
@@ -1047,212 +1355,362 @@ function AdminContent() {
                 )}
               </div>
 
-              {/* Drawer desktop */}
-              {empleadoSeleccionado && (
-                <div className="hidden md:flex w-80 shrink-0 rounded-2xl p-6 flex-col gap-5"
-                  style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-                  <div className="flex items-center justify-between">
-                    <h3 className="text-sm font-bold" style={{ color: "var(--texto-primario)" }}>Perfil del empleado</h3>
-                    <button onClick={() => { setEmpleadoSeleccionado(null); setEditandoEmpleado(false); }}
-                      className="w-7 h-7 flex items-center justify-center rounded-lg text-lg leading-none transition-colors"
-                      style={{ color: "var(--texto-muted)", background: "var(--gris-pagina)" }}>×</button>
-                  </div>
-                  {editandoEmpleado ? (
-                    <div className="flex flex-col gap-4">
-                      <div className="flex flex-col gap-1.5">
-                        <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Nombre</label>
-                        <input value={editEmpleadoForm.nombre} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, nombre: e.target.value }))}
-                          className="w-full px-3 py-2 text-sm rounded-xl border outline-none"
-                          style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }} />
-                      </div>
-                      <div className="flex flex-col gap-1.5">
-                        <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Apellidos</label>
-                        <input value={editEmpleadoForm.apellidos} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, apellidos: e.target.value }))}
-                          className="w-full px-3 py-2 text-sm rounded-xl border outline-none"
-                          style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }} />
-                      </div>
-                      <div className="flex flex-col gap-1.5">
-                        <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Email</label>
-                        <input value={editEmpleadoForm.email} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, email: e.target.value }))}
-                          className="w-full px-3 py-2 text-sm rounded-xl border outline-none"
-                          style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }} />
-                      </div>
-                      <div className="flex flex-col gap-1.5">
-                        <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Puesto</label>
-                        <input value={editEmpleadoForm.puestoTrabajo} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, puestoTrabajo: e.target.value }))}
-                          className="w-full px-3 py-2 text-sm rounded-xl border outline-none"
-                          style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }} />
-                      </div>
-                      <div className="flex flex-col gap-1.5">
-                        <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Departamento</label>
-                        <select value={editEmpleadoForm.departamento} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, departamento: e.target.value }))}
-                          className="w-full px-3 py-2.5 text-sm rounded-xl border outline-none"
-                          style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }}>
-                          <option value="">Sin departamento</option>
-                          {DEPARTAMENTOS.map((d) => (
-                            <option key={d.id} value={d.id}>{d.label}</option>
-                          ))}
-                        </select>
-                      </div>
-                      <div className="flex gap-2 pt-2" style={{ borderTop: "1px solid var(--gris-borde)" }}>
-                        <button onClick={() => setEditandoEmpleado(false)}
-                          className="flex-1 text-sm font-semibold py-2 rounded-xl border"
-                          style={{ borderColor: "var(--gris-borde)", color: "var(--texto-muted)" }}>
-                          Cancelar
-                        </button>
-                        <button onClick={handleGuardarEditEmpleado} disabled={guardandoEditEmpleado}
-                          className="flex-1 text-sm font-semibold py-2 rounded-xl transition-opacity"
-                          style={{ background: "linear-gradient(135deg, #2563eb 0%, #1b3f7e 100%)", color: "#fff", opacity: guardandoEditEmpleado ? 0.7 : 1 }}>
-                          {guardandoEditEmpleado ? "Guardando…" : "Guardar"}
-                        </button>
-                      </div>
-                    </div>
-                  ) : (
-                    <>
-                      <div className="flex items-center gap-4 p-4 rounded-xl"
-                        style={{ background: "var(--gris-pagina)" }}>
-                        <div className="w-14 h-14 rounded-full flex items-center justify-center text-lg font-bold shrink-0"
-                          style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                          {getInitials(empleadoSeleccionado.nombre, empleadoSeleccionado.apellidos)}
-                        </div>
-                        <div>
-                          <p className="text-sm font-bold" style={{ color: "var(--texto-primario)" }}>
-                            {empleadoSeleccionado.nombre} {empleadoSeleccionado.apellidos}
-                          </p>
-                          <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>
-                            {empleadoSeleccionado.email}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="flex flex-col gap-3 pt-1" style={{ borderTop: "1px solid var(--gris-borde)" }}>
-                        <DrawerRow label="Puesto" value={empleadoSeleccionado.puestoTrabajo ?? "—"} />
-                        <DrawerRow label="Departamento" value={DEPARTAMENTOS.find((d) => d.id === empleadoSeleccionado.departamento)?.label ?? "—"} />
-                        <DrawerRow label="Rol" value={empleadoSeleccionado.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Administrador" : "Empleado"} />
-                        <DrawerRow label="Estado" value={empleadoSeleccionado.activo ? "Activo" : "Inactivo"} />
-                        <DrawerRow label="Alta" value={formatFecha(empleadoSeleccionado.fechaRegistro)} />
-                      </div>
-                      <div className="flex flex-col gap-2 pt-1" style={{ borderTop: "1px solid var(--gris-borde)" }}>
-                        <button onClick={iniciarEditEmpleado}
-                          className="w-full text-sm font-semibold py-2.5 rounded-xl transition-colors"
-                          style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                          Editar empleado
-                        </button>
-                        <button
-                          onClick={() => handleToggleEmpleado(empleadoSeleccionado.usuarioId, empleadoSeleccionado.activo)}
-                          className="w-full text-sm font-semibold py-2.5 rounded-xl transition-colors"
-                          style={empleadoSeleccionado.activo
-                            ? { background: "var(--error-light)", color: "var(--error)", border: "1px solid var(--error)" }
-                            : { background: "var(--exito-light)", color: "var(--exito)", border: "1px solid var(--exito)" }}
-                        >
-                          {empleadoSeleccionado.activo ? "Desactivar empleado" : "Activar empleado"}
-                        </button>
-                      </div>
-                    </>
-                  )}
-                </div>
-              )}
             </div>
 
+            {/* ── Slide-over desktop ── */}
+            <AnimatePresence>
+              {empleadoSeleccionado && (
+                <>
+                  {/* Backdrop sutil */}
+                  <motion.div
+                    className="hidden md:block fixed inset-0 z-40"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.2 }}
+                    style={{ background: "rgba(15,25,35,0.25)" }}
+                    onClick={() => { setEmpleadoSeleccionado(null); setEditandoEmpleado(false); }}
+                  />
+                  {/* Panel */}
+                  <motion.div
+                    className="hidden md:flex fixed top-0 right-0 h-full z-50 flex-col overflow-hidden"
+                    style={{
+                      width: 400,
+                      background: "#2563EB",
+                      borderLeft: "1px solid rgba(0,0,0,0.08)",
+                      boxShadow: "-8px 0 32px rgba(0,0,0,0.12)",
+                    }}
+                    initial={{ x: "100%" }}
+                    animate={{ x: 0 }}
+                    exit={{ x: "100%" }}
+                    transition={{ type: "spring", stiffness: 340, damping: 34 }}
+                  >
+                    {/* Header slide-over */}
+                    <div className="px-6 flex items-center justify-between shrink-0"
+                      style={{ height: 80, borderBottom: "1px solid rgba(255,255,255,0.08)", position: "relative", background: "#2563EB" }}>
+                      <div style={{ position: "absolute", inset: 0, overflow: "hidden" }}>
+                        <Grainient
+                          color1="#1B3F7E" color2="#2563EB" color3="#1D4ED8"
+                          timeSpeed={0.18} warpStrength={1.2} warpFrequency={4.0}
+                          warpSpeed={1.5} warpAmplitude={60} grainAmount={0.08}
+                          contrast={1.3} saturation={1.1} zoom={0.85}
+                          style={{ width: "100%", height: "100%", display: "block" }}
+                        />
+                      </div>
+                      <div style={{ position: "relative", zIndex: 1 }}>
+                        <h3 className="text-xl font-bold" style={{ color: "#ffffff" }}>Ficha de empleado</h3>
+                      </div>
+                      <div style={{ position: "relative", zIndex: 1 }}>
+                        <IconButton variant="glass" label="Cerrar" onClick={() => { setEmpleadoSeleccionado(null); setEditandoEmpleado(false); }} />
+                      </div>
+                    </div>
+
+                    {/* Contenido scroll */}
+                    <div className="flex-1 overflow-y-auto" style={{ background: "var(--gris-pagina)" }}>
+                      <AnimatePresence mode="wait">
+                        {editandoEmpleado ? (
+                          <motion.div key="edit"
+                            initial={{ opacity: 0, x: 16 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 16 }}
+                            transition={{ duration: 0.18, ease: "easeOut" }}
+                            className="flex flex-col gap-6 px-6 py-6"
+                          >
+                            {/* Avatar mini — reactivo al formulario */}
+                            <div className="flex items-center gap-3 py-4 px-4 rounded-2xl" style={{ background: "var(--blanco)", border: "1px solid var(--surface-border)" }}>
+                              <div className="w-12 h-12 rounded-full flex items-center justify-center text-base font-bold shrink-0"
+                                style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)", border: "2px solid var(--azul-egm)" }}>
+                                {getInitials(
+                                  editEmpleadoForm.nombre || empleadoSeleccionado.nombre,
+                                  editEmpleadoForm.apellidos || empleadoSeleccionado.apellidos
+                                )}
+                              </div>
+                              <div className="min-w-0">
+                                <p className="text-sm font-bold truncate" style={{ color: "var(--texto-primario)" }}>
+                                  {(editEmpleadoForm.nombre || empleadoSeleccionado.nombre)}{" "}
+                                  {(editEmpleadoForm.apellidos || empleadoSeleccionado.apellidos)}
+                                </p>
+                                <p className="text-xs mt-0.5 truncate" style={{ color: "var(--texto-muted)" }}>
+                                  {editEmpleadoForm.email || empleadoSeleccionado.email}
+                                </p>
+                              </div>
+                            </div>
+
+                            {/* Campos */}
+                            <div className="flex flex-col gap-4 p-5 rounded-2xl" style={{ background: "var(--blanco)", border: "1px solid var(--surface-border)" }}>
+                              {[
+                                { key: "nombre", label: "Nombre" },
+                                { key: "apellidos", label: "Apellidos" },
+                                { key: "email", label: "Email", type: "email" },
+                                { key: "puestoTrabajo", label: "Puesto" },
+                              ].map(({ key, label, type = "text" }) => (
+                                <EmpCampo key={key} label={label} type={type}
+                                  value={editEmpleadoForm[key as keyof NuevoEmpleadoForm]}
+                                  onChange={(v) => setEditEmpleadoForm((f) => ({ ...f, [key]: v }))} />
+                              ))}
+                              <div className="flex flex-col gap-1.5">
+                                <label className="text-sm font-semibold" style={{ color: "var(--texto-label)" }}>Departamento</label>
+                                <EmpSelect label="" value={editEmpleadoForm.departamento}
+                                  onChange={(v) => setEditEmpleadoForm((f) => ({ ...f, departamento: v }))}
+                                  options={DEPARTAMENTOS} placeholder="Sin departamento" />
+                              </div>
+                            </div>
+                          </motion.div>
+                        ) : (
+                          <motion.div key="view"
+                            initial={{ opacity: 0, x: -16 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -16 }}
+                            transition={{ duration: 0.18, ease: "easeOut" }}
+                            className="flex flex-col gap-6 px-6 py-6"
+                          >
+                            {/* Avatar + contacto */}
+                            <div className="flex flex-col items-center gap-3 py-6 px-4 rounded-2xl"
+                              style={{ background: "var(--blanco)", border: "1px solid var(--surface-border)" }}>
+                              {/* Avatar con dot de estado */}
+                              <div className="relative">
+                                <div className="w-20 h-20 rounded-full flex items-center justify-center text-2xl font-bold shrink-0"
+                                  style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)", border: "3px solid var(--azul-egm)" }}>
+                                  {getInitials(empleadoSeleccionado.nombre, empleadoSeleccionado.apellidos)}
+                                </div>
+                                <span className="absolute bottom-0.5 right-0.5 w-4 h-4 rounded-full border-2 border-white"
+                                  style={{ background: empleadoSeleccionado.activo ? "var(--exito)" : "var(--texto-muted)" }} />
+                              </div>
+                              <div className="text-center">
+                                <p className="text-base font-bold" style={{ color: "var(--texto-primario)" }}>
+                                  {empleadoSeleccionado.nombre} {empleadoSeleccionado.apellidos}
+                                </p>
+                                <p className="text-sm mt-0.5" style={{ color: "var(--texto-muted)" }}>{empleadoSeleccionado.email}</p>
+                              </div>
+                            </div>
+
+                            {/* Datos */}
+                            <div className="flex flex-col gap-0" style={{ borderRadius: 14, overflow: "hidden", border: "1px solid var(--surface-border)" }}>
+                              {empleadoSeleccionado.puestoTrabajo && (
+                                <div className="flex items-center justify-between px-5 py-4" style={{ borderBottom: "1px solid var(--surface-border)", background: "var(--blanco)" }}>
+                                  <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>Puesto</span>
+                                  <span className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                                    {empleadoSeleccionado.puestoTrabajo}
+                                  </span>
+                                </div>
+                              )}
+                              <div className="flex items-center justify-between px-5 py-4" style={{ borderBottom: "1px solid var(--surface-border)", background: "var(--blanco)" }}>
+                                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>Departamento</span>
+                                {empleadoSeleccionado.departamento
+                                  ? <span className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "rgba(10,138,150,0.10)", color: "#0A8A96" }}>
+                                      {DEPARTAMENTOS.find((d) => d.id === empleadoSeleccionado.departamento)?.label ?? empleadoSeleccionado.departamento}
+                                    </span>
+                                  : <span className="text-sm" style={{ color: "var(--texto-muted)" }}>—</span>}
+                              </div>
+                              <div className="flex items-center justify-between px-5 py-4" style={{ borderBottom: "1px solid var(--surface-border)", background: "var(--blanco)" }}>
+                                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>Perfil</span>
+                                <span className="text-xs font-semibold px-3 py-1 rounded-full"
+                                  style={empleadoSeleccionado.codigoRol === "ROLE_ADMIN_EMPRESA"
+                                    ? { background: "var(--verde-oliva-light)", color: "var(--verde-oliva)" }
+                                    : { background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+                                  {empleadoSeleccionado.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Administrador" : "Empleado"}
+                                </span>
+                              </div>
+                              <div className="flex items-center justify-between px-5 py-4" style={{ borderBottom: "1px solid var(--surface-border)", background: "var(--blanco)" }}>
+                                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>Estado</span>
+                                <span className="text-xs font-semibold px-3 py-1 rounded-full"
+                                  style={empleadoSeleccionado.activo
+                                    ? { background: "var(--exito-light)", color: "var(--exito)" }
+                                    : { background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
+                                  {empleadoSeleccionado.activo ? "Activo" : "Inactivo"}
+                                </span>
+                              </div>
+                              <div className="flex items-center justify-between px-5 py-4" style={{ background: "var(--blanco)" }}>
+                                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>Alta</span>
+                                <span className="text-xs font-semibold px-3 py-1 rounded-full"
+                                  style={{ background: "var(--gris-superficie)", color: "var(--texto-secundario)" }}>
+                                  {formatFecha(empleadoSeleccionado.fechaRegistro)}
+                                </span>
+                              </div>
+                            </div>
+                          </motion.div>
+                        )}
+                      </AnimatePresence>
+                    </div>
+
+                    {/* Footer acciones */}
+                    <div className="px-6 py-5 flex flex-col gap-2.5 shrink-0"
+                      style={{ borderTop: "1px solid var(--surface-border)", background: "var(--blanco)" }}>
+                      {editandoEmpleado ? (
+                        <div className="flex gap-2.5">
+                          <Button variant="secondary" size="md" className="flex-1" onClick={() => setEditandoEmpleado(false)}>
+                            Cancelar
+                          </Button>
+                          <Button variant="primary" size="md" className="flex-1" onClick={handleGuardarEditEmpleado} disabled={guardandoEditEmpleado}>
+                            {guardandoEditEmpleado
+                              ? <><span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" />&nbsp;Guardando…</>
+                              : "Guardar cambios"}
+                          </Button>
+                        </div>
+                      ) : (
+                        <>
+                          <Button variant="primary" size="md" onClick={iniciarEditEmpleado}>
+                            Editar empleado
+                          </Button>
+                          <Button
+                            variant={empleadoSeleccionado.activo ? "danger" : "secondary"}
+                            size="md"
+                            onClick={() => handleToggleEmpleado(empleadoSeleccionado.usuarioId, empleadoSeleccionado.activo)}>
+                            {empleadoSeleccionado.activo ? "Desactivar empleado" : "Activar empleado"}
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </motion.div>
+                </>
+              )}
+            </AnimatePresence>
+
             {/* Bottom sheet móvil */}
+            <AnimatePresence>
             {empleadoSeleccionado && (
-              <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl p-6 flex flex-col gap-4"
-                style={{
-                  background: "var(--blanco)",
-                  border: "1px solid var(--gris-borde)",
-                  boxShadow: "0 -4px 24px rgba(0,0,0,0.12)"
-                }}>
-                <div className="flex items-center justify-between">
-                  <h3 className="text-sm font-bold" style={{ color: "var(--texto-primario)" }}>Perfil del empleado</h3>
-                  <button onClick={() => { setEmpleadoSeleccionado(null); setEditandoEmpleado(false); }}
-                    className="w-7 h-7 flex items-center justify-center rounded-lg text-lg leading-none"
-                    style={{ color: "var(--texto-muted)", background: "var(--gris-pagina)" }}>×</button>
-                </div>
-                {editandoEmpleado ? (
-                  <div className="flex flex-col gap-4 max-h-[60vh] overflow-y-auto">
-                    <div className="flex flex-col gap-1.5">
-                      <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Nombre</label>
-                      <input value={editEmpleadoForm.nombre} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, nombre: e.target.value }))}
-                        className="w-full px-3 py-2 text-sm rounded-xl border outline-none"
-                        style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }} />
+              <>
+                {/* Backdrop */}
+                <motion.div
+                  className="md:hidden fixed inset-0"
+                  initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                  style={{ background: "rgba(15,25,35,0.35)", zIndex: 1090 }}
+                  onClick={() => { setEmpleadoSeleccionado(null); setEditandoEmpleado(false); }}
+                />
+                <motion.div
+                  className="md:hidden fixed bottom-0 left-0 right-0 rounded-t-3xl flex flex-col"
+                  initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
+                  transition={{ type: "spring", stiffness: 380, damping: 36 }}
+                  style={{ background: "var(--gris-pagina)", boxShadow: "0 -8px 40px rgba(0,0,0,0.18)", maxHeight: "88vh", zIndex: 1100 }}>
+
+                  {/* Header con Grainient — igual que slide-over desktop */}
+                  <div className="relative rounded-t-3xl overflow-hidden shrink-0"
+                    style={{ background: "#2563EB" }}>
+                    <div style={{ position: "absolute", inset: 0, overflow: "hidden" }}>
+                      <Grainient
+                        color1="#1B3F7E" color2="#2563EB" color3="#1D4ED8"
+                        timeSpeed={0.18} warpStrength={1.2} warpFrequency={4.0}
+                        warpSpeed={1.5} warpAmplitude={60} grainAmount={0.08}
+                        contrast={1.3} saturation={1.1} zoom={0.85}
+                        style={{ width: "100%", height: "100%", display: "block" }}
+                      />
                     </div>
-                    <div className="flex flex-col gap-1.5">
-                      <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Apellidos</label>
-                      <input value={editEmpleadoForm.apellidos} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, apellidos: e.target.value }))}
-                        className="w-full px-3 py-2 text-sm rounded-xl border outline-none"
-                        style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }} />
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                      <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Email</label>
-                      <input value={editEmpleadoForm.email} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, email: e.target.value }))}
-                        className="w-full px-3 py-2 text-sm rounded-xl border outline-none"
-                        style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }} />
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                      <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Puesto</label>
-                      <input value={editEmpleadoForm.puestoTrabajo} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, puestoTrabajo: e.target.value }))}
-                        className="w-full px-3 py-2 text-sm rounded-xl border outline-none"
-                        style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }} />
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                      <label className="text-xs font-semibold" style={{ color: "var(--texto-muted)" }}>Departamento</label>
-                      <select value={editEmpleadoForm.departamento} onChange={(e) => setEditEmpleadoForm((f) => ({ ...f, departamento: e.target.value }))}
-                        className="w-full px-3 py-2.5 text-sm rounded-xl border outline-none"
-                        style={{ borderColor: "var(--gris-borde)", color: "var(--texto-primario)" }}>
-                        <option value="">Sin departamento</option>
-                        {DEPARTAMENTOS.map((d) => (
-                          <option key={d.id} value={d.id}>{d.label}</option>
-                        ))}
-                      </select>
-                    </div>
-                    <div className="flex gap-2 pt-2">
-                      <button onClick={() => setEditandoEmpleado(false)}
-                        className="flex-1 text-sm font-semibold py-2 rounded-xl border"
-                        style={{ borderColor: "var(--gris-borde)", color: "var(--texto-muted)" }}>
-                        Cancelar
-                      </button>
-                      <button onClick={handleGuardarEditEmpleado} disabled={guardandoEditEmpleado}
-                        className="flex-1 text-sm font-semibold py-2 rounded-xl transition-opacity"
-                        style={{ background: "linear-gradient(135deg, #2563eb 0%, #1b3f7e 100%)", color: "#fff", opacity: guardandoEditEmpleado ? 0.7 : 1 }}>
-                        {guardandoEditEmpleado ? "Guardando…" : "Guardar"}
-                      </button>
+                    <div className="relative z-10 px-5 pt-2 pb-5">
+                      <div className="flex items-center justify-between mb-3">
+                        <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: "rgba(255,255,255,0.6)" }}>
+                          {editandoEmpleado ? "Editando empleado" : "Ficha de empleado"}
+                        </p>
+                        <IconButton variant="glass" label="Cerrar" onClick={() => { setEmpleadoSeleccionado(null); setEditandoEmpleado(false); }} />
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <div className="relative shrink-0">
+                          <div className="w-12 h-12 rounded-full flex items-center justify-center text-base font-bold"
+                            style={{ background: "rgba(255,255,255,0.2)", color: "#fff", border: "2px solid rgba(255,255,255,0.4)" }}>
+                            {getInitials(
+                              editandoEmpleado ? (editEmpleadoForm.nombre || empleadoSeleccionado.nombre) : empleadoSeleccionado.nombre,
+                              editandoEmpleado ? (editEmpleadoForm.apellidos || empleadoSeleccionado.apellidos) : empleadoSeleccionado.apellidos
+                            )}
+                          </div>
+                        </div>
+                        <div className="min-w-0">
+                          <p className="text-base font-bold truncate" style={{ color: "#fff" }}>
+                            {editandoEmpleado
+                              ? `${editEmpleadoForm.nombre || empleadoSeleccionado.nombre} ${editEmpleadoForm.apellidos || empleadoSeleccionado.apellidos}`
+                              : `${empleadoSeleccionado.nombre} ${empleadoSeleccionado.apellidos}`}
+                          </p>
+                          <p className="text-xs truncate mt-0.5" style={{ color: "rgba(255,255,255,0.65)" }}>
+                            {editandoEmpleado ? (editEmpleadoForm.email || empleadoSeleccionado.email) : empleadoSeleccionado.email}
+                          </p>
+                        </div>
+                      </div>
                     </div>
                   </div>
-                ) : (
-                  <>
-                    <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold shrink-0"
-                        style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                        {getInitials(empleadoSeleccionado.nombre, empleadoSeleccionado.apellidos)}
+
+                  {/* Contenido scrollable */}
+                  <div className="flex-1 overflow-y-auto">
+                    <AnimatePresence mode="wait">
+                      {editandoEmpleado ? (
+                        <motion.div key="edit"
+                          initial={{ opacity: 0, x: 16 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 16 }}
+                          transition={{ duration: 0.18, ease: "easeOut" }}
+                          className="px-4 py-4">
+                          <div className="flex flex-col gap-3 p-4 rounded-2xl" style={{ background: "var(--blanco)", border: "1px solid var(--surface-border)" }}>
+                            {/* Nombre + Apellidos en fila */}
+                            <div className="grid grid-cols-2 gap-3">
+                              <EmpCampo label="Nombre"
+                                value={editEmpleadoForm.nombre}
+                                onChange={(v) => setEditEmpleadoForm((f) => ({ ...f, nombre: v }))} />
+                              <EmpCampo label="Apellidos"
+                                value={editEmpleadoForm.apellidos}
+                                onChange={(v) => setEditEmpleadoForm((f) => ({ ...f, apellidos: v }))} />
+                            </div>
+                            <EmpCampo label="Email" type="email"
+                              value={editEmpleadoForm.email}
+                              onChange={(v) => setEditEmpleadoForm((f) => ({ ...f, email: v }))} />
+                            <EmpCampo label="Puesto"
+                              value={editEmpleadoForm.puestoTrabajo}
+                              onChange={(v) => setEditEmpleadoForm((f) => ({ ...f, puestoTrabajo: v }))} />
+                            <div className="flex flex-col gap-1.5">
+                              <label className="text-sm font-semibold" style={{ color: "var(--texto-label)" }}>Departamento</label>
+                              <EmpSelect label="" value={editEmpleadoForm.departamento}
+                                onChange={(v) => setEditEmpleadoForm((f) => ({ ...f, departamento: v }))}
+                                options={DEPARTAMENTOS} placeholder="Sin departamento" />
+                            </div>
+                          </div>
+                        </motion.div>
+                      ) : (
+                        <motion.div key="view"
+                          initial={{ opacity: 0, x: -16 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -16 }}
+                          transition={{ duration: 0.18, ease: "easeOut" }}
+                          className="px-4 py-4">
+                          <div className="flex flex-col gap-0 rounded-2xl overflow-hidden" style={{ border: "1px solid var(--surface-border)" }}>
+                            {[
+                              { label: "Puesto", value: empleadoSeleccionado.puestoTrabajo, badge: { bg: "var(--azul-egm-light)", color: "var(--azul-egm)" } },
+                              { label: "Departamento", value: DEPARTAMENTOS.find(d => d.id === empleadoSeleccionado.departamento)?.label, badge: { bg: "rgba(10,138,150,0.10)", color: "#0A8A96" } },
+                              { label: "Perfil", value: empleadoSeleccionado.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Administrador" : "Empleado", badge: empleadoSeleccionado.codigoRol === "ROLE_ADMIN_EMPRESA" ? { bg: "var(--verde-oliva-light)", color: "var(--verde-oliva)" } : { bg: "var(--azul-egm-light)", color: "var(--azul-egm)" } },
+                              { label: "Estado", value: empleadoSeleccionado.activo ? "Activo" : "Inactivo", badge: empleadoSeleccionado.activo ? { bg: "var(--exito-light)", color: "var(--exito)" } : { bg: "var(--gris-superficie)", color: "var(--texto-muted)" } },
+                              { label: "Alta", value: formatFecha(empleadoSeleccionado.fechaRegistro), badge: { bg: "var(--gris-superficie)", color: "var(--texto-secundario)" } },
+                            ].map(({ label, value, badge }, idx, arr) => (
+                              <div key={label} className="flex items-center justify-between px-4 py-3"
+                                style={{ borderBottom: idx < arr.length - 1 ? "1px solid var(--surface-border)" : "none", background: "var(--blanco)" }}>
+                                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>{label}</span>
+                                {value
+                                  ? <span className="text-xs font-semibold px-2.5 py-1 rounded-full" style={{ background: badge.bg, color: badge.color }}>{value}</span>
+                                  : <span className="text-xs" style={{ color: "var(--texto-muted)" }}>—</span>}
+                              </div>
+                            ))}
+                          </div>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </div>
+
+                  {/* Footer fijo */}
+                  <div className="px-5 py-4 shrink-0"
+                    style={{ borderTop: "1px solid var(--surface-border)", background: "var(--blanco)", paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}>
+                    {editandoEmpleado ? (
+                      <div className="flex gap-2.5">
+                        <Button variant="secondary" size="md" className="flex-1" onClick={() => setEditandoEmpleado(false)}>
+                          Cancelar
+                        </Button>
+                        <Button variant="primary" size="md" className="flex-1" onClick={handleGuardarEditEmpleado} disabled={guardandoEditEmpleado}>
+                          {guardandoEditEmpleado
+                            ? <><span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" />&nbsp;Guardando…</>
+                            : "Guardar cambios"}
+                        </Button>
                       </div>
-                      <div>
-                        <p className="text-sm font-bold" style={{ color: "var(--texto-primario)" }}>
-                          {empleadoSeleccionado.nombre} {empleadoSeleccionado.apellidos}
-                        </p>
-                        <p className="text-xs" style={{ color: "var(--texto-muted)" }}>{empleadoSeleccionado.email}</p>
+                    ) : (
+                      <div className="flex flex-col gap-2">
+                        <Button variant="primary" size="md" className="w-full" onClick={iniciarEditEmpleado}>
+                          Editar empleado
+                        </Button>
+                        <Button variant={empleadoSeleccionado.activo ? "danger" : "secondary"} size="md" className="w-full"
+                          onClick={() => handleToggleEmpleado(empleadoSeleccionado.usuarioId, empleadoSeleccionado.activo)}>
+                          {empleadoSeleccionado.activo ? "Desactivar empleado" : "Activar empleado"}
+                        </Button>
                       </div>
-                    </div>
-                    <div className="flex flex-col gap-3" style={{ borderTop: "1px solid var(--gris-borde)", paddingTop: "12px" }}>
-                      <DrawerRow label="Puesto" value={empleadoSeleccionado.puestoTrabajo ?? "—"} />
-                      <DrawerRow label="Departamento" value={DEPARTAMENTOS.find((d) => d.id === empleadoSeleccionado.departamento)?.label ?? "—"} />
-                      <DrawerRow label="Rol" value={empleadoSeleccionado.codigoRol === "ROLE_ADMIN_EMPRESA" ? "Administrador" : "Empleado"} />
-                      <DrawerRow label="Estado" value={empleadoSeleccionado.activo ? "Activo" : "Inactivo"} />
-                    </div>
-                    <button onClick={iniciarEditEmpleado}
-                      className="w-full text-sm font-semibold py-3 rounded-xl transition-colors"
-                      style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                      Editar empleado
-                    </button>
-                    <button
-                      onClick={() => handleToggleEmpleado(empleadoSeleccionado.usuarioId, empleadoSeleccionado.activo)}
-                      className="w-full text-sm font-semibold py-3 rounded-xl"
-                      style={empleadoSeleccionado.activo ? { background: "var(--error-light)", color: "var(--error)", border: "1px solid var(--error)" } : { background: "var(--exito-light)", color: "var(--exito)", border: "1px solid var(--exito)" }}
-                    >
-                      {empleadoSeleccionado.activo ? "Desactivar empleado" : "Activar empleado"}
-                    </button>
-                  </>
-                )}
-              </div>
+                    )}
+                  </div>
+                </motion.div>
+              </>
             )}
+            </AnimatePresence>
 
             {/* Import result notification */}
             {importResult && (
@@ -1549,101 +2007,7 @@ function AdminContent() {
           </>
         )}
 
-        {/* ── TAB PROGRESO DEL EQUIPO ── */}
-        {activeTab === "empleados" && (
-          <div className="rounded-2xl overflow-hidden mt-6" style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-            <div className="px-6 py-4 flex items-center justify-between" style={{ borderBottom: "1px solid var(--gris-borde)", background: "var(--gris-pagina)" }}>
-              <div>
-                <p style={{ fontFamily: "var(--font-raleway), sans-serif", fontWeight: 800, fontSize: "1.2rem", color: "var(--texto-primario)", letterSpacing: "-0.02em", lineHeight: 1.1 }}>
-                  Progreso del equipo
-                </p>
-                <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>Seguimiento individual por empleado</p>
-              </div>
-              <span className="text-xs font-semibold px-3 py-1 rounded-full" style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                {progresoEmpresa.length} empleado{progresoEmpresa.length !== 1 ? "s" : ""}
-              </span>
-            </div>
-            {cargandoProgreso ? (
-              <div className="flex items-center justify-center py-20">
-                <div className="w-6 h-6 border-2 rounded-full animate-spin"
-                  style={{ borderColor: "var(--gris-borde)", borderTopColor: "var(--azul-egm)" }} />
-              </div>
-            ) : progresoEmpresa.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-20 text-center">
-                <p className="text-sm font-medium" style={{ color: "var(--texto-primario)" }}>No hay datos de progreso</p>
-                <p className="text-xs mt-1" style={{ color: "var(--texto-muted)" }}>Los datos aparecerán cuando los empleados completen módulos</p>
-              </div>
-            ) : (
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead>
-                    <tr style={{ background: "var(--gris-pagina)", borderBottom: "1px solid var(--gris-borde)" }}>
-                      <th className="text-left py-3 px-4 text-xs font-bold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>Empleado</th>
-                      {progresoEmpresa[0]?.modulos.map((m) => (
-                        <th key={m.moduloId} className="text-center py-3 px-4 text-xs font-bold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>
-                          {m.nombreModulo}
-                        </th>
-                      ))}
-                      <th className="text-center py-3 px-4 text-xs font-bold uppercase tracking-wider" style={{ color: "var(--texto-muted)" }}>Media</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {progresoEmpresa.slice(progPage * PAGE_SIZE, (progPage + 1) * PAGE_SIZE).map((emp, idx, arr) => {
-                      const media = emp.modulos.length > 0
-                        ? Math.round(emp.modulos.reduce((acc, m) => acc + m.porcentaje, 0) / emp.modulos.length)
-                        : 0;
-                      const initials = [emp.nombre, emp.apellidos].join(" ").split(" ").slice(0, 2).map(p => p[0]).join("").toUpperCase();
-                      return (
-                        <tr key={emp.usuarioId} style={{ borderBottom: idx < arr.length - 1 ? "1px solid var(--gris-borde)" : "none" }}>
-                          <td className="py-3.5 px-4">
-                            <div className="flex items-center gap-2.5">
-                              <div className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
-                                style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
-                                {initials}
-                              </div>
-                              <div>
-                                <p className="text-sm font-medium" style={{ color: "var(--texto-primario)" }}>{emp.nombre} {emp.apellidos}</p>
-                              </div>
-                            </div>
-                          </td>
-                          {emp.modulos.map((m) => (
-                            <td key={m.moduloId} className="py-3.5 px-4">
-                              <div className="flex items-center gap-2 justify-center">
-                                <div className="w-16 rounded-full overflow-hidden" style={{ height: "5px", background: "var(--gris-superficie)" }}>
-                                  <div style={{ width: `${m.porcentaje}%`, height: "100%", background: m.porcentaje === 100 ? "var(--verde-oliva)" : m.porcentaje >= 50 ? "var(--azul-egm)" : "#f59e0b", borderRadius: "9999px" }} />
-                                </div>
-                                <span className="text-xs font-semibold" style={{ color: m.porcentaje === 100 ? "var(--verde-oliva)" : m.porcentaje >= 50 ? "var(--azul-egm)" : "#b45309" }}>{m.porcentaje}%</span>
-                              </div>
-                            </td>
-                          ))}
-                          <td className="py-3.5 px-4 text-center">
-                            <span className="text-sm font-bold" style={{ color: media >= 80 ? "var(--verde-oliva)" : media >= 50 ? "var(--azul-egm)" : "#b45309" }}>{media}%</span>
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-                {/* Paginación progreso */}
-                {progresoEmpresa.length > PAGE_SIZE && (
-                  <div className="flex items-center justify-between px-5 py-3" style={{ borderTop: "1px solid var(--gris-borde)" }}>
-                    <span className="text-xs" style={{ color: "var(--texto-muted)" }}>
-                      {progPage * PAGE_SIZE + 1}–{Math.min((progPage + 1) * PAGE_SIZE, progresoEmpresa.length)} de {progresoEmpresa.length}
-                    </span>
-                    <div className="flex gap-2">
-                      <button onClick={() => setProgPage(p => Math.max(0, p - 1))} disabled={progPage === 0}
-                        className="px-3 py-1.5 rounded-lg text-xs font-semibold disabled:opacity-40"
-                        style={{ background: "var(--gris-pagina)", color: "var(--texto-primario)" }}>← Anterior</button>
-                      <button onClick={() => setProgPage(p => p + 1)} disabled={(progPage + 1) * PAGE_SIZE >= progresoEmpresa.length}
-                        className="px-3 py-1.5 rounded-lg text-xs font-semibold disabled:opacity-40"
-                        style={{ background: "var(--gris-pagina)", color: "var(--texto-primario)" }}>Siguiente →</button>
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        )}
+        {/* ── TAB PROGRESO DEL EQUIPO — oculto hasta que formación esté operativa ── */}
 
         {/* ── TAB MÓDULOS FORMATIVOS ── */}
         {activeTab === "formaciones" && (
@@ -1830,7 +2194,7 @@ function AdminContent() {
 
         {/* ── TAB ESTADÍSTICAS ── */}
         {activeTab === "estadisticas" && (
-          <div className="animate-fadeIn">
+          <div>
             {/* ── Barra de filtros y personalización ── */}
             <div className="bg-white rounded-2xl border border-slate-100 shadow-sm p-4 mb-6 flex flex-wrap items-center gap-3">
               {/* Rango temporal */}
@@ -2162,6 +2526,9 @@ function AdminContent() {
             )}
           </div>
         )}
+
+        </motion.div>
+        </AnimatePresence>
       </div>
 
 
@@ -2267,23 +2634,196 @@ function AdminContent() {
       })()}
 
       {/* Toast */}
-      {toast && (
-        <div className="fixed bottom-6 left-1/2 z-300 flex items-center gap-2.5 px-5 py-3 rounded-2xl text-sm font-semibold shadow-xl"
-          style={{ transform: "translateX(-50%)", background: "linear-gradient(135deg, #1b3f7e 0%, #2563eb 100%)", color: "#fff", animation: "toastIn 0.3s cubic-bezier(0.34,1.56,0.64,1)" }}>
-          <Check size={16} strokeWidth={2.5} />
-          {toast}
-          <style>{`@keyframes toastIn { from { opacity:0; transform:translateX(-50%) translateY(12px) scale(0.95); } to { opacity:1; transform:translateX(-50%) translateY(0) scale(1); } }`}</style>
-        </div>
-      )}
+      <AnimatePresence>
+        {toast && (
+          <motion.div
+            key={toast.msg}
+            initial={{ opacity: 0, y: 14, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 8, scale: 0.97 }}
+            transition={{ duration: 0.25, ease: [0.34, 1.2, 0.64, 1] }}
+            className="fixed bottom-6 left-1/2 z-[300] flex items-center gap-2.5 px-5 py-3 rounded-2xl text-sm font-semibold shadow-xl"
+            style={{
+              translateX: "-50%",
+              background: toast.tipo === "error"
+                ? "linear-gradient(135deg, #c0392b 0%, #e74c3c 100%)"
+                : "linear-gradient(135deg, #1b3f7e 0%, #2563eb 100%)",
+              color: "#fff",
+            }}>
+            {toast.tipo === "error"
+              ? <X size={16} strokeWidth={2.5} />
+              : <Check size={16} strokeWidth={2.5} />}
+            {toast.msg}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
 
-function DrawerRow({ label, value }: { label: string; value: string }) {
+// ── Select animado para el modal de empleado ─────────────────────────────────
+function EmpSelect({ label, value, onChange, options, placeholder = "Sin departamento" }: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: { id: string; label: string }[];
+  placeholder?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ bottom: 0, left: 0, width: 0 });
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const selected = options.find(o => o.id === value);
+
+  function calcPos() {
+    if (!triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    setPos({ bottom: window.innerHeight - r.top + 6, left: r.left, width: r.width });
+  }
+
+  useEffect(() => {
+    function onClickOut(e: MouseEvent) {
+      const t = e.target as Node;
+      if (!wrapRef.current?.contains(t) && !dropdownRef.current?.contains(t)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onClickOut);
+    return () => document.removeEventListener("mousedown", onClickOut);
+  }, []);
+
   return (
-    <div className="flex items-center justify-between">
-      <span className="text-xs" style={{ color: "var(--texto-muted)" }}>{label}</span>
-      <span className="text-xs font-medium" style={{ color: "var(--texto-primario)" }}>{value}</span>
+    <div className="flex flex-col gap-1.5" ref={wrapRef}>
+      <label className="text-sm font-semibold" style={{ color: "var(--texto-label)" }}>{label}</label>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => { calcPos(); setOpen(p => !p); }}
+        className="w-full flex items-center justify-between rounded-lg px-3.5 text-sm border transition-all duration-150 cursor-pointer"
+        style={{
+          height: "44px",
+          borderColor: open ? "var(--azul-egm)" : "rgba(0,0,0,0.12)",
+          boxShadow: open ? "0 0 0 3px rgba(22,50,105,0.08)" : "none",
+          background: "#ffffff",
+          color: selected ? "var(--texto-primario)" : "var(--texto-placeholder)",
+          textAlign: "left",
+        }}
+      >
+        <span>{selected?.label ?? placeholder}</span>
+        <motion.span
+          animate={{ rotate: open ? 180 : 0 }}
+          transition={{ duration: 0.18 }}
+          style={{ color: "var(--texto-muted)", display: "flex", flexShrink: 0 }}
+        >
+          <ChevronDown size={15} />
+        </motion.span>
+      </button>
+
+      {createPortal(
+        <AnimatePresence>
+          {open && (
+            <motion.div
+              ref={dropdownRef}
+              initial={{ opacity: 0, y: 6, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 4, scale: 0.97 }}
+              transition={{ duration: 0.15, ease: "easeOut" }}
+              style={{
+                position: "fixed",
+                bottom: pos.bottom,
+                left: pos.left,
+                width: pos.width,
+                zIndex: 9999,
+                background: "#ffffff",
+                border: "1px solid rgba(0,0,0,0.10)",
+                borderRadius: "10px",
+                boxShadow: "0 -8px 24px rgba(0,0,0,0.12)",
+                overflow: "hidden",
+                transformOrigin: "bottom center",
+              }}
+            >
+              {[{ id: "", label: placeholder }, ...options].map((opt) => {
+                const isSelected = value === opt.id;
+                return (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    onClick={() => { onChange(opt.id); setOpen(false); }}
+                    className="w-full text-left px-3.5 py-2.5 text-sm transition-colors cursor-pointer"
+                    style={{
+                      background: isSelected ? "var(--azul-egm-light)" : "transparent",
+                      color: isSelected ? "var(--azul-egm)" : "var(--texto-primario)",
+                      fontWeight: isSelected ? 600 : 400,
+                    }}
+                    onMouseEnter={(e) => { if (!isSelected) e.currentTarget.style.background = "var(--gris-pagina)"; }}
+                    onMouseLeave={(e) => { if (!isSelected) e.currentTarget.style.background = "transparent"; }}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body
+      )}
+    </div>
+  );
+}
+
+// ── Campo reutilizable para el modal de empleado ─────────────────────────────
+function EmpCampo({ label, value, onChange, placeholder, required, type = "text", hint }: {
+  label: string; value: string; onChange: (v: string) => void;
+  placeholder?: string; required?: boolean; type?: string; hint?: string;
+}) {
+  const [foco, setFoco] = useState(false);
+  const [verPass, setVerPass] = useState(false);
+  const isPassword = type === "password";
+  const inputType = isPassword ? (verPass ? "text" : "password") : type;
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-semibold" style={{ color: "var(--texto-label)" }}>
+        {label}{required && (
+          <span className="relative group ml-0.5 inline-block" style={{ color: "#ef4444" }}>
+            *
+            <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-1.5 px-2 py-1 rounded-lg text-xs font-semibold whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+              style={{ background: "#1f2937", color: "#fff", boxShadow: "0 2px 8px rgba(0,0,0,0.18)", zIndex: 99 }}>
+              Obligatorio
+            </span>
+          </span>
+        )}
+      </label>
+      <div className="relative">
+        <input
+          type={inputType}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          onFocus={() => setFoco(true)}
+          onBlur={() => setFoco(false)}
+          className="w-full rounded-lg text-sm outline-none border transition-all duration-150"
+          style={{
+            height: "44px",
+            paddingLeft: "14px",
+            paddingRight: isPassword ? "40px" : "14px",
+            borderColor: foco ? "var(--azul-egm)" : "rgba(0,0,0,0.12)",
+            boxShadow: foco ? "0 0 0 3px rgba(22,50,105,0.08)" : "none",
+            background: "#ffffff",
+            color: "var(--texto-primario)",
+          }}
+        />
+        {isPassword && (
+          <button
+            type="button"
+            tabIndex={-1}
+            onClick={() => setVerPass((v) => !v)}
+            className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center justify-center"
+            style={{ color: "var(--texto-muted)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+          >
+            {verPass ? <EyeOff size={16} /> : <Eye size={16} />}
+          </button>
+        )}
+      </div>
+      {hint && <p className="text-xs" style={{ color: "var(--texto-placeholder)" }}>{hint}</p>}
     </div>
   );
 }


### PR DESCRIPTION
…a ordenable y bottom sheet

- Tabla desktop: columnas ordenables (nombre, puesto, departamento, perfil, estado) con anchos fijos via colgroup, botón reset glass circular animado
- Mobile: tarjetas de empleado con avatar, badge de rol y paginación de 10/página
- Bottom sheet: header Grainient, avatar reactivo al editar, footer full-width alineado con safe-area-inset, sin handle decorativo
- Modal nuevo empleado: botones full-width apilados en móvil con orden primario correcto
- Reseteo de página al cruzar breakpoint md via matchMedia listener
- Limpieza: eliminados DrawerRow (dead code) y FileSpreadsheet (import sin uso)