### PR TITLE
feat(eventos): ubicacion con mapa interactivo (Leaflet + OpenStreetMap)

### DIFF
--- a/app/dashboard/eventos/page.tsx
+++ b/app/dashboard/eventos/page.tsx
@@ -10,6 +10,7 @@ import {
   type ComunidadEvento,
 } from "@/lib/api/comunidad";
 import { ModalEvento } from "@/components/eventos/ModalEvento";
+import { ModalUbicacion } from "@/components/eventos/ModalUbicacion";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 type EstadoEvento = "PROXIMO" | "EN_CURSO" | "FINALIZADO";
@@ -44,10 +45,12 @@ function formatHoras(ev: ComunidadEvento) {
 
 // ── Card de evento ────────────────────────────────────────────────────────────
 function EventoCard({
-  evento, puedeEditar, onEditar, onDesactivar,
+  evento, puedeEditar, onEditar, onDesactivar, onVerUbicacion,
 }: {
   evento: ComunidadEvento; puedeEditar: boolean;
-  onEditar: (e: ComunidadEvento) => void; onDesactivar: (e: ComunidadEvento) => void;
+  onEditar: (e: ComunidadEvento) => void;
+  onDesactivar: (e: ComunidadEvento) => void;
+  onVerUbicacion: (e: ComunidadEvento) => void;
 }) {
   const [hovered,   setHovered]   = useState(false);
   const [menuOpen,  setMenuOpen]  = useState(false);
@@ -167,6 +170,34 @@ function EventoCard({
                 {evento.esGlobal ? "EGM Atalayas (global)" : "Tu empresa"}
               </span>
             </div>
+
+            {/* Lugar + botón Ver ubicación */}
+            {evento.lugar && (
+              <div className="flex items-start gap-1.5">
+                <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+                  style={{ color: "#9ca3af", flexShrink: 0, marginTop: 3 }}>
+                  <path strokeLinecap="round" strokeLinejoin="round"
+                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                <span className="text-xs line-clamp-1" style={{ color: "#6b7280" }}>{evento.lugar}</span>
+              </div>
+            )}
+            {evento.latitud != null && evento.longitud != null && (
+              <button
+                type="button"
+                onClick={() => onVerUbicacion(evento)}
+                className="inline-flex items-center gap-1.5 self-start text-xs font-semibold px-2.5 py-1 rounded-lg transition-colors"
+                style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = "#dbeafe"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = "var(--azul-egm-light)"; }}
+              >
+                <svg width="11" height="11" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                </svg>
+                Ver ubicación
+              </button>
+            )}
           </div>
         </>
       )}
@@ -218,11 +249,12 @@ export default function EventosPage() {
   const esAdminEmpresa = usuario?.codigoRol === "ROLE_ADMIN_EMPRESA";
   const puedeEditar   = esSuperAdmin || esAdminEmpresa;
 
-  const [eventos,   setEventos]   = useState<ComunidadEvento[]>([]);
-  const [cargando,  setCargando]  = useState(true);
-  const [toast,     setToast]     = useState<{ msg: string; tipo: "ok" | "err" } | null>(null);
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editando,  setEditando]  = useState<ComunidadEvento | null>(null);
+  const [eventos,    setEventos]    = useState<ComunidadEvento[]>([]);
+  const [cargando,   setCargando]   = useState(true);
+  const [toast,      setToast]      = useState<{ msg: string; tipo: "ok" | "err" } | null>(null);
+  const [modalOpen,  setModalOpen]  = useState(false);
+  const [editando,   setEditando]   = useState<ComunidadEvento | null>(null);
+  const [verUbicacion, setVerUbicacion] = useState<ComunidadEvento | null>(null);
 
   const mostrarToast = useCallback((msg: string, tipo: "ok" | "err" = "ok") => {
     setToast({ msg, tipo });
@@ -310,6 +342,7 @@ export default function EventosPage() {
                 <EventoCard key={e.eventoId} evento={e} puedeEditar={puedeEditar}
                   onEditar={handleEditar}
                   onDesactivar={handleDesactivar}
+                  onVerUbicacion={setVerUbicacion}
                 />
               ))}
             </div>
