### PR TITLE
feat(admin): nueva tab Eventos para crear/gestionar eventos de comunidad

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -31,6 +31,7 @@ import { getEstadisticasAdminEmpresa, type EstadisticasEmpresaResponse, type Fil
 import { exportStats, type ExportFormat, type StatsSection } from "@/lib/utils/statsExport";
 import GestionIncidencias from "@/components/pages/GestionIncidencias";
 import { DocumentosAdminTab } from "@/components/documentos/DocumentosAdminTab";
+import { EventosAdminTab } from "@/components/eventos/EventosAdminTab";
 // ExcelJS movido a API routes: /api/admin/export-empleados y /api/admin/import-empleados
 
 const EMPTY_ANUNCIO: NoticiaInput = {
@@ -992,7 +993,7 @@ function AdminContent() {
   const searchParams = useSearchParams();
   const { usuario } = useAuth();
 
-  const [activeTab, setActiveTab] = useState<"empleados" | "anuncios" | "formaciones" | "incidencias" | "estadisticas" | "documentos">("empleados");
+  const [activeTab, setActiveTab] = useState<"empleados" | "anuncios" | "formaciones" | "incidencias" | "estadisticas" | "documentos" | "eventos">("empleados");
   const [tabMenuOpen, setTabMenuOpen] = useState(false);
 
   const queryClient = useQueryClient();
@@ -1194,6 +1195,7 @@ function AdminContent() {
     if (tab === "empleados") setActiveTab("empleados");
     if (tab === "estadisticas") setActiveTab("estadisticas");
     if (tab === "documentos") setActiveTab("documentos");
+    if (tab === "eventos") setActiveTab("eventos");
     const editId = searchParams.get("edit");
     if (editId && formaciones.length > 0) {
       const f = formaciones.find((x) => x.moduloId === editId);
@@ -1582,6 +1584,7 @@ function AdminContent() {
     { key: "incidencias" as const, label: "Incidencias",        icon: <TriangleAlert size={20} />, accent: "#B45309", badge: 0 },
     { key: "anuncios"    as const, label: "Anuncios",           icon: <Megaphone size={20} />,     accent: "#0EA5E9", badge: 0 },
     { key: "formaciones" as const, label: "Módulos formativos", icon: <GraduationCap size={20} />, accent: "#7B4A85", badge: 0 },
+    { key: "eventos"     as const, label: "Eventos",            icon: <Calendar size={20} />,      accent: "#0F766E", badge: 0 },
     { key: "estadisticas"as const, label: "Estadísticas",       icon: <BarChart3 size={20} />,     accent: "#2D8653", badge: 0 },
     { key: "documentos"  as const, label: "Documentos",         icon: <FileText size={20} />,      accent: "#4E6D7E", badge: 0 },
   ];
@@ -3084,6 +3087,11 @@ function AdminContent() {
             }))}
             departamentos={DEPARTAMENTOS}
           />
+        )}
+
+        {/* ── TAB EVENTOS ── */}
+        {activeTab === "eventos" && (
+          <EventosAdminTab esSuperAdmin={usuario?.codigoRol === "ROLE_ADMIN"} />
         )}
 
         {/* ── TAB ESTADÍSTICAS ── */}

--- a/app/dashboard/eventos/page.tsx
+++ b/app/dashboard/eventos/page.tsx
@@ -4,44 +4,58 @@ import React, { useEffect, useState, useCallback } from "react";
 import DashboardHero from "@/components/ui/DashboardHero";
 import { Button }    from "@/components/ui/Button";
 import { useAuth }   from "@/context/AuthContext";
-import { getEventos, desactivarEvento } from "@/lib/api/eventos";
-import type { Evento, EstadoEvento } from "@/lib/types/eventos";
+import {
+  getEventosComunidad,
+  desactivarEventoComunidad,
+  type ComunidadEvento,
+} from "@/lib/api/comunidad";
+import { ModalEvento } from "@/components/eventos/ModalEvento";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+type EstadoEvento = "PROXIMO" | "EN_CURSO" | "FINALIZADO";
+
 const ESTADO_CONFIG: Record<EstadoEvento, { label: string; bg: string; color: string }> = {
   PROXIMO:    { label: "Próximo",    bg: "rgba(59,130,246,0.09)",  color: "#2563eb" },
-  EN_CURSO:   { label: "En curso",   bg: "rgba(16,185,129,0.09)", color: "#059669" },
+  EN_CURSO:   { label: "Hoy",        bg: "rgba(16,185,129,0.09)",  color: "#059669" },
   FINALIZADO: { label: "Finalizado", bg: "rgba(0,0,0,0.06)",       color: "#6b7280" },
-  CANCELADO:  { label: "Cancelado",  bg: "rgba(239,68,68,0.09)",   color: "#dc2626" },
 };
 
