### PR TITLE
fix: llamar a backend al completar modulo para guardar certificado en…

### DIFF
--- a/app/dashboard/formacion/[moduloId]/page.tsx
+++ b/app/dashboard/formacion/[moduloId]/page.tsx
@@ -12,6 +12,7 @@ import { useAuth } from "@/context/AuthContext";
 import { apiFetch, API_URL } from "@/lib/api";
 import { PresentationViewer } from "@/components/presentation/PresentationViewer";
 import { getBestSpanishVoice } from "@/lib/speech";
+import { generarCertificadoModulo } from "@/lib/api/documentos";
 
 // ── TIPOS ─────────────────────────────────────────────────────────────────────
 type TipoContenido = "texto" | "video" | "pdf" | "quiz";
@@ -397,6 +398,8 @@ export default function Page() {
       } else {
         // Último ítem — módulo completado
         setModuloCompletado(true);
+        // Generar y guardar el certificado en el backend (aparece en "Mis documentos")
+        generarCertificadoModulo(id).catch(() => null);
       }
       setCompletando(false);
     }, 600);

--- a/lib/api/documentos.ts
+++ b/lib/api/documentos.ts
@@ -82,6 +82,23 @@ export async function firmarDocumento(documentoId: string, firmaBase64: string):
   return res.json();
 }
 
+/**
+ * Llama al backend para generar el certificado cuando el empleado completa un módulo.
+ * Si ya existe lo devuelve directamente. Devuelve la URL del PDF en Supabase.
+ */
+export async function generarCertificadoModulo(moduloId: string): Promise<string | null> {
+  try {
+    const res = await apiFetch(`${API_URL}/documentos/me/certificado/${moduloId}`, {
+      method: "POST",
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.url ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function obtenerCertificadoModulo(moduloId: string): Promise<string | null> {
   try {
     const res = await apiFetch(`${API_URL}/documentos/me/certificado/${moduloId}`);


### PR DESCRIPTION
… documentos

- generarCertificadoModulo(): POST /documentos/me/certificado/{moduloId}
- marcarCompletado: cuando es el ultimo item llama a generarCertificadoModulo(id) de forma silenciosa (no bloquea UI si falla)