@@ -327,6 +360,7 @@ export default function EventosPage() {
                 <EventoCard key={e.eventoId} evento={e} puedeEditar={puedeEditar}
                   onEditar={handleEditar}
                   onDesactivar={handleDesactivar}
+                  onVerUbicacion={setVerUbicacion}
                 />
               ))}
             </div>
@@ -341,6 +375,17 @@ export default function EventosPage() {
           esSuperAdmin={esSuperAdmin}
           onClose={() => { setModalOpen(false); setEditando(null); }}
           onGuardado={handleGuardado}
+        />
+      )}
+
+      {/* Modal Ver ubicación */}
+      {verUbicacion && verUbicacion.latitud != null && verUbicacion.longitud != null && (
+        <ModalUbicacion
+          titulo={verUbicacion.titulo}
+          lugar={verUbicacion.lugar}
+          latitud={verUbicacion.latitud}
+          longitud={verUbicacion.longitud}
+          onClose={() => setVerUbicacion(null)}
         />
       )}
 

--- a/components/eventos/MapaUbicacion.tsx
+++ b/components/eventos/MapaUbicacion.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+// ============================================================
+// MapaUbicacion — wrapper de Leaflet con marker. Usado en:
+//  - ModalEvento (preview al buscar dirección)
+//  - ModalUbicacion (visualización completa al pulsar "Ver ubicación")
+//
+// Leaflet usa el DOM directamente, así que importamos dinámicamente
+// para evitar errores de SSR de Next.js.
+// ============================================================
+
+import dynamic from "next/dynamic";
+import "leaflet/dist/leaflet.css";
+
+interface Props {
+  latitud:   number;
+  longitud:  number;
+  /** Texto opcional en el popup del marker (nombre del lugar) */
+  etiqueta?: string;
+  /** Altura en píxeles del contenedor del mapa */
+  alturaPx?: number;
+  /** Zoom inicial (default 15) */
+  zoom?:     number;
+}
+
+// Carga del componente real solo en cliente (evita SSR)
+const MapaInner = dynamic(() => import("./MapaUbicacionInner"), {
+  ssr: false,
+  loading: () => (
+    <div className="rounded-xl flex items-center justify-center bg-slate-100"
+      style={{ height: 240 }}>
+      <p className="text-xs text-slate-400">Cargando mapa…</p>
+    </div>
+  ),
+});
+
+export function MapaUbicacion(props: Props) {
+  return <MapaInner {...props} />;
+}

--- a/components/eventos/MapaUbicacionInner.tsx
+++ b/components/eventos/MapaUbicacionInner.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+// ============================================================
+// MapaUbicacionInner — componente real de Leaflet.
+// SOLO se importa dinámicamente desde MapaUbicacion (no SSR).
+// ============================================================
+
+import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
+import L from "leaflet";
+
+// Fix para los iconos por defecto de Leaflet que no cargan bien con bundlers
+// Apuntamos a las URLs públicas del CDN (sin necesidad de copiar assets).
+delete (L.Icon.Default.prototype as unknown as { _getIconUrl?: () => string })._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+  iconUrl:       "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+  shadowUrl:     "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+});
+
+interface Props {
+  latitud:   number;
+  longitud:  number;
+  etiqueta?: string;
+  alturaPx?: number;
+  zoom?:     number;
+}
+
+export default function MapaUbicacionInner({
+  latitud, longitud, etiqueta, alturaPx = 240, zoom = 15,
+}: Props) {
+  return (
+    <div className="rounded-xl overflow-hidden border border-slate-200"
+      style={{ height: alturaPx }}>
+      <MapContainer
+        center={[latitud, longitud]}
+        zoom={zoom}
+        scrollWheelZoom={false}
+        style={{ width: "100%", height: "100%" }}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <Marker position={[latitud, longitud]}>
+          {etiqueta && <Popup>{etiqueta}</Popup>}
+        </Marker>
+      </MapContainer>
+    </div>
+  );
+}

--- a/components/eventos/ModalEvento.tsx
+++ b/components/eventos/ModalEvento.tsx
@@ -7,13 +7,15 @@
 // ============================================================
 
 import { useState } from "react";
-import { Calendar, X, Loader2 } from "lucide-react";
+import { Calendar, X, Loader2, MapPin, Search, Check } from "lucide-react";
 import {
   crearEventoComunidad,
   actualizarEventoComunidad,
   type ComunidadEvento,
   type ComunidadEventoInput,
 } from "@/lib/api/comunidad";