-function calcEstado(evento: Evento): EstadoEvento {
-  if (evento.estado) return evento.estado;
-  const fecha = new Date(evento.fecha);
-  const hoyMs = new Date().setHours(0, 0, 0, 0);
-  if (fecha.getTime() > hoyMs) return "PROXIMO";
-  if (fecha.getTime() === hoyMs) return "EN_CURSO";
+function calcEstado(ev: ComunidadEvento): EstadoEvento {
+  const ahora    = Date.now();
+  const ini      = new Date(ev.fechaInicio).getTime();
+  const fin      = ev.fechaFin ? new Date(ev.fechaFin).getTime() : ini;
+  if (ini > ahora) return "PROXIMO";
+  if (ahora <= fin) return "EN_CURSO";
   return "FINALIZADO";
 }
 
 function formatFecha(iso: string) {
-  const d = new Date(iso + "T00:00:00");
-  return d.toLocaleDateString("es-ES", { weekday: "long", day: "numeric", month: "long", year: "numeric" });
+  return new Date(iso).toLocaleDateString("es-ES", {
+    weekday: "long", day: "numeric", month: "long", year: "numeric",
+  });
+}
+
+function formatHoras(ev: ComunidadEvento) {
+  const ini = new Date(ev.fechaInicio).toLocaleTimeString("es-ES", { hour: "2-digit", minute: "2-digit" });
+  if (!ev.fechaFin) return ini;
+  const fin = new Date(ev.fechaFin).toLocaleTimeString("es-ES", { hour: "2-digit", minute: "2-digit" });
+  return `${ini} – ${fin}`;
 }
 
 // ── Card de evento ────────────────────────────────────────────────────────────
 function EventoCard({
-  evento, esSuperAdmin, onEditar, onDesactivar,
+  evento, puedeEditar, onEditar, onDesactivar,
 }: {
-  evento: Evento; esSuperAdmin: boolean;
-  onEditar: (e: Evento) => void; onDesactivar: (e: Evento) => void;
+  evento: ComunidadEvento; puedeEditar: boolean;
+  onEditar: (e: ComunidadEvento) => void; onDesactivar: (e: ComunidadEvento) => void;
 }) {
-  const [hovered, setHovered] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
+  const [hovered,   setHovered]   = useState(false);
+  const [menuOpen,  setMenuOpen]  = useState(false);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const estado  = calcEstado(evento);
   const cfg     = ESTADO_CONFIG[estado];
-  const pasado  = estado === "FINALIZADO" || estado === "CANCELADO";
+  const pasado  = estado === "FINALIZADO";
+  const fechaIni = new Date(evento.fechaInicio);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -70,10 +84,14 @@ function EventoCard({
       <div className="flex items-center gap-3 px-4 pt-4 pb-3">
         {/* Bloque día */}
         <div className="shrink-0 rounded-xl flex flex-col items-center justify-center"
-          style={{ width: 46, height: 46, background: pasado ? "#f3f4f6" : "linear-gradient(135deg, #e8eef8 0%, #d4e0f5 100%)", color: pasado ? "#9ca3af" : "var(--azul-egm)" }}>
-          <span className="text-lg font-bold leading-none">{new Date(evento.fecha + "T00:00:00").getDate()}</span>
+          style={{
+            width: 46, height: 46,
+            background: pasado ? "#f3f4f6" : "linear-gradient(135deg, #e8eef8 0%, #d4e0f5 100%)",
+            color: pasado ? "#9ca3af" : "var(--azul-egm)",
+          }}>
+          <span className="text-lg font-bold leading-none">{fechaIni.getDate()}</span>
           <span className="text-[10px] font-semibold uppercase tracking-wide leading-none mt-0.5">
-            {new Date(evento.fecha + "T00:00:00").toLocaleDateString("es-ES", { month: "short" })}
+            {fechaIni.toLocaleDateString("es-ES", { month: "short" }).replace(".", "")}
           </span>
         </div>
 
@@ -82,8 +100,7 @@ function EventoCard({
             {evento.titulo}
           </h3>
           <p className="text-xs mt-0.5" style={{ color: "#9ca3af" }}>
-            {formatFecha(evento.fecha)}
-            {evento.horaInicio && ` · ${evento.horaInicio}${evento.horaFin ? ` – ${evento.horaFin}` : ""}`}
+            {formatFecha(evento.fechaInicio)} · {formatHoras(evento)}
           </p>
         </div>
 
@@ -94,8 +111,8 @@ function EventoCard({
             {cfg.label}
           </span>
 
-          {/* Menú superadmin */}
-          {esSuperAdmin && (
+          {/* Menú admin */}
+          {puedeEditar && (
             <div ref={menuRef} style={{ position: "relative" }}>
               <button
                 onClick={() => setMenuOpen(p => !p)}
@@ -126,7 +143,7 @@ function EventoCard({
       </div>
 
       {/* Cuerpo */}
-      {(evento.descripcion || evento.lugar) && (
+      {(evento.descripcion || true) && (
         <>
           <div style={{ height: "1px", background: "rgba(0,0,0,0.06)", margin: "0 16px" }} />
           <div className="px-4 py-3 flex flex-col gap-2">
@@ -135,30 +152,23 @@ function EventoCard({
                 {evento.descripcion}
               </p>
             )}
-            {evento.lugar && (
-              <div className="flex items-center gap-1.5">
-                <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} style={{ color: "#9ca3af", flexShrink: 0 }}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/><path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-                </svg>
-                <span className="text-xs" style={{ color: "#9ca3af" }}>{evento.lugar}</span>
-              </div>
-            )}
+            <div className="flex items-center gap-1.5">
+              <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                style={{ color: "#9ca3af", flexShrink: 0 }}>
+                {evento.esGlobal ? (
+                  <path strokeLinecap="round" strokeLinejoin="round"
+                    d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                ) : (
+                  <path strokeLinecap="round" strokeLinejoin="round"
+                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+                )}
+              </svg>
+              <span className="text-xs font-medium" style={{ color: evento.esGlobal ? "var(--azul-egm)" : "var(--verde-oliva)" }}>
+                {evento.esGlobal ? "EGM Atalayas (global)" : "Tu empresa"}
+              </span>
+            </div>
           </div>
         </>
-      )}
-
-      {/* Footer */}
-      {evento.urlInfo && (
-        <div className="px-4 pb-4 mt-auto">
-          <a href={evento.urlInfo} target="_blank" rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs font-semibold"
-            style={{ color: "var(--azul-egm)" }}>
-            Más información
-            <svg width="11" height="11" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
-            </svg>
-          </a>
-        </div>
       )}
     </div>
   );
@@ -204,27 +214,35 @@ function SkeletonCard() {
 // ── Página ────────────────────────────────────────────────────────────────────
 export default function EventosPage() {
   const { usuario } = useAuth();
-  const esSuperAdmin = usuario?.codigoRol === "ROLE_ADMIN";
+  const esSuperAdmin  = usuario?.codigoRol === "ROLE_ADMIN";
+  const esAdminEmpresa = usuario?.codigoRol === "ROLE_ADMIN_EMPRESA";
+  const puedeEditar   = esSuperAdmin || esAdminEmpresa;
 
-  const [eventos,   setEventos]   = useState<Evento[]>([]);
+  const [eventos,   setEventos]   = useState<ComunidadEvento[]>([]);
   const [cargando,  setCargando]  = useState(true);
   const [toast,     setToast]     = useState<{ msg: string; tipo: "ok" | "err" } | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editando,  setEditando]  = useState<ComunidadEvento | null>(null);
 
   const mostrarToast = useCallback((msg: string, tipo: "ok" | "err" = "ok") => {
     setToast({ msg, tipo });
     setTimeout(() => setToast(null), 2200);
   }, []);
 
-  useEffect(() => {
-    getEventos()
+  const cargar = useCallback(() => {
+    setCargando(true);
+    getEventosComunidad()
       .then(setEventos)
       .catch(() => mostrarToast("Error al cargar los eventos", "err"))
       .finally(() => setCargando(false));
   }, [mostrarToast]);
 
-  async function handleDesactivar(evento: Evento) {
+  useEffect(() => { cargar(); }, [cargar]);
+
+  async function handleDesactivar(evento: ComunidadEvento) {
+    if (!confirm(`¿Cancelar el evento "${evento.titulo}"?`)) return;
     try {
-      await desactivarEvento(evento.eventoId);
+      await desactivarEventoComunidad(evento.eventoId);
       setEventos(prev => prev.filter(e => e.eventoId !== evento.eventoId));
       mostrarToast("Evento cancelado");
     } catch {
@@ -232,9 +250,22 @@ export default function EventosPage() {
     }
   }
 
-  // Separar próximos de pasados
-  const proximos  = eventos.filter(e => calcEstado(e) !== "FINALIZADO" && calcEstado(e) !== "CANCELADO");
-  const pasados   = eventos.filter(e => calcEstado(e) === "FINALIZADO" || calcEstado(e) === "CANCELADO");
+  function handleEditar(ev: ComunidadEvento) { setEditando(ev); setModalOpen(true); }
+  function handleNuevo()                    { setEditando(null); setModalOpen(true); }
+  function handleGuardado() {
+    setModalOpen(false);
+    setEditando(null);
+    cargar();
+    mostrarToast("Evento guardado");
+  }
+
+  // Separar próximos/en curso de pasados
+  const activos  = eventos.filter(e => calcEstado(e) !== "FINALIZADO");
+  const pasados  = eventos.filter(e => calcEstado(e) === "FINALIZADO");
+
+  // Ordenar: futuros ascendente, pasados descendente
+  activos.sort((a, b) => new Date(a.fechaInicio).getTime() - new Date(b.fechaInicio).getTime());
+  pasados.sort((a, b) => new Date(b.fechaInicio).getTime() - new Date(a.fechaInicio).getTime());
 
   return (
     <div className="flex flex-col gap-6 pb-10">
@@ -243,9 +274,9 @@ export default function EventosPage() {
         subtitulo="Actividades, jornadas y encuentros del área empresarial EGM Atalayas."
         variante="seccion"
       />
-      {esSuperAdmin && (
-        <div className="px-4 sm:px-6 lg:px-8 -mt-2">
-          <Button variant="primary" onClick={() => mostrarToast("Próximamente — modal de evento")}>
+      {puedeEditar && (
+        <div className="px-4 sm:px-6 lg:px-8 -mt-2 flex justify-end">
+          <Button variant="primary" onClick={handleNuevo}>
             <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2} className="mr-1.5">
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4"/>
             </svg>
@@ -256,7 +287,7 @@ export default function EventosPage() {
 
       <div className="px-4 sm:px-6 lg:px-8 flex flex-col gap-8">
 
-        {/* Próximos */}
+        {/* Próximos / en curso */}
         <section>
           <h2 className="text-sm font-semibold uppercase tracking-wider mb-3" style={{ color: "#9ca3af" }}>
             Próximos
@@ -265,7 +296,7 @@ export default function EventosPage() {
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {[1, 2, 3].map(i => <SkeletonCard key={i} />)}
             </div>
-          ) : proximos.length === 0 ? (
+          ) : activos.length === 0 ? (
             <div className="rounded-2xl flex flex-col items-center justify-center py-14 gap-3"
               style={{ background: "#f9fafb", border: "1px solid rgba(0,0,0,0.06)" }}>
               <svg width="36" height="36" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.4} style={{ color: "#d1d5db" }}>
@@ -275,9 +306,9 @@ export default function EventosPage() {
             </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {proximos.map(e => (
-                <EventoCard key={e.eventoId} evento={e} esSuperAdmin={esSuperAdmin}
-                  onEditar={() => mostrarToast("Próximamente — editar evento")}
+              {activos.map(e => (
+                <EventoCard key={e.eventoId} evento={e} puedeEditar={puedeEditar}
+                  onEditar={handleEditar}
                   onDesactivar={handleDesactivar}
                 />
               ))}
@@ -293,8 +324,8 @@ export default function EventosPage() {
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {pasados.map(e => (
-                <EventoCard key={e.eventoId} evento={e} esSuperAdmin={esSuperAdmin}
-                  onEditar={() => mostrarToast("Próximamente — editar evento")}
+                <EventoCard key={e.eventoId} evento={e} puedeEditar={puedeEditar}
+                  onEditar={handleEditar}
                   onDesactivar={handleDesactivar}
                 />
               ))}
@@ -302,6 +333,16 @@ export default function EventosPage() {
           </section>
         )}
       </div>
+
+      {/* Modal crear/editar */}
+      {modalOpen && (
+        <ModalEvento
+          evento={editando}
+          esSuperAdmin={esSuperAdmin}
+          onClose={() => { setModalOpen(false); setEditando(null); }}
+          onGuardado={handleGuardado}
+        />
+      )}
 
       {/* Toast */}
       {toast && (

--- a/components/eventos/EventosAdminTab.tsx
+++ b/components/eventos/EventosAdminTab.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+// ============================================================
+// EventosAdminTab — tab del panel admin para gestionar eventos
+// de comunidad. Lista, crea y desactiva eventos.
+// ============================================================
+
+import { useEffect, useState } from "react";
+import {
+  Calendar, Plus, X, Trash2, Pencil, Loader2, MapPin, Clock, Globe2, Building2,
+} from "lucide-react";
+import {
+  getEventosComunidad,
+  crearEventoComunidad,
+  actualizarEventoComunidad,
+  desactivarEventoComunidad,
+  type ComunidadEvento,
+  type ComunidadEventoInput,
+} from "@/lib/api/comunidad";
+
+interface Props {
+  /** Si quien usa el panel es ROLE_ADMIN (superadmin) → puede marcar eventos como globales */
+  esSuperAdmin?: boolean;
+}
+
+export function EventosAdminTab({ esSuperAdmin = false }: Props) {
+  const [eventos, setEventos]   = useState<ComunidadEvento[]>([]);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError]       = useState<string | null>(null);
+  const [modalAbierto, setModalAbierto] = useState(false);
+  const [editando, setEditando] = useState<ComunidadEvento | null>(null);
+
+  const cargar = async () => {
+    setCargando(true);
+    setError(null);
+    try {
+      const data = await getEventosComunidad();
+      // Ordenar: futuros primero (asc), pasados al final (desc)
+      const ahora = Date.now();
+      const ordenados = [...data].sort((a, b) => {
+        const ta = new Date(a.fechaInicio).getTime();
+        const tb = new Date(b.fechaInicio).getTime();
+        const fa = ta >= ahora, fb = tb >= ahora;
+        if (fa && !fb) return -1;
+        if (!fa && fb) return 1;
+        return fa ? ta - tb : tb - ta;
+      });
+      setEventos(ordenados);
+    } catch {
+      setError("Error al cargar eventos");
+    } finally {
+      setCargando(false);
+    }
+  };
+
+  useEffect(() => { cargar(); }, []);
+
+  const handleDesactivar = async (ev: ComunidadEvento) => {
+    if (!confirm(`¿Desactivar el evento "${ev.titulo}"?`)) return;
+    try {
+      await desactivarEventoComunidad(ev.eventoId);
+      setEventos((prev) => prev.filter((e) => e.eventoId !== ev.eventoId));
+    } catch {
+      alert("No se pudo desactivar el evento");
+    }
+  };
+
+  const handleGuardado = () => {
+    setModalAbierto(false);
+    setEditando(null);
+    cargar();
+  };
+
+  return (
+    <section className="bg-white rounded-2xl border border-slate-100 shadow-sm p-6">
+      <div className="flex items-start justify-between mb-6 gap-4">
+        <div>
+          <h2 className="text-lg font-bold text-slate-800 flex items-center gap-2">
+            <Calendar className="w-5 h-5 text-blue-700" />
+            Eventos
+          </h2>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Crea y gestiona los eventos visibles para los empleados {esSuperAdmin ? "(puedes marcarlos como globales EGM)" : "de tu empresa"}
+          </p>
+        </div>
+        <button
+          onClick={() => { setEditando(null); setModalAbierto(true); }}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-colors"
+          style={{ background: "var(--azul-egm)", color: "#fff" }}
+        >
+          <Plus className="w-4 h-4" />
+          Crear evento
+        </button>
+      </div>
+
+      {cargando ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="w-6 h-6 animate-spin text-slate-400" />
+        </div>
+      ) : error ? (
+        <div className="text-center py-12 text-sm text-red-600">{error}</div>
+      ) : eventos.length === 0 ? (
+        <div className="text-center py-16">
+          <Calendar className="w-12 h-12 text-slate-300 mx-auto mb-3" />
+          <p className="text-sm font-medium text-slate-700">Aún no hay eventos</p>
+          <p className="text-xs text-slate-500 mt-1">Crea el primero pulsando &quot;Crear evento&quot;</p>
+        </div>
+      ) : (
+        <ul className="space-y-2.5">
+          {eventos.map((ev) => {
+            const fechaIni = new Date(ev.fechaInicio);
+            const esFuturo = fechaIni.getTime() >= Date.now();
+            const acento   = ev.esGlobal ? "var(--azul-egm)" : "var(--verde-oliva)";
+            return (
+              <li key={ev.eventoId}
+                className="border border-slate-100 rounded-xl p-4 hover:border-blue-200 hover:bg-blue-50/20 transition-colors">
+                <div className="flex items-start gap-4">
+                  {/* Bloque fecha */}
+                  <div className="shrink-0 w-14 rounded-xl py-2 text-center"
+                    style={{ background: esFuturo ? "var(--azul-egm-light)" : "var(--gris-superficie)" }}>
+                    <p className="text-lg font-bold leading-none"
+                      style={{ color: esFuturo ? "var(--azul-egm)" : "var(--texto-muted)" }}>
+                      {fechaIni.getDate()}
+                    </p>
+                    <p className="text-[10px] uppercase tracking-wider mt-0.5"
+                      style={{ color: esFuturo ? "var(--azul-egm)" : "var(--texto-muted)" }}>
+                      {fechaIni.toLocaleDateString("es-ES", { month: "short" }).replace(".", "")}
+                    </p>
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider"
+                        style={{ background: ev.esGlobal ? "var(--azul-egm-light)" : "var(--verde-oliva-light)", color: acento }}>
+                        {ev.esGlobal ? <Globe2 className="w-3 h-3" /> : <Building2 className="w-3 h-3" />}
+                        {ev.esGlobal ? "EGM Global" : "Tu empresa"}
+                      </span>
+                      {!esFuturo && (
+                        <span className="inline-flex px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider bg-slate-100 text-slate-500">
+                          Finalizado
+                        </span>
+                      )}
+                    </div>
+                    <p className="font-semibold text-slate-800 truncate">{ev.titulo}</p>
+                    {ev.descripcion && (
+                      <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">{ev.descripcion}</p>
+                    )}
+                    <div className="flex items-center gap-3 mt-1.5 text-[11px] text-slate-500 flex-wrap">
+                      <span className="inline-flex items-center gap-1">
+                        <Clock className="w-3 h-3" />
+                        {fechaIni.toLocaleString("es-ES", { day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit" })}
+                        {ev.fechaFin && ` – ${new Date(ev.fechaFin).toLocaleTimeString("es-ES", { hour: "2-digit", minute: "2-digit" })}`}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-1.5 shrink-0">
+                    <button
+                      onClick={() => { setEditando(ev); setModalAbierto(true); }}
+                      title="Editar"
+                      className="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50">
+                      <Pencil className="w-3.5 h-3.5" />
+                    </button>
+                    <button
+                      onClick={() => handleDesactivar(ev)}
+                      title="Desactivar"
+                      className="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-red-100 text-red-500 hover:bg-red-50">
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {modalAbierto && (
+        <ModalEvento
+          evento={editando}
+          esSuperAdmin={esSuperAdmin}
+          onClose={() => { setModalAbierto(false); setEditando(null); }}
+          onGuardado={handleGuardado}
+        />
+      )}
+    </section>
+  );
+}
+
+// ────────────────────────────────────────────────────────────
+// ModalEvento — form de creación/edición
+// ────────────────────────────────────────────────────────────
+
+function ModalEvento({ evento, esSuperAdmin, onClose, onGuardado }: {
+  evento:        ComunidadEvento | null;
+  esSuperAdmin:  boolean;
+  onClose:       () => void;
+  onGuardado:    () => void;
+}) {
+  const esNuevo = !evento;
+
+  // Convertir ISO con timezone a formato datetime-local (YYYY-MM-DDTHH:mm)
+  const isoToLocal = (iso: string | null | undefined): string => {
+    if (!iso) return "";
+    const d = new Date(iso);
+    const tz = d.getTimezoneOffset() * 60000;
+    return new Date(d.getTime() - tz).toISOString().slice(0, 16);
+  };
+
+  const [titulo,      setTitulo]      = useState(evento?.titulo ?? "");
+  const [descripcion, setDescripcion] = useState(evento?.descripcion ?? "");
+  const [fechaInicio, setFechaInicio] = useState(isoToLocal(evento?.fechaInicio));
+  const [fechaFin,    setFechaFin]    = useState(isoToLocal(evento?.fechaFin));
+  const [esGlobal,    setEsGlobal]    = useState(evento?.esGlobal ?? false);
+  const [enviando,    setEnviando]    = useState(false);
+  const [error,       setError]       = useState<string | null>(null);
+
+  const enviar = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!titulo.trim() || !fechaInicio) {
+      setError("Título y fecha de inicio son obligatorios");
+      return;
+    }
+    setEnviando(true);
+    setError(null);
+    try {
+      const payload: ComunidadEventoInput = {
+        titulo:      titulo.trim(),
+        descripcion: descripcion.trim() || null,
+        fechaInicio: new Date(fechaInicio).toISOString(),
+        fechaFin:    fechaFin ? new Date(fechaFin).toISOString() : null,
+        ...(esSuperAdmin && { esGlobal }),
+      };
+      if (esNuevo) {
+        await crearEventoComunidad(payload);
+      } else {
+        await actualizarEventoComunidad(evento!.eventoId, payload);
+      }
+      onGuardado();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error al guardar");
+    } finally {
+      setEnviando(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "rgba(0,0,0,0.55)" }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+          <h2 className="text-base font-bold text-slate-800 flex items-center gap-2">
+            <Calendar className="w-5 h-5 text-blue-700" />
+            {esNuevo ? "Crear evento" : "Editar evento"}
+          </h2>
+          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-slate-100">
+            <X className="w-4 h-4 text-slate-500" />
+          </button>
+        </div>
+
+        <form onSubmit={enviar} className="px-6 py-5 flex flex-col gap-4">
+          {/* Título */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
+              Título <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={titulo}
+              onChange={(e) => setTitulo(e.target.value)}
+              maxLength={150}
+              required
+              placeholder="Ej: Jornada de Networking EGM"
+              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
+            />
+          </div>
+
+          {/* Descripción */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-700 mb-1.5">Descripción</label>
+            <textarea
+              value={descripcion ?? ""}
+              onChange={(e) => setDescripcion(e.target.value)}
+              maxLength={500}
+              rows={3}
+              placeholder="Detalles, lugar, ponentes, etc."
+              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm resize-none focus:outline-none focus:border-blue-500"
+            />
+            <p className="text-[10px] text-slate-400 text-right mt-1">{(descripcion ?? "").length}/500</p>
+          </div>
+
+          {/* Fechas */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-semibold text-slate-700 mb-1.5">
+                Inicio <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="datetime-local"
+                value={fechaInicio}
+                onChange={(e) => setFechaInicio(e.target.value)}
+                required
+                className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-semibold text-slate-700 mb-1.5">Fin (opcional)</label>
+              <input
+                type="datetime-local"
+                value={fechaFin}
+                onChange={(e) => setFechaFin(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
+              />
+            </div>
+          </div>
+
+          {/* Global (solo superadmin) */}
+          {esSuperAdmin && (
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={esGlobal}
+                onChange={(e) => setEsGlobal(e.target.checked)}
+                className="w-4 h-4"
+              />
+              <span className="text-sm text-slate-700">
+                Visible para <strong>todas las empresas</strong> (evento global EGM)
+              </span>
+            </label>
+          )}
+
+          {error && (
+            <div className="px-3 py-2 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {/* Acciones */}
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={enviando}
+              className="px-4 py-2 rounded-xl text-sm font-semibold border border-slate-200 text-slate-600 hover:bg-slate-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={enviando}
+              className="flex-1 inline-flex items-center justify-center gap-2 py-2 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50"
+              style={{ background: "var(--azul-egm)", color: "#fff" }}
+            >
+              {enviando ? <Loader2 className="w-4 h-4 animate-spin" /> : <Calendar className="w-4 h-4" />}
+              {esNuevo ? "Crear evento" : "Guardar cambios"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/eventos/EventosAdminTab.tsx
+++ b/components/eventos/EventosAdminTab.tsx
@@ -7,16 +7,14 @@
 
 import { useEffect, useState } from "react";
 import {
-  Calendar, Plus, X, Trash2, Pencil, Loader2, MapPin, Clock, Globe2, Building2,
+  Calendar, Plus, Trash2, Pencil, Loader2, Clock, Globe2, Building2,
 } from "lucide-react";
 import {
   getEventosComunidad,
-  crearEventoComunidad,
-  actualizarEventoComunidad,
   desactivarEventoComunidad,
   type ComunidadEvento,
-  type ComunidadEventoInput,
 } from "@/lib/api/comunidad";
+import { ModalEvento } from "./ModalEvento";
 
 interface Props {
   /** Si quien usa el panel es ROLE_ADMIN (superadmin) → puede marcar eventos como globales */
@@ -184,183 +182,5 @@ export function EventosAdminTab({ esSuperAdmin = false }: Props) {
         />
       )}
     </section>
-  );
-}
-
-// ────────────────────────────────────────────────────────────
-// ModalEvento — form de creación/edición
-// ────────────────────────────────────────────────────────────
-
-function ModalEvento({ evento, esSuperAdmin, onClose, onGuardado }: {
-  evento:        ComunidadEvento | null;
-  esSuperAdmin:  boolean;
-  onClose:       () => void;
-  onGuardado:    () => void;
-}) {
-  const esNuevo = !evento;
-
-  // Convertir ISO con timezone a formato datetime-local (YYYY-MM-DDTHH:mm)
-  const isoToLocal = (iso: string | null | undefined): string => {
-    if (!iso) return "";
-    const d = new Date(iso);
-    const tz = d.getTimezoneOffset() * 60000;
-    return new Date(d.getTime() - tz).toISOString().slice(0, 16);
-  };
-
-  const [titulo,      setTitulo]      = useState(evento?.titulo ?? "");
-  const [descripcion, setDescripcion] = useState(evento?.descripcion ?? "");
-  const [fechaInicio, setFechaInicio] = useState(isoToLocal(evento?.fechaInicio));
-  const [fechaFin,    setFechaFin]    = useState(isoToLocal(evento?.fechaFin));
-  const [esGlobal,    setEsGlobal]    = useState(evento?.esGlobal ?? false);
-  const [enviando,    setEnviando]    = useState(false);
-  const [error,       setError]       = useState<string | null>(null);
-
-  const enviar = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!titulo.trim() || !fechaInicio) {
-      setError("Título y fecha de inicio son obligatorios");
-      return;
-    }
-    setEnviando(true);
-    setError(null);
-    try {
-      const payload: ComunidadEventoInput = {
-        titulo:      titulo.trim(),
-        descripcion: descripcion.trim() || null,
-        fechaInicio: new Date(fechaInicio).toISOString(),
-        fechaFin:    fechaFin ? new Date(fechaFin).toISOString() : null,
-        ...(esSuperAdmin && { esGlobal }),
-      };
-      if (esNuevo) {
-        await crearEventoComunidad(payload);
-      } else {
-        await actualizarEventoComunidad(evento!.eventoId, payload);
-      }
-      onGuardado();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Error al guardar");
-    } finally {
-      setEnviando(false);
-    }
-  };
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      style={{ background: "rgba(0,0,0,0.55)" }}
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100">
-          <h2 className="text-base font-bold text-slate-800 flex items-center gap-2">
-            <Calendar className="w-5 h-5 text-blue-700" />
-            {esNuevo ? "Crear evento" : "Editar evento"}
-          </h2>
-          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-slate-100">
-            <X className="w-4 h-4 text-slate-500" />
-          </button>
-        </div>
-
-        <form onSubmit={enviar} className="px-6 py-5 flex flex-col gap-4">
-          {/* Título */}
-          <div>
-            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
-              Título <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="text"
-              value={titulo}
-              onChange={(e) => setTitulo(e.target.value)}
-              maxLength={150}
-              required
-              placeholder="Ej: Jornada de Networking EGM"
-              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
-            />
-          </div>
-
-          {/* Descripción */}
-          <div>
-            <label className="block text-xs font-semibold text-slate-700 mb-1.5">Descripción</label>
-            <textarea
-              value={descripcion ?? ""}
-              onChange={(e) => setDescripcion(e.target.value)}
-              maxLength={500}
-              rows={3}
-              placeholder="Detalles, lugar, ponentes, etc."
-              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm resize-none focus:outline-none focus:border-blue-500"
-            />
-            <p className="text-[10px] text-slate-400 text-right mt-1">{(descripcion ?? "").length}/500</p>
-          </div>
-
-          {/* Fechas */}
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs font-semibold text-slate-700 mb-1.5">
-                Inicio <span className="text-red-500">*</span>
-              </label>
-              <input
-                type="datetime-local"
-                value={fechaInicio}
-                onChange={(e) => setFechaInicio(e.target.value)}
-                required
-                className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
-              />
-            </div>
-            <div>
-              <label className="block text-xs font-semibold text-slate-700 mb-1.5">Fin (opcional)</label>
-              <input
-                type="datetime-local"
-                value={fechaFin}
-                onChange={(e) => setFechaFin(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
-              />
-            </div>
-          </div>
-
-          {/* Global (solo superadmin) */}
-          {esSuperAdmin && (
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={esGlobal}
-                onChange={(e) => setEsGlobal(e.target.checked)}
-                className="w-4 h-4"
-              />
-              <span className="text-sm text-slate-700">
-                Visible para <strong>todas las empresas</strong> (evento global EGM)
-              </span>
-            </label>
-          )}
-
-          {error && (
-            <div className="px-3 py-2 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
-              {error}
-            </div>
-          )}
-
-          {/* Acciones */}
-          <div className="flex gap-3 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={enviando}
-              className="px-4 py-2 rounded-xl text-sm font-semibold border border-slate-200 text-slate-600 hover:bg-slate-50"
-            >
-              Cancelar
-            </button>
-            <button
-              type="submit"
-              disabled={enviando}
-              className="flex-1 inline-flex items-center justify-center gap-2 py-2 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50"
-              style={{ background: "var(--azul-egm)", color: "#fff" }}
-            >
-              {enviando ? <Loader2 className="w-4 h-4 animate-spin" /> : <Calendar className="w-4 h-4" />}
-              {esNuevo ? "Crear evento" : "Guardar cambios"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
   );
 }

--- a/components/eventos/ModalEvento.tsx
+++ b/components/eventos/ModalEvento.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+// ============================================================
+// ModalEvento — formulario reutilizable para crear o editar un
+// evento de comunidad. Usado en EventosAdminTab y en la vista
+// /dashboard/eventos.
+// ============================================================
+
+import { useState } from "react";
+import { Calendar, X, Loader2 } from "lucide-react";
+import {
+  crearEventoComunidad,
+  actualizarEventoComunidad,
+  type ComunidadEvento,
+  type ComunidadEventoInput,
+} from "@/lib/api/comunidad";
+
+interface Props {
+  /** Si es null → modo creación; si tiene datos → modo edición */
+  evento:       ComunidadEvento | null;
+  /** Sólo los ROLE_ADMIN (superadmin) pueden marcar eventos como globales */
+  esSuperAdmin: boolean;
+  onClose:      () => void;
+  onGuardado:   (evento: ComunidadEvento) => void;
+}
+
+export function ModalEvento({ evento, esSuperAdmin, onClose, onGuardado }: Props) {
+  const esNuevo = !evento;
+
+  // Convertir ISO con timezone a formato datetime-local (YYYY-MM-DDTHH:mm)
+  const isoToLocal = (iso: string | null | undefined): string => {
+    if (!iso) return "";
+    const d = new Date(iso);
+    const tz = d.getTimezoneOffset() * 60000;
+    return new Date(d.getTime() - tz).toISOString().slice(0, 16);
+  };
+
+  const [titulo,      setTitulo]      = useState(evento?.titulo ?? "");
+  const [descripcion, setDescripcion] = useState(evento?.descripcion ?? "");
+  const [fechaInicio, setFechaInicio] = useState(isoToLocal(evento?.fechaInicio));
+  const [fechaFin,    setFechaFin]    = useState(isoToLocal(evento?.fechaFin));
+  const [esGlobal,    setEsGlobal]    = useState(evento?.esGlobal ?? false);
+  const [enviando,    setEnviando]    = useState(false);
+  const [error,       setError]       = useState<string | null>(null);
+
+  const enviar = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!titulo.trim() || !fechaInicio) {
+      setError("Título y fecha de inicio son obligatorios");
+      return;
+    }
+    setEnviando(true);
+    setError(null);
+    try {
+      const payload: ComunidadEventoInput = {
+        titulo:      titulo.trim(),
+        descripcion: descripcion.trim() || null,
+        fechaInicio: new Date(fechaInicio).toISOString(),
+        fechaFin:    fechaFin ? new Date(fechaFin).toISOString() : null,
+        ...(esSuperAdmin && { esGlobal }),
+      };
+      const guardado = esNuevo
+        ? await crearEventoComunidad(payload)
+        : await actualizarEventoComunidad(evento!.eventoId, payload);
+      onGuardado(guardado);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error al guardar");
+    } finally {
+      setEnviando(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "rgba(0,0,0,0.55)" }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+          <h2 className="text-base font-bold text-slate-800 flex items-center gap-2">
+            <Calendar className="w-5 h-5 text-blue-700" />
+            {esNuevo ? "Crear evento" : "Editar evento"}
+          </h2>
+          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-slate-100">
+            <X className="w-4 h-4 text-slate-500" />
+          </button>
+        </div>
+
+        <form onSubmit={enviar} className="px-6 py-5 flex flex-col gap-4">
+          {/* Título */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
+              Título <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={titulo}
+              onChange={(e) => setTitulo(e.target.value)}
+              maxLength={150}
+              required
+              placeholder="Ej: Jornada de Networking EGM"
+              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
+            />
+          </div>
+
+          {/* Descripción */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-700 mb-1.5">Descripción</label>
+            <textarea
+              value={descripcion ?? ""}
+              onChange={(e) => setDescripcion(e.target.value)}
+              maxLength={500}
+              rows={3}
+              placeholder="Detalles, lugar, ponentes, etc."
+              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm resize-none focus:outline-none focus:border-blue-500"
+            />
+            <p className="text-[10px] text-slate-400 text-right mt-1">{(descripcion ?? "").length}/500</p>
+          </div>
+
+          {/* Fechas */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-semibold text-slate-700 mb-1.5">
+                Inicio <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="datetime-local"
+                value={fechaInicio}
+                onChange={(e) => setFechaInicio(e.target.value)}
+                required
+                className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-semibold text-slate-700 mb-1.5">Fin (opcional)</label>
+              <input
+                type="datetime-local"
+                value={fechaFin}
+                onChange={(e) => setFechaFin(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
+              />
+            </div>
+          </div>
+
+          {/* Global (solo superadmin) */}
+          {esSuperAdmin && (
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={esGlobal}
+                onChange={(e) => setEsGlobal(e.target.checked)}
+                className="w-4 h-4"
+              />
+              <span className="text-sm text-slate-700">
+                Visible para <strong>todas las empresas</strong> (evento global EGM)
+              </span>
+            </label>
+          )}
+
+          {error && (
+            <div className="px-3 py-2 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {/* Acciones */}
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={enviando}
+              className="px-4 py-2 rounded-xl text-sm font-semibold border border-slate-200 text-slate-600 hover:bg-slate-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={enviando}
+              className="flex-1 inline-flex items-center justify-center gap-2 py-2 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50"
+              style={{ background: "var(--azul-egm)", color: "#fff" }}
+            >
+              {enviando ? <Loader2 className="w-4 h-4 animate-spin" /> : <Calendar className="w-4 h-4" />}
+              {esNuevo ? "Crear evento" : "Guardar cambios"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/lib/api/comunidad.ts
+++ b/lib/api/comunidad.ts
@@ -31,3 +31,53 @@ export async function getEventosComunidad(): Promise<ComunidadEvento[]> {
     return [];
   }
 }
+
+export interface ComunidadEventoInput {
+  titulo:       string;
+  descripcion?: string | null;
+  fechaInicio:  string;          // ISO datetime
+  fechaFin?:    string | null;
+  esGlobal?:    boolean;         // solo aplica si quien crea es ROLE_ADMIN
+}
+
+/**
+ * Crea un nuevo evento de comunidad.
+ * - ADMIN_EMPRESA: lo crea para su empresa (esGlobal se ignora)
+ * - ADMIN (superadmin): puede crearlo global o por empresa
+ */
+export async function crearEventoComunidad(data: ComunidadEventoInput): Promise<ComunidadEvento> {
+  const res = await apiFetch(`${API_URL}/comunidad/eventos`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const msg = await res.text().catch(() => "");
+    throw new Error(msg || "Error al crear el evento");
+  }
+  return res.json();
+}
+
+/**
+ * Actualiza un evento existente. Mismas reglas de permisos que crear.
+ */
+export async function actualizarEventoComunidad(id: string, data: ComunidadEventoInput): Promise<ComunidadEvento> {
+  const res = await apiFetch(`${API_URL}/comunidad/eventos/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error("Error al actualizar el evento");
+  return res.json();
+}
+
+/**
+ * Desactiva (soft delete) un evento de comunidad.
+ */
+export async function desactivarEventoComunidad(id: string): Promise<ComunidadEvento> {
+  const res = await apiFetch(`${API_URL}/comunidad/eventos/${id}/desactivar`, {
+    method: "PATCH",
+  });
+  if (!res.ok) throw new Error("Error al desactivar el evento");
+  return res.json();
+}


### PR DESCRIPTION
- EventosAdminTab: listado de eventos con bloque de fecha visual, badge global/empresa, fecha+hora formateada, acciones editar/desactivar. Modal de creacion/edicion con validacion (titulo, descripcion, fechas). Si el usuario es ROLE_ADMIN (superadmin), checkbox para marcar como global.
- lib/api/comunidad.ts: anadidas crearEventoComunidad, actualizarEventoComunidad, desactivarEventoComunidad (POST/PUT/PATCH a /api/v1/comunidad/eventos).
- app/dashboard/admin/page.tsx:
  - "eventos" anadido al tipo activeTab y al deeplink ?tab=
  - Entry en array tabs (entre Formaciones y Estadisticas)
  - Render condicional cuando activeTab === "eventos"

Permisos los aplica el backend:
- ADMIN_EMPRESA crea/edita/desactiva eventos de su empresa
- ADMIN puede ademas marcar eventos como globales EGM