### PR TITLE
feat(formacion): conectar progreso real de modulos al backend

### DIFF
--- a/app/dashboard/formacion/[moduloId]/page.tsx
+++ b/app/dashboard/formacion/[moduloId]/page.tsx
@@ -13,6 +13,7 @@ import { apiFetch, API_URL } from "@/lib/api";
 import { PresentationViewer } from "@/components/presentation/PresentationViewer";
 import { getBestSpanishVoice } from "@/lib/speech";
 import { generarCertificadoModulo } from "@/lib/api/documentos";
+import { guardarProgresoModulo, getMiProgresoModulo } from "@/lib/api/moduloProgreso";
 
 // ── TIPOS ─────────────────────────────────────────────────────────────────────
 type TipoContenido = "texto" | "video" | "pdf" | "quiz";
@@ -347,7 +348,20 @@ export default function Page() {
           const data: ModuloAPI = await res.json();
           setModuloApi(data);
           const base = apiToMock(data);
-          const { completados, activoId: savedActivo } = cargarEstado(id, esAdmin);
+          let { completados, activoId: savedActivo } = cargarEstado(id, esAdmin);
+
+          // Sincronizar con el backend: si el backend tiene MÁS progreso, lo respetamos
+          // (caso típico: el usuario lo completó en otro dispositivo).
+          if (!esAdmin) {
+            const remoto = await getMiProgresoModulo(id);
+            if (remoto && remoto.contenidosCompletados > completados.length) {
+              // Marcamos los primeros N ítems como completados
+              completados = base.contenidos.slice(0, remoto.contenidosCompletados).map((c) => c.id);
+              // Guardamos también en localStorage para mantener consistencia
+              guardarEstado(id, completados, savedActivo, base.totalItems, esAdmin);
+            }
+          }
+
           const moduloConEstado = aplicarEstado(base, completados);
           setModulo(moduloConEstado);
           const yaCompletado = completados.length >= moduloConEstado.totalItems;
@@ -393,12 +407,17 @@ export default function Page() {
           return c;
         }),
       }) : null);
+
+      // Sincronizar progreso al backend (no bloquea la UI si falla)
+      guardarProgresoModulo(id, nuevosCompletados, modulo.totalItems).catch(() => null);
+
       if (siguiente) {
         setActivoId(siguiente.id);
       } else {
         // Último ítem — módulo completado
         setModuloCompletado(true);
-        // Generar y guardar el certificado en el backend (aparece en "Mis documentos")
+        // Backend dispara el certificado automáticamente al recibir % = 100
+        // (pero llamamos también explícitamente para cubrir el caso de sincronización en frío)
         generarCertificadoModulo(id).catch(() => null);
       }
       setCompletando(false);

--- a/lib/api/moduloProgreso.ts
+++ b/lib/api/moduloProgreso.ts
@@ -1,0 +1,57 @@
+import { API_URL, apiFetch } from "../api";
+
+export interface ModuloProgresoResponse {
+  moduloId:              string;
+  contenidosCompletados: number;
+  totalContenidos:       number;
+  porcentaje:            number;
+  completado:            boolean;
+  fechaInicio?:          string | null;
+  fechaCompletado?:      string | null;
+  actualizadoEn?:        string | null;
+}
+
+/**
+ * Guarda (upsert monótono) el progreso del usuario en un módulo.
+ * El backend nunca permite que el % baje y dispara la generación del
+ * certificado cuando se alcanza el 100 %.
+ */
+export async function guardarProgresoModulo(
+  moduloId: string,
+  contenidosCompletados: number,
+  totalContenidos: number,
+): Promise<ModuloProgresoResponse | null> {
+  try {
+    const res = await apiFetch(`${API_URL}/modulos/${moduloId}/progreso`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ contenidosCompletados, totalContenidos }),
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+/** Devuelve todos los progresos del usuario autenticado. */
+export async function getMisProgresosModulo(): Promise<ModuloProgresoResponse[]> {
+  try {
+    const res = await apiFetch(`${API_URL}/modulos/me/progreso`);
+    if (!res.ok) return [];
+    return res.json();
+  } catch {
+    return [];
+  }
+}
+
+/** Devuelve el progreso del usuario en un módulo concreto. */
+export async function getMiProgresoModulo(moduloId: string): Promise<ModuloProgresoResponse | null> {
+  try {
+    const res = await apiFetch(`${API_URL}/modulos/${moduloId}/progreso/me`);
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
- lib/api/moduloProgreso.ts: cliente API con guardar/leer progreso
- Pagina de modulo: marcarCompletado envia progreso al backend tras marcar cada contenido (no bloquea UI si falla)
- Al cargar el modulo, sincroniza con el backend: si tiene mas progreso que el localStorage (caso: completado en otro dispositivo), hidratamos el estado local desde el remoto

Funciona en tandem con el endpoint del backend POST /modulos/{id}/progreso que dispara la generacion automatica del certificado al llegar al 100%.