+import { buscarDireccion, type GeocodingResult } from "@/lib/geocoding";
+import { MapaUbicacion } from "./MapaUbicacion";
 
 interface Props {
   /** Si es null → modo creación; si tiene datos → modo edición */
@@ -43,6 +45,43 @@ export function ModalEvento({ evento, esSuperAdmin, onClose, onGuardado }: Props
   const [enviando,    setEnviando]    = useState(false);
   const [error,       setError]       = useState<string | null>(null);
 
+  // ── Ubicación ──────────────────────────────────────────────
+  const [lugar,    setLugar]    = useState(evento?.lugar ?? "");
+  const [latitud,  setLatitud]  = useState<number | null>(evento?.latitud ?? null);
+  const [longitud, setLongitud] = useState<number | null>(evento?.longitud ?? null);
+  const [buscandoMapa, setBuscandoMapa] = useState(false);
+  const [resultadosMapa, setResultadosMapa] = useState<GeocodingResult[]>([]);
+  const [erroresMapa, setErroresMapa] = useState<string | null>(null);
+
+  const buscar = async () => {
+    if (!lugar.trim()) return;
+    setBuscandoMapa(true);
+    setErroresMapa(null);
+    setResultadosMapa([]);
+    try {
+      const res = await buscarDireccion(lugar, 5);
+      if (res.length === 0) setErroresMapa("Sin resultados — prueba con más detalles");
+      else setResultadosMapa(res);
+    } finally {
+      setBuscandoMapa(false);
+    }
+  };
+
+  const seleccionar = (r: GeocodingResult) => {
+    setLatitud(r.latitud);
+    setLongitud(r.longitud);
+    setLugar(r.etiqueta);
+    setResultadosMapa([]);
+  };
+
+  const limpiarUbicacion = () => {
+    setLatitud(null);
+    setLongitud(null);
+    setLugar("");
+    setResultadosMapa([]);
+    setErroresMapa(null);
+  };
+
   const enviar = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!titulo.trim() || !fechaInicio) {
@@ -57,6 +96,9 @@ export function ModalEvento({ evento, esSuperAdmin, onClose, onGuardado }: Props
         descripcion: descripcion.trim() || null,
         fechaInicio: new Date(fechaInicio).toISOString(),
         fechaFin:    fechaFin ? new Date(fechaFin).toISOString() : null,
+        lugar:       lugar.trim() || null,
+        latitud,
+        longitud,
         ...(esSuperAdmin && { esGlobal }),
       };
       const guardado = esNuevo
@@ -142,6 +184,79 @@ export function ModalEvento({ evento, esSuperAdmin, onClose, onGuardado }: Props
                 className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
               />
             </div>
+          </div>
+
+          {/* Ubicación (opcional) */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
+              Ubicación (opcional)
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={lugar ?? ""}
+                onChange={(e) => setLugar(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); buscar(); } }}
+                placeholder="Ej: Edificio Central EGM Atalayas, Alicante"
+                className="flex-1 px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
+              />
+              <button
+                type="button"
+                onClick={buscar}
+                disabled={!lugar.trim() || buscandoMapa}
+                className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-semibold border border-slate-200 text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+                title="Buscar en el mapa"
+              >
+                {buscandoMapa ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Search className="w-3.5 h-3.5" />}
+                Buscar
+              </button>
+            </div>
+
+            {/* Resultados de búsqueda */}
+            {resultadosMapa.length > 0 && (
+              <ul className="mt-2 border border-slate-200 rounded-lg overflow-hidden divide-y divide-slate-100">
+                {resultadosMapa.map((r, i) => (
+                  <li key={i}>
+                    <button
+                      type="button"
+                      onClick={() => seleccionar(r)}
+                      className="w-full text-left px-3 py-2 text-xs hover:bg-blue-50 flex items-start gap-2"
+                    >
+                      <MapPin className="w-3.5 h-3.5 text-blue-600 mt-0.5 shrink-0" />
+                      <span className="line-clamp-2">{r.etiqueta}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {erroresMapa && (
+              <p className="mt-1.5 text-xs text-amber-700">{erroresMapa}</p>
+            )}
+
+            {/* Preview del mapa cuando hay coordenadas */}
+            {latitud !== null && longitud !== null && (
+              <div className="mt-3 space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs text-emerald-700 inline-flex items-center gap-1">
+                    <Check className="w-3 h-3" />
+                    Ubicación seleccionada
+                  </p>
+                  <button
+                    type="button"
+                    onClick={limpiarUbicacion}
+                    className="text-xs text-red-600 hover:underline"
+                  >
+                    Quitar
+                  </button>
+                </div>
+                <MapaUbicacion
+                  latitud={latitud}
+                  longitud={longitud}
+                  etiqueta={lugar ?? undefined}
+                  alturaPx={180}
+                />
+              </div>
+            )}
           </div>
 
           {/* Global (solo superadmin) */}

--- a/components/eventos/ModalUbicacion.tsx
+++ b/components/eventos/ModalUbicacion.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+// ============================================================
+// ModalUbicacion — popup con mapa para ver la ubicación de un
+// evento. Se abre desde la card de evento al pulsar "Ver ubicación".
+// ============================================================
+
+import { X, MapPin, ExternalLink } from "lucide-react";
+import { MapaUbicacion } from "./MapaUbicacion";
+
+interface Props {
+  titulo:    string;
+  lugar?:    string | null;
+  latitud:   number;
+  longitud:  number;
+  onClose:   () => void;
+}
+
+export function ModalUbicacion({ titulo, lugar, latitud, longitud, onClose }: Props) {
+  const urlGoogleMaps = `https://www.google.com/maps?q=${latitud},${longitud}`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "rgba(0,0,0,0.55)" }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-start justify-between px-6 py-4 border-b border-slate-100">
+          <div className="flex items-start gap-3 min-w-0">
+            <div className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
+              style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)" }}>
+              <MapPin className="w-4 h-4" />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-base font-bold text-slate-800 truncate">{titulo}</h2>
+              {lugar && (
+                <p className="text-xs text-slate-500 mt-0.5 truncate">{lugar}</p>
+              )}
+            </div>
+          </div>
+          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-slate-100 shrink-0">
+            <X className="w-4 h-4 text-slate-500" />
+          </button>
+        </div>
+
+        {/* Mapa */}
+        <div className="p-4">
+          <MapaUbicacion
+            latitud={latitud}
+            longitud={longitud}
+            etiqueta={lugar ?? undefined}
+            alturaPx={400}
+            zoom={16}
+          />
+        </div>
+
+        {/* Footer con CTA */}
+        <div className="flex items-center justify-between gap-3 px-6 py-3 border-t border-slate-100 bg-slate-50">
+          <p className="text-xs text-slate-500">
+            Coordenadas: {latitud.toFixed(5)}, {longitud.toFixed(5)}
+          </p>
+          <a
+            href={urlGoogleMaps}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs font-semibold text-blue-700 hover:underline"
+          >
+            Abrir en Google Maps
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/api/comunidad.ts
+++ b/lib/api/comunidad.ts
@@ -14,6 +14,11 @@ export interface ComunidadEvento {
   activo:        boolean;
   fechaInicio:   string;          // ISO datetime con timezone
   fechaFin:      string | null;
+  /** Dirección o nombre del lugar (texto libre) */
+  lugar?:        string | null;
+  /** Coordenada para mapa (decimales) */
+  latitud?:      number | null;
+  longitud?:     number | null;
   creadoEn:      string;
   actualizadoEn: string;
 }
@@ -38,6 +43,9 @@ export interface ComunidadEventoInput {
   fechaInicio:  string;          // ISO datetime
   fechaFin?:    string | null;
   esGlobal?:    boolean;         // solo aplica si quien crea es ROLE_ADMIN
+  lugar?:       string | null;
+  latitud?:     number | null;
+  longitud?:    number | null;
 }
 
 /**

--- a/lib/geocoding.ts
+++ b/lib/geocoding.ts
@@ -1,0 +1,48 @@
+/**
+ * Cliente ligero del API de Nominatim (OpenStreetMap) para geocoding.
+ *
+ * Nominatim es gratis y sin API key, pero la política de uso pide:
+ *   - User-Agent identificativo
+ *   - Máximo ~1 req/seg
+ *   - Cachear resultados cuando sea posible
+ *
+ * Para uso pesado en producción habría que montar instancia propia o usar
+ * un servicio comercial (Mapbox, Google), pero para crear unos pocos eventos
+ * desde el panel admin esto sobra.
+ */
+
+export interface GeocodingResult {
+  latitud:   number;
+  longitud:  number;
+  /** Etiqueta canónica devuelta por Nominatim (calle, ciudad, país...) */
+  etiqueta:  string;
+}
+
+/**
+ * Busca una dirección y devuelve hasta `limit` resultados.
+ * Devuelve [] si no hay resultados o si la red falla.
+ */
+export async function buscarDireccion(query: string, limit = 5): Promise<GeocodingResult[]> {
+  const q = query.trim();
+  if (q.length < 3) return [];
+  try {
+    const url = new URL("https://nominatim.openstreetmap.org/search");
+    url.searchParams.set("q",      q);
+    url.searchParams.set("format", "json");
+    url.searchParams.set("addressdetails", "1");
+    url.searchParams.set("limit",  String(limit));
+    const res = await fetch(url.toString(), {
+      headers: { "Accept-Language": "es" },
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+    return data.map((item: { lat: string; lon: string; display_name: string }) => ({
+      latitud:  parseFloat(item.lat),
+      longitud: parseFloat(item.lon),
+      etiqueta: item.display_name,
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@gsap/react": "^2.1.2",
         "@supabase/supabase-js": "^2.104.1",
         "@tanstack/react-query": "^5.100.10",
+        "@types/leaflet": "^1.9.21",
         "@types/pdf-parse": "^1.1.5",
         "bootstrap-icons": "^1.13.1",
         "exceljs": "^4.4.0",
@@ -19,6 +20,7 @@
         "gsap": "^3.15.0",
         "hls.js": "^1.6.16",
         "jspdf": "^4.2.1",
+        "leaflet": "^1.9.4",
         "lucide-react": "^1.8.0",
         "motion": "^12.38.0",
         "next": "^16.2.1",
@@ -28,6 +30,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-icons": "^5.6.0",
+        "react-leaflet": "^5.0.0",
         "recharts": "^3.8.1",
         "server-only": "^0.0.1"
       },
@@ -1520,6 +1523,17 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -2373,6 +2387,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2386,6 +2406,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.37",
@@ -6324,6 +6353,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -7734,6 +7769,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@gsap/react": "^2.1.2",
     "@supabase/supabase-js": "^2.104.1",
     "@tanstack/react-query": "^5.100.10",
+    "@types/leaflet": "^1.9.21",
     "@types/pdf-parse": "^1.1.5",
     "bootstrap-icons": "^1.13.1",
     "exceljs": "^4.4.0",
@@ -20,6 +21,7 @@
     "gsap": "^3.15.0",
     "hls.js": "^1.6.16",
     "jspdf": "^4.2.1",
+    "leaflet": "^1.9.4",
     "lucide-react": "^1.8.0",
     "motion": "^12.38.0",
     "next": "^16.2.1",
@@ -29,6 +31,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-icons": "^5.6.0",
+    "react-leaflet": "^5.0.0",
     "recharts": "^3.8.1",
     "server-only": "^0.0.1"
   },


### PR DESCRIPTION
Cuando se crea un evento de comunidad ahora se puede especificar una ubicacion (direccion + coordenadas). En la card del evento aparece el nombre del lugar y un boton "Ver ubicacion" que abre un modal con un mapa interactivo y un link a Google Maps.

Cambios:
- lib/api/comunidad.ts: ComunidadEvento y Input incluyen lugar/lat/lng
- lib/geocoding.ts: cliente de Nominatim (OpenStreetMap) gratis
- components/eventos/MapaUbicacion + MapaUbicacionInner: wrapper de Leaflet con dynamic import para evitar SSR (Leaflet usa DOM directo)
- components/eventos/ModalUbicacion: popup con mapa + coords + link a Google Maps
- components/eventos/ModalEvento: input "Ubicacion" + boton "Buscar" que llama a Nominatim, lista de resultados clicables, preview de mapa con marker cuando hay coordenadas, boton "Quitar" para reset
- app/dashboard/eventos/page.tsx: cada card muestra el lugar y, si hay coordenadas, un boton "Ver ubicacion" que abre ModalUbicacion

Dependencias nuevas: leaflet, react-leaflet, @types/leaflet.