### PR TITLE
feat: redesign admin panel tabs — eventos, incidencias, forms

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -206,10 +206,10 @@ function AdminContent() {
     { key: "empleados" as const, label: "Empleados", icon: <Users size={20} />, accent: "#1B3F7E", badge: 0 },
     { key: "incidencias" as const, label: "Incidencias", icon: <TriangleAlert size={20} />, accent: "#B45309", badge: 0 },
     { key: "anuncios" as const, label: "Anuncios", icon: <Megaphone size={20} />, accent: "#0EA5E9", badge: 0 },
-    { key: "formaciones" as const, label: "Módulos formativos", icon: <GraduationCap size={20} />, accent: "#7B4A85", badge: 0 },
     { key: "eventos" as const, label: "Eventos", icon: <Calendar size={20} />, accent: "#0F766E", badge: 0 },
-    { key: "estadisticas" as const, label: "Estadísticas", icon: <BarChart3 size={20} />, accent: "#2D8653", badge: 0 },
+    { key: "formaciones" as const, label: "Módulos formativos", icon: <GraduationCap size={20} />, accent: "#7B4A85", badge: 0 },
     { key: "documentos" as const, label: "Documentos", icon: <FileText size={20} />, accent: "#4E6D7E", badge: 0 },
+    { key: "estadisticas" as const, label: "Estadísticas", icon: <BarChart3 size={20} />, accent: "#2D8653", badge: 0 },
   ];
 
   return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -132,6 +132,7 @@ body::-webkit-scrollbar,
   --tab-incidencias:  #B45309;   /* ámbar oscuro */
   --tab-estadisticas: #2D8653;   /* = exito, verde esmeralda */
   --tab-documentos:   #4E6D7E;   /* azul pizarra */
+  --tab-eventos:      #0F766E;   /* teal */
 
   /* ════════════════════════════════════════════
      IA (índigo)

--- a/components/documentos/DocumentosAdminTab.tsx
+++ b/components/documentos/DocumentosAdminTab.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/lib/types/documentos";
 import {
   FileText, Upload, Trash2, Check, X, AlertTriangle, ChevronDown,
-  Users, Building2, Globe, Plus, Search, CheckCircle2, Clock,
+  Users, Building2, Globe, Plus, Search, CheckCircle2, Clock, Download,
 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { IconButton } from "@/components/ui/IconButton";
@@ -527,6 +527,16 @@ export function DocumentosAdminTab({ empresaId, empleados, departamentos, docume
                       Asignados
                     </Button>
                     <motion.button
+                      title="Descargar documento"
+                      onClick={() => window.open(d.archivoUrl, "_blank")}
+                      whileTap={{ scale: 0.88 }}
+                      className="flex items-center justify-center w-8 h-8 shrink-0 cursor-pointer"
+                      style={{ borderRadius: "50%", background: "var(--gris-superficie)", color: "var(--texto-secundario)", border: "1px solid var(--gris-borde)", transition: "background 0.15s ease, box-shadow 0.18s" }}
+                      onMouseEnter={(e) => { const el = e.currentTarget as HTMLElement; el.style.background = "var(--azul-egm)"; el.style.color = "#fff"; el.style.borderColor = "var(--azul-egm)"; el.style.boxShadow = "0 4px 14px rgba(22,50,105,0.25)"; }}
+                      onMouseLeave={(e) => { const el = e.currentTarget as HTMLElement; el.style.background = "var(--gris-superficie)"; el.style.color = "var(--texto-secundario)"; el.style.borderColor = "var(--gris-borde)"; el.style.boxShadow = "none"; }}>
+                      <Download size={13} strokeWidth={2} />
+                    </motion.button>
+                    <motion.button
                       title="Eliminar documento"
                       onClick={() => setConfirmEliminar(d)}
                       whileTap={{ scale: 0.88 }}
@@ -739,7 +749,7 @@ function ModalSubirDocumento({
         initial={{ opacity: 0, y: 32, scale: 0.97 }} animate={{ opacity: 1, y: 0, scale: 1 }} exit={{ opacity: 0, y: 16, scale: 0.97 }}
         transition={{ duration: 0.28, ease: [0.34, 1.1, 0.64, 1] }}
         className="w-full sm:max-w-lg rounded-t-3xl sm:rounded-2xl overflow-hidden flex flex-col"
-        style={{ background: "#ffffff", maxHeight: "92dvh", boxShadow: "0 28px 64px rgba(0,0,0,0.22)" }}
+        style={{ background: "var(--gris-panel)", maxHeight: "92dvh", boxShadow: "0 28px 64px rgba(0,0,0,0.22)" }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* ── Header ── */}
@@ -771,7 +781,7 @@ function ModalSubirDocumento({
         </div>
 
         {/* ── Cuerpo scrollable con transición entre pasos ── */}
-        <div className="overflow-y-auto flex-1 bg-white" style={{ minHeight: 0 }}>
+        <div className="overflow-y-auto flex-1" style={{ minHeight: 0 }}>
           <AnimatePresence mode="wait" initial={false}>
             {paso === 1 ? (
               <motion.div
@@ -1311,7 +1321,7 @@ function ModalEditarDocumento({
         initial={{ opacity: 0, y: 32, scale: 0.97 }} animate={{ opacity: 1, y: 0, scale: 1 }} exit={{ opacity: 0, y: 16, scale: 0.97 }}
         transition={{ duration: 0.28, ease: [0.34, 1.1, 0.64, 1] }}
         className="w-full sm:max-w-lg rounded-t-3xl sm:rounded-2xl overflow-hidden flex flex-col"
-        style={{ background: "#ffffff", maxHeight: "92dvh", boxShadow: "0 28px 64px rgba(0,0,0,0.22)" }}
+        style={{ background: "var(--gris-panel)", maxHeight: "92dvh", boxShadow: "0 28px 64px rgba(0,0,0,0.22)" }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* ── Header ── */}
@@ -1340,7 +1350,7 @@ function ModalEditarDocumento({
         </div>
 
         {/* ── Cuerpo ── */}
-        <div className="overflow-y-auto flex-1 bg-white" style={{ minHeight: 0 }}>
+        <div className="overflow-y-auto flex-1" style={{ minHeight: 0 }}>
           <AnimatePresence mode="wait" initial={false}>
             {paso === 1 ? (
               <motion.div key="paso1"

--- a/components/empleados/EmpleadosAdminTab.tsx
+++ b/components/empleados/EmpleadosAdminTab.tsx
@@ -444,8 +444,6 @@ export function EmpleadosAdminTab({ empleados, cargandoEmpleados, empresaId, onT
                 <EmpCampo label="Contraseña inicial" required type="password" placeholder="Mínimo 8 caracteres"
                   hint="El empleado podrá cambiarla en su primer acceso"
                   value={formEmpleado.password} onChange={(v) => setFormEmpleado({ ...formEmpleado, password: v })} />
-                {/* Divisor secciones */}
-                <div style={{ borderTop: "1px solid rgba(0,0,0,0.07)", margin: "2px 0" }} />
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   {/* Puesto */}
                   <EmpCampo label="Puesto de trabajo" placeholder="Ej: Técnico de producción"
@@ -466,7 +464,7 @@ export function EmpleadosAdminTab({ empleados, cargandoEmpleados, empresaId, onT
               </form>
 
               {/* Footer */}
-              <div className="flex flex-col sm:flex-row sm:justify-end gap-2.5 px-5 sm:px-6 py-4 shrink-0"
+              <div className="flex flex-col sm:flex-row sm:justify-between gap-2.5 px-5 sm:px-6 py-4 shrink-0"
                 style={{ borderTop: "1px solid rgba(0,0,0,0.07)", background: "#ffffff", paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}>
                 <Button type="button" variant="secondary" className="w-full sm:w-auto order-2 sm:order-1"
                   onClick={() => { setShowFormEmpleado(false); setErrorEmpleado(null); }} disabled={guardandoEmpleado}>

--- a/components/eventos/EventosAdminTab.tsx
+++ b/components/eventos/EventosAdminTab.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-// ============================================================
-// EventosAdminTab — tab del panel admin para gestionar eventos
-// de comunidad. Lista, crea y desactiva eventos.
-// ============================================================
-
-import { useEffect, useState } from "react";
+import { useState, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { AnimatePresence, motion } from "motion/react";
 import {
-  Calendar, Plus, Trash2, Pencil, Loader2, Clock, Globe2, Building2,
+  Calendar, Plus, MapPin, Globe2, Building2, Clock, Search, ChevronDown,
 } from "lucide-react";
 import {
   getEventosComunidad,
@@ -16,28 +14,202 @@ import {
 } from "@/lib/api/comunidad";
 import { ModalEvento } from "./ModalEvento";
 import { ModalConfirm } from "@/components/ui/ModalConfirm";
+import { Button } from "@/components/ui/Button";
+
+const TAB_COLOR  = "#0F766E";
+const QK_EVENTOS = ["eventos-admin"];
+
+// ── Helpers de fecha ─────────────────────────────────────────────────────────
+
+function formatFechaCorta(iso: string) {
+  return new Date(iso).toLocaleDateString("es-ES", { day: "2-digit", month: "short", year: "numeric" }).replace(".", "");
+}
+
+function formatHora(iso: string) {
+  return new Date(iso).toLocaleTimeString("es-ES", { hour: "2-digit", minute: "2-digit" });
+}
+
+function esFuturo(iso: string) {
+  return new Date(iso).getTime() >= Date.now();
+}
+
+// ── Skeleton ─────────────────────────────────────────────────────────────────
+
+function SkeletonCard() {
+  return (
+    <div className="flex flex-col rounded-2xl overflow-hidden animate-pulse"
+      style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", boxShadow: "0 1px 4px rgba(0,0,0,0.04)" }}>
+      <div style={{ height: 110, background: "var(--gris-superficie)" }} />
+      <div className="flex flex-col gap-2.5 px-3.5 pt-3 pb-3.5">
+        <div className="flex gap-1.5">
+          <div className="h-4 rounded-md w-20" style={{ background: "var(--gris-borde)" }} />
+          <div className="h-4 rounded-md w-16" style={{ background: "var(--gris-superficie)" }} />
+        </div>
+        <div className="h-4 rounded-full w-3/4" style={{ background: "var(--gris-borde)" }} />
+        <div className="h-3 rounded-full w-1/2" style={{ background: "var(--gris-superficie)" }} />
+        <div className="h-3 rounded-full w-2/3" style={{ background: "var(--gris-superficie)" }} />
+        <div className="flex gap-2 pt-1">
+          <div className="h-8 flex-1 rounded-xl" style={{ background: "var(--gris-borde)" }} />
+          <div className="h-8 w-8 rounded-xl" style={{ background: "var(--gris-superficie)" }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Tarjeta de evento ─────────────────────────────────────────────────────────
+
+function EventoCard({
+  ev,
+  onEditar,
+  onEliminar,
+}: {
+  ev: ComunidadEvento;
+  onEditar: () => void;
+  onEliminar: () => void;
+}) {
+  const futuro = esFuturo(ev.fechaInicio);
+  const d      = new Date(ev.fechaInicio);
+  const dia    = d.getDate();
+  const mes    = d.toLocaleDateString("es-ES", { month: "short" }).replace(".", "").toUpperCase();
+
+  const gradFuturo = "linear-gradient(135deg, #065F46 0%, #0F766E 55%, #0D9488 100%)";
+  const gradPasado = "linear-gradient(135deg, #374151 0%, #4B5563 100%)";
+
+  return (
+    <div
+      className="flex flex-col rounded-2xl overflow-hidden cursor-pointer"
+      style={{
+        background:  "var(--blanco)",
+        border:      "1px solid var(--gris-borde)",
+        boxShadow:   "0 1px 4px rgba(0,0,0,0.04)",
+        transition:  "box-shadow 0.2s, transform 0.2s",
+      }}
+      onClick={onEditar}
+      onMouseEnter={e => { e.currentTarget.style.boxShadow = "0 8px 24px rgba(0,0,0,0.10)"; e.currentTarget.style.transform = "translateY(-2px)"; }}
+      onMouseLeave={e => { e.currentTarget.style.boxShadow = "0 1px 4px rgba(0,0,0,0.04)"; e.currentTarget.style.transform = "translateY(0)"; }}
+    >
+      {/* ── Cabecera ── */}
+      <div className="relative w-full overflow-hidden"
+        style={{ height: 110, background: futuro ? gradFuturo : gradPasado }}>
+
+        {/* Imagen de portada */}
+        {ev.imagenUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={ev.imagenUrl} alt={ev.titulo}
+            className="absolute inset-0 w-full h-full object-cover" />
+        )}
+
+        {/* Overlay oscuro para legibilidad */}
+        <div className="absolute inset-0 pointer-events-none"
+          style={{ background: "linear-gradient(180deg, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.40) 100%)" }} />
+
+        {/* Icono decorativo de fondo */}
+        <Calendar size={64} strokeWidth={0.8}
+          className="absolute -bottom-3 -right-3 pointer-events-none"
+          style={{ color: "rgba(255,255,255,0.08)" }} />
+
+        {/* Fecha destacada — esquina inferior izquierda */}
+        <div className="absolute bottom-3 left-4 flex items-end gap-1.5">
+          <span className="font-black leading-none"
+            style={{ fontSize: "2.6rem", color: "#fff", lineHeight: 1, textShadow: "0 2px 8px rgba(0,0,0,0.3)" }}>
+            {dia}
+          </span>
+          <div className="flex flex-col pb-1">
+            <span className="font-bold uppercase tracking-widest"
+              style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.90)", letterSpacing: "0.12em" }}>
+              {mes}
+            </span>
+            <span className="font-semibold"
+              style={{ fontSize: "0.6rem", color: "rgba(255,255,255,0.55)", letterSpacing: "0.04em" }}>
+              {d.getFullYear()}
+            </span>
+          </div>
+        </div>
+
+        {/* Badge top-right */}
+        <div className="absolute top-2.5 right-2.5 flex flex-col items-end gap-1">
+          {ev.esGlobal && (
+            <span className="inline-flex items-center gap-1 text-[10px] font-bold px-2 py-0.5 rounded-full"
+              style={{ background: "rgba(27,63,126,0.85)", color: "#fff", backdropFilter: "blur(4px)" }}>
+              <Globe2 size={9} strokeWidth={2.5} /> EGM Global
+            </span>
+          )}
+          {!futuro && (
+            <span className="text-[10px] font-bold px-2 py-0.5 rounded-full"
+              style={{ background: "rgba(0,0,0,0.55)", color: "rgba(255,255,255,0.85)", backdropFilter: "blur(4px)" }}>
+              Finalizado
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* ── Cuerpo ── */}
+      <div className="flex flex-col flex-1 px-3.5 pt-3 pb-3.5 gap-2">
+
+        {/* Badge empresa */}
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-semibold"
+            style={{
+              background: ev.esGlobal ? "#1B3F7E18" : `${TAB_COLOR}15`,
+              color:      ev.esGlobal ? "var(--azul-egm)" : TAB_COLOR,
+            }}>
+            {ev.esGlobal
+              ? <><Globe2 size={9} strokeWidth={2.5} />EGM Global</>
+              : <><Building2 size={9} strokeWidth={2.5} />Tu empresa</>}
+          </span>
+        </div>
+
+        {/* Título */}
+        <h3 className="font-bold leading-snug line-clamp-2"
+          style={{ fontSize: "0.875rem", color: "var(--texto-primario)", minHeight: "2.6em" }}>
+          {ev.titulo}
+        </h3>
+
+        {/* Meta */}
+        <div className="flex flex-col gap-1">
+          <span className="inline-flex items-center gap-1.5 text-xs font-medium" style={{ color: "var(--texto-secundario)" }}>
+            <Clock size={11} strokeWidth={2} style={{ color: futuro ? TAB_COLOR : "var(--texto-secundario)", flexShrink: 0 }} />
+            {formatHora(ev.fechaInicio)}
+            {ev.fechaFin ? ` – ${formatHora(ev.fechaFin)}` : ""}
+          </span>
+          {ev.lugar && (
+            <span className="inline-flex items-center gap-1.5 text-xs font-medium" style={{ color: "var(--texto-secundario)" }}>
+              <MapPin size={11} strokeWidth={2} style={{ color: futuro ? TAB_COLOR : "var(--texto-secundario)", flexShrink: 0 }} />
+              <span className="truncate">{ev.lugar}</span>
+            </span>
+          )}
+        </div>
+
+        {/* Acciones */}
+        <div className="flex items-center gap-1.5 mt-auto pt-2" onClick={e => e.stopPropagation()}>
+          <Button variant="primary" size="sm" className="flex-1 justify-center" onClick={onEditar}>
+            Editar
+          </Button>
+          <Button variant="danger" size="sm" className="flex-1 justify-center" onClick={onEliminar}>
+            Desactivar
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Componente principal ──────────────────────────────────────────────────────
 
 interface Props {
-  /** Si quien usa el panel es ROLE_ADMIN (superadmin) → puede marcar eventos como globales */
   esSuperAdmin?: boolean;
 }
 
 export function EventosAdminTab({ esSuperAdmin = false }: Props) {
-  const [eventos, setEventos]   = useState<ComunidadEvento[]>([]);
-  const [cargando, setCargando] = useState(true);
-  const [error, setError]       = useState<string | null>(null);
-  const [modalAbierto, setModalAbierto] = useState(false);
-  const [editando, setEditando] = useState<ComunidadEvento | null>(null);
-  const [confirmDesactivar, setConfirmDesactivar] = useState<ComunidadEvento | null>(null);
+  const qc = useQueryClient();
 
-  const cargar = async () => {
-    setCargando(true);
-    setError(null);
-    try {
+  const { data: eventos = [], isLoading: cargando, isError } = useQuery<ComunidadEvento[]>({
+    queryKey: QK_EVENTOS,
+    queryFn: async () => {
       const data = await getEventosComunidad();
-      // Ordenar: futuros primero (asc), pasados al final (desc)
       const ahora = Date.now();
-      const ordenados = [...data].sort((a, b) => {
+      return [...data].sort((a, b) => {
         const ta = new Date(a.fechaInicio).getTime();
         const tb = new Date(b.fechaInicio).getTime();
         const fa = ta >= ahora, fb = tb >= ahora;
@@ -45,140 +217,292 @@ export function EventosAdminTab({ esSuperAdmin = false }: Props) {
         if (!fa && fb) return 1;
         return fa ? ta - tb : tb - ta;
       });
-      setEventos(ordenados);
-    } catch {
-      setError("Error al cargar eventos");
-    } finally {
-      setCargando(false);
-    }
-  };
+    },
+    staleTime: 60_000,
+  });
 
-  useEffect(() => { cargar(); }, []);
+  type Filtro = "todos" | "proximos" | "finalizados";
+  const [search, setSearch]                     = useState("");
+  const [filtro, setFiltro]                     = useState<Filtro>("todos");
+  const [dropOpen, setDropOpen]                 = useState(false);
+  const [dropPos,  setDropPos]                  = useState({ top: 0, left: 0, width: 0 });
+  const dropRef = useRef<HTMLButtonElement>(null);
+  const [modalAbierto, setModalAbierto]         = useState(false);
+  const [editando, setEditando]                 = useState<ComunidadEvento | null>(null);
+  const [confirmEliminar, setConfirmEliminar]   = useState<ComunidadEvento | null>(null);
+  const [eliminando, setEliminando]             = useState(false);
 
-  const handleDesactivar = (ev: ComunidadEvento) => setConfirmDesactivar(ev);
+  if (typeof document !== "undefined") {
+    document.body.style.overflow = (modalAbierto || !!confirmEliminar) ? "hidden" : "";
+  }
 
-  const ejecutarDesactivar = async () => {
-    if (!confirmDesactivar) return;
-    try {
-      await desactivarEventoComunidad(confirmDesactivar.eventoId);
-      setEventos((prev) => prev.filter((e) => e.eventoId !== confirmDesactivar.eventoId));
-    } catch {
-      setError("No se pudo desactivar el evento. Inténtalo de nuevo.");
-    } finally {
-      setConfirmDesactivar(null);
-    }
-  };
+  const filtrados = eventos.filter(ev => {
+    if (filtro === "proximos"    && !esFuturo(ev.fechaInicio)) return false;
+    if (filtro === "finalizados" &&  esFuturo(ev.fechaInicio)) return false;
+    return !search.trim() ||
+      ev.titulo.toLowerCase().includes(search.toLowerCase()) ||
+      (ev.descripcion ?? "").toLowerCase().includes(search.toLowerCase()) ||
+      (ev.lugar ?? "").toLowerCase().includes(search.toLowerCase());
+  });
 
-  const handleGuardado = () => {
+  const handleGuardado = (ev: ComunidadEvento) => {
+    qc.setQueryData<ComunidadEvento[]>(QK_EVENTOS, (prev = []) => {
+      const existe = prev.find(e => e.eventoId === ev.eventoId);
+      const lista  = existe
+        ? prev.map(e => e.eventoId === ev.eventoId ? ev : e)
+        : [ev, ...prev];
+      const ahora  = Date.now();
+      return [...lista].sort((a, b) => {
+        const ta = new Date(a.fechaInicio).getTime();
+        const tb = new Date(b.fechaInicio).getTime();
+        const fa  = ta >= ahora, fb = tb >= ahora;
+        if (fa && !fb) return -1;
+        if (!fa && fb) return 1;
+        return fa ? ta - tb : tb - ta;
+      });
+    });
     setModalAbierto(false);
     setEditando(null);
-    cargar();
   };
 
+  const ejecutarEliminar = async () => {
+    if (!confirmEliminar) return;
+    setEliminando(true);
+    try {
+      await desactivarEventoComunidad(confirmEliminar.eventoId);
+      qc.setQueryData<ComunidadEvento[]>(QK_EVENTOS, (prev = []) =>
+        prev.filter(e => e.eventoId !== confirmEliminar.eventoId)
+      );
+    } finally {
+      setEliminando(false);
+      setConfirmEliminar(null);
+    }
+  };
+
+  const totalFuturos = eventos.filter(ev => esFuturo(ev.fechaInicio)).length;
+
   return (
-    <section className="bg-white rounded-2xl border border-slate-100 shadow-sm p-6">
-      <div className="flex items-start justify-between mb-6 gap-4">
-        <div>
-          <h2 className="text-lg font-bold text-slate-800 flex items-center gap-2">
-            <Calendar className="w-5 h-5 text-blue-700" />
-            Eventos
-          </h2>
-          <p className="text-xs text-slate-500 mt-0.5">
-            Crea y gestiona los eventos visibles para los empleados {esSuperAdmin ? "(puedes marcarlos como globales EGM)" : "de tu empresa"}
-          </p>
-        </div>
-        <button
-          onClick={() => { setEditando(null); setModalAbierto(true); }}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-colors"
-          style={{ background: "var(--azul-egm)", color: "#fff" }}
-        >
-          <Plus className="w-4 h-4" />
-          Crear evento
-        </button>
+    <div>
+      {/* ── Título + subtítulo ── */}
+      <div className="mb-8 text-center sm:text-left">
+        <h1 style={{
+          fontFamily: "var(--font-raleway), sans-serif", fontWeight: 800,
+          fontSize: "clamp(1.6rem, 2.5vw, 2.2rem)", color: "var(--texto-primario)",
+          letterSpacing: "-0.02em", lineHeight: 1.1,
+        }}>
+          Eventos
+        </h1>
+        <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
+          {cargando ? "Cargando eventos…" : isError ? "Error al cargar" : eventos.length === 0
+            ? "No hay eventos registrados"
+            : <>
+                {eventos.length} evento{eventos.length !== 1 ? "s" : ""}
+                {totalFuturos > 0 && (
+                  <span className="font-semibold" style={{ color: TAB_COLOR }}>
+                    {" · "}{totalFuturos} próximo{totalFuturos !== 1 ? "s" : ""}
+                  </span>
+                )}
+              </>
+          }
+        </p>
       </div>
 
-      {cargando ? (
-        <div className="flex items-center justify-center py-16">
-          <Loader2 className="w-6 h-6 animate-spin text-slate-400" />
-        </div>
-      ) : error ? (
-        <div className="text-center py-12 text-sm text-red-600">{error}</div>
-      ) : eventos.length === 0 ? (
-        <div className="text-center py-16">
-          <Calendar className="w-12 h-12 text-slate-300 mx-auto mb-3" />
-          <p className="text-sm font-medium text-slate-700">Aún no hay eventos</p>
-          <p className="text-xs text-slate-500 mt-1">Crea el primero pulsando &quot;Crear evento&quot;</p>
-        </div>
-      ) : (
-        <ul className="space-y-2.5">
-          {eventos.map((ev) => {
-            const fechaIni = new Date(ev.fechaInicio);
-            const esFuturo = fechaIni.getTime() >= Date.now();
-            const acento   = ev.esGlobal ? "var(--azul-egm)" : "var(--verde-oliva)";
-            return (
-              <li key={ev.eventoId}
-                className="border border-slate-100 rounded-xl p-4 hover:border-blue-200 hover:bg-blue-50/20 transition-colors">
-                <div className="flex items-start gap-4">
-                  {/* Bloque fecha */}
-                  <div className="shrink-0 w-14 rounded-xl py-2 text-center"
-                    style={{ background: esFuturo ? "var(--azul-egm-light)" : "var(--gris-superficie)" }}>
-                    <p className="text-lg font-bold leading-none"
-                      style={{ color: esFuturo ? "var(--azul-egm)" : "var(--texto-muted)" }}>
-                      {fechaIni.getDate()}
-                    </p>
-                    <p className="text-[10px] uppercase tracking-wider mt-0.5"
-                      style={{ color: esFuturo ? "var(--azul-egm)" : "var(--texto-muted)" }}>
-                      {fechaIni.toLocaleDateString("es-ES", { month: "short" }).replace(".", "")}
-                    </p>
-                  </div>
-
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1 flex-wrap">
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider"
-                        style={{ background: ev.esGlobal ? "var(--azul-egm-light)" : "var(--verde-oliva-light)", color: acento }}>
-                        {ev.esGlobal ? <Globe2 className="w-3 h-3" /> : <Building2 className="w-3 h-3" />}
-                        {ev.esGlobal ? "EGM Global" : "Tu empresa"}
-                      </span>
-                      {!esFuturo && (
-                        <span className="inline-flex px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider bg-slate-100 text-slate-500">
-                          Finalizado
-                        </span>
+      {/* ── Toolbar ── */}
+      {(() => {
+        const FILTROS = [
+          { id: "todos"       as Filtro, label: "Todos"       },
+          { id: "proximos"    as Filtro, label: "Próximos"    },
+          { id: "finalizados" as Filtro, label: "Finalizados" },
+        ];
+        const activoLabel = FILTROS.find(f => f.id === filtro)?.label ?? "Todos";
+        const searchInput = (placeholder: string) => (
+          <div className="relative flex-1 sm:flex-none" style={{ width: undefined }}>
+            <span className="absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none" style={{ color: "var(--texto-muted)" }}>
+              <Search size={15} strokeWidth={2} />
+            </span>
+            <input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder={placeholder}
+              className="w-full pl-9 pr-3 py-2.5 text-sm rounded-xl outline-none"
+              style={{
+                background: "var(--blanco)",
+                border: "1.5px solid var(--gris-borde)",
+                color: "var(--texto-primario)",
+                transition: "border-color 0.15s",
+              }}
+              onFocus={e => e.currentTarget.style.borderColor = TAB_COLOR}
+              onBlur={e  => e.currentTarget.style.borderColor = "var(--gris-borde)"}
+            />
+          </div>
+        );
+        return (
+          <div className="flex flex-col gap-2 mb-6">
+            {/* Desktop */}
+            <div className="hidden sm:flex items-center gap-2">
+              <div style={{ width: 260 }}>{searchInput("Buscar eventos…")}</div>
+              <div className="flex gap-1 p-1 rounded-xl" style={{ background: "var(--gris-superficie)", border: "1px solid var(--gris-borde)" }}>
+                {FILTROS.map(({ id, label }) => {
+                  const active = filtro === id;
+                  return (
+                    <button key={id} type="button" onClick={() => setFiltro(id)}
+                      className="relative text-xs font-semibold px-3 py-1.5 rounded-lg focus:outline-none cursor-pointer whitespace-nowrap"
+                      style={{ color: active ? "var(--texto-primario)" : "var(--texto-muted)", background: "none", border: "none", transition: "color 0.15s" }}>
+                      {active && (
+                        <motion.span layoutId="ev-filtro-pill"
+                          className="absolute inset-0 rounded-lg"
+                          style={{ background: "var(--blanco)", boxShadow: "0 1px 4px rgba(0,0,0,0.10)" }}
+                          transition={{ type: "spring", stiffness: 380, damping: 32 }}
+                        />
                       )}
-                    </div>
-                    <p className="font-semibold text-slate-800 truncate">{ev.titulo}</p>
-                    {ev.descripcion && (
-                      <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">{ev.descripcion}</p>
-                    )}
-                    <div className="flex items-center gap-3 mt-1.5 text-[11px] text-slate-500 flex-wrap">
-                      <span className="inline-flex items-center gap-1">
-                        <Clock className="w-3 h-3" />
-                        {fechaIni.toLocaleString("es-ES", { day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit" })}
-                        {ev.fechaFin && ` – ${new Date(ev.fechaFin).toLocaleTimeString("es-ES", { hour: "2-digit", minute: "2-digit" })}`}
-                      </span>
-                    </div>
-                  </div>
+                      <span className="relative z-10">{label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="flex-1" />
+              <Button variant="primary" size="md" onClick={() => { setEditando(null); setModalAbierto(true); }}>
+                <Plus size={14} /> Crear evento
+              </Button>
+            </div>
 
-                  <div className="flex flex-col gap-1.5 shrink-0">
-                    <button
-                      onClick={() => { setEditando(ev); setModalAbierto(true); }}
-                      title="Editar"
-                      className="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-50">
-                      <Pencil className="w-3.5 h-3.5" />
-                    </button>
-                    <button
-                      onClick={() => handleDesactivar(ev)}
-                      title="Desactivar"
-                      className="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-red-100 text-red-500 hover:bg-red-50">
-                      <Trash2 className="w-3.5 h-3.5" />
-                    </button>
+            {/* Móvil */}
+            <div className="flex flex-col gap-2 sm:hidden">
+              <div className="flex gap-2">
+                {searchInput("Buscar…")}
+                <Button variant="primary" size="md" onClick={() => { setEditando(null); setModalAbierto(true); }}>
+                  <Plus size={14} />
+                </Button>
+              </div>
+              {/* Dropdown filtro */}
+              <button
+                ref={dropRef}
+                onClick={() => {
+                  if (!dropOpen && dropRef.current) {
+                    const r = dropRef.current.getBoundingClientRect();
+                    setDropPos({ top: r.bottom + 5, left: r.left, width: r.width });
+                  }
+                  setDropOpen(v => !v);
+                }}
+                className="flex items-center justify-between w-full px-3.5 py-2.5 text-sm font-semibold rounded-xl cursor-pointer"
+                style={{
+                  background: "var(--blanco)",
+                  border: `1.5px solid ${filtro !== "todos" ? TAB_COLOR : "var(--gris-borde)"}`,
+                  color: filtro !== "todos" ? TAB_COLOR : "var(--texto-primario)",
+                  transition: "border-color 0.15s",
+                }}
+              >
+                <span>{activoLabel}</span>
+                <ChevronDown size={14} strokeWidth={2.3} style={{ color: "var(--texto-muted)", transform: dropOpen ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.15s" }} />
+              </button>
+              {dropOpen && createPortal(
+                <>
+                  <div className="fixed inset-0 z-[9998]" onClick={() => setDropOpen(false)} />
+                  <div className="fixed z-[9999] rounded-xl overflow-hidden"
+                    style={{
+                      top: dropPos.top, left: dropPos.left,
+                      minWidth: Math.max(dropPos.width, 180),
+                      background: "var(--blanco)",
+                      border: "1px solid var(--gris-borde)",
+                      boxShadow: "0 8px 24px rgba(0,0,0,0.13)",
+                    }}>
+                    {FILTROS.map(opt => {
+                      const sel = filtro === opt.id;
+                      return (
+                        <button key={opt.id} onClick={() => { setFiltro(opt.id); setDropOpen(false); }}
+                          className="flex items-center w-full px-4 py-2.5 text-sm font-semibold cursor-pointer text-left"
+                          style={{
+                            color: sel ? TAB_COLOR : "var(--texto-primario)",
+                            background: sel ? `${TAB_COLOR}10` : "transparent",
+                          }}
+                          onMouseEnter={e => { if (!sel) (e.currentTarget as HTMLElement).style.background = "var(--gris-pagina)"; }}
+                          onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = sel ? `${TAB_COLOR}10` : "transparent"; }}
+                        >
+                          {opt.label}
+                        </button>
+                      );
+                    })}
                   </div>
-                </div>
-              </li>
-            );
-          })}
-        </ul>
+                </>,
+                document.body
+              )}
+            </div>
+          </div>
+        );
+      })()}
+
+      {/* ── Contenido ── */}
+      {cargando ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+          {[0, 1, 2, 3, 4, 5, 6, 7].map(i => <SkeletonCard key={i} />)}
+        </div>
+
+      ) : isError ? (
+        <div className="flex flex-col items-center justify-center py-20 gap-4 rounded-2xl text-center"
+          style={{ background: "var(--blanco)", border: "1px solid #fca5a5" }}>
+          <div className="rounded-2xl p-4" style={{ background: "#fee2e2" }}>
+            <Calendar size={28} style={{ color: "#dc2626" }} />
+          </div>
+          <div>
+            <p className="font-semibold text-sm" style={{ color: "var(--texto-primario)" }}>No se pudieron cargar los eventos</p>
+            <p className="text-xs mt-1" style={{ color: "var(--texto-muted)" }}>Comprueba tu conexión e inténtalo de nuevo</p>
+          </div>
+          <button onClick={() => qc.invalidateQueries({ queryKey: QK_EVENTOS })}
+            className="text-xs font-semibold px-4 py-2 rounded-xl cursor-pointer"
+            style={{ background: "#dc2626", color: "white" }}>
+            Reintentar
+          </button>
+        </div>
+
+      ) : filtrados.length === 0 ? (
+        <div className="card flex flex-col items-center justify-center py-16 text-center gap-4">
+          <div className="flex items-center justify-center rounded-full"
+            style={{ width: 72, height: 72, background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
+            {search ? <Search size={28} strokeWidth={1.4} /> : <Calendar size={28} strokeWidth={1.4} />}
+          </div>
+          <div>
+            <p className="text-lg font-bold mb-1.5" style={{ color: "var(--texto-primario)" }}>
+              {search ? "Sin resultados" : "Todavía no hay eventos"}
+            </p>
+            <p className="text-sm" style={{ color: "var(--texto-muted)", maxWidth: 320, margin: "0 auto" }}>
+              {search
+                ? <>No hay eventos que coincidan con <span className="font-semibold" style={{ color: "var(--texto-primario)" }}>"{search}"</span></>
+                : "Crea el primer evento para que los empleados puedan verlo."}
+            </p>
+          </div>
+          {search && (
+            <button onClick={() => setSearch("")}
+              className="text-sm font-semibold px-5 py-2.5 rounded-xl cursor-pointer"
+              style={{ background: TAB_COLOR, color: "white" }}>
+              Ver todos
+            </button>
+          )}
+        </div>
+
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+          <AnimatePresence initial={false}>
+            {filtrados.map((ev, idx) => (
+              <motion.div
+                key={ev.eventoId}
+                layout
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.97 }}
+                transition={{ duration: 0.2, ease: "easeOut", delay: idx * 0.03 }}
+              >
+                <EventoCard
+                  ev={ev}
+                  onEditar={() => { setEditando(ev); setModalAbierto(true); }}
+                  onEliminar={() => setConfirmEliminar(ev)}
+                />
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
       )}
 
+      {/* ── Modal crear/editar ── */}
       {modalAbierto && (
         <ModalEvento
           evento={editando}
@@ -188,19 +512,20 @@ export function EventosAdminTab({ esSuperAdmin = false }: Props) {
         />
       )}
 
+      {/* ── Confirm desactivar ── */}
       <ModalConfirm
-        abierto={!!confirmDesactivar}
+        abierto={!!confirmEliminar}
         titulo="¿Desactivar evento?"
         descripcion={
-          confirmDesactivar
-            ? `"${confirmDesactivar.titulo}" dejará de ser visible para los empleados.`
+          confirmEliminar
+            ? `"${confirmEliminar.titulo}" dejará de ser visible para los empleados.`
             : ""
         }
-        textoConfirmar="Desactivar evento"
+        textoConfirmar={eliminando ? "Desactivando…" : "Desactivar"}
         variante="danger"
-        onConfirmar={ejecutarDesactivar}
-        onCancelar={() => setConfirmDesactivar(null)}
+        onConfirmar={ejecutarEliminar}
+        onCancelar={() => setConfirmEliminar(null)}
       />
-    </section>
+    </div>
   );
 }

--- a/components/eventos/ModalEvento.tsx
+++ b/components/eventos/ModalEvento.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-// ============================================================
-// ModalEvento — formulario reutilizable para crear o editar un
-// evento de comunidad. Usado en EventosAdminTab y en la vista
-// /dashboard/eventos.
-// ============================================================
-
-import { useRef, useState } from "react";
-import { Calendar, X, Loader2, MapPin, Search, Check, ImagePlus, Trash2 } from "lucide-react";
+import { useRef, useState, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "motion/react";
+import {
+  Loader2, MapPin, Search, Check, ImagePlus, Trash2, Globe2,
+} from "lucide-react";
 import {
   crearEventoComunidad,
   actualizarEventoComunidad,
@@ -17,58 +15,103 @@ import {
 } from "@/lib/api/comunidad";
 import { buscarDireccion, type GeocodingResult } from "@/lib/geocoding";
 import { MapaUbicacion } from "./MapaUbicacion";
+import { Button } from "@/components/ui/Button";
+import { IconButton } from "@/components/ui/IconButton";
+import Grainient from "@/components/ui/Grainient";
+
+const TAB_COLOR = "#0F766E";
+
+const inputBase: React.CSSProperties = {
+  background:    "var(--blanco)",
+  border:        "1px solid rgba(0,0,0,0.12)",
+  borderRadius:  "var(--radius-lg)",
+  color:         "var(--texto-primario)",
+  fontSize:      "0.875rem",
+  width:         "100%",
+  height:        "44px",
+  paddingLeft:   "14px",
+  paddingRight:  "14px",
+  outline:       "none",
+  transition:    "border-color 0.15s",
+};
+
+const textareaBase: React.CSSProperties = {
+  ...inputBase,
+  height:        "auto",
+  padding:       "10px 14px",
+  resize:        "none",
+};
+
+const labelBase: React.CSSProperties = {
+  display:       "block",
+  fontSize:      "0.875rem",
+  fontWeight:    600,
+  color:         "var(--texto-label)",
+  marginBottom:  6,
+};
 
 interface Props {
-  /** Si es null → modo creación; si tiene datos → modo edición */
   evento:       ComunidadEvento | null;
-  /** Sólo los ROLE_ADMIN (superadmin) pueden marcar eventos como globales */
   esSuperAdmin: boolean;
   onClose:      () => void;
   onGuardado:   (evento: ComunidadEvento) => void;
 }
 
 export function ModalEvento({ evento, esSuperAdmin, onClose, onGuardado }: Props) {
+  type TabId = "informacion" | "detalles";
+
   const esNuevo = !evento;
 
-  // Convertir ISO con timezone a formato datetime-local (YYYY-MM-DDTHH:mm)
   const isoToLocal = (iso: string | null | undefined): string => {
     if (!iso) return "";
     const d = new Date(iso);
-    const tz = d.getTimezoneOffset() * 60000;
-    return new Date(d.getTime() - tz).toISOString().slice(0, 16);
+    return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
   };
 
-  const [titulo,      setTitulo]      = useState(evento?.titulo ?? "");
-  const [descripcion, setDescripcion] = useState(evento?.descripcion ?? "");
-  const [fechaInicio, setFechaInicio] = useState(isoToLocal(evento?.fechaInicio));
-  const [fechaFin,    setFechaFin]    = useState(isoToLocal(evento?.fechaFin));
-  const [esGlobal,    setEsGlobal]    = useState(evento?.esGlobal ?? false);
-  const [enviando,    setEnviando]    = useState(false);
-  const [error,       setError]       = useState<string | null>(null);
+  // ── Form state ────────────────────────────────────────────────────────────────
+  const [titulo,       setTitulo]      = useState(evento?.titulo ?? "");
+  const [descripcion,  setDescripcion] = useState(evento?.descripcion ?? "");
+  const [fechaInicio,  setFechaInicio] = useState(isoToLocal(evento?.fechaInicio));
+  const [fechaFin,     setFechaFin]    = useState(isoToLocal(evento?.fechaFin));
+  const [esGlobal,     setEsGlobal]    = useState(evento?.esGlobal ?? false);
+  const [enviando,     setEnviando]    = useState(false);
+  const [error,        setError]       = useState<string | null>(null);
 
-  // ── Ubicación ──────────────────────────────────────────────
-  const [lugar,    setLugar]    = useState(evento?.lugar ?? "");
-  const [latitud,  setLatitud]  = useState<number | null>(evento?.latitud ?? null);
-  const [longitud, setLongitud] = useState<number | null>(evento?.longitud ?? null);
-  const [buscandoMapa, setBuscandoMapa] = useState(false);
+  // ── Tabs ──────────────────────────────────────────────────────────────────────
+  const [activeTab,    setActiveTab]   = useState<TabId>("informacion");
+  const visitedTabs = useRef<Set<TabId>>(new Set(["informacion"]));
+
+  const TABS: { id: TabId; label: string }[] = [
+    { id: "informacion", label: "Información" },
+    { id: "detalles",    label: "Detalles"    },
+  ];
+
+  const goTab = (id: TabId) => {
+    visitedTabs.current.add(id);
+    setActiveTab(id);
+  };
+
+  // ── Ubicación ────────────────────────────────────────────────────────────────
+  const [lugar,          setLugar]          = useState(evento?.lugar ?? "");
+  const [latitud,        setLatitud]        = useState<number | null>(evento?.latitud ?? null);
+  const [longitud,       setLongitud]       = useState<number | null>(evento?.longitud ?? null);
+  const [buscandoMapa,   setBuscandoMapa]   = useState(false);
   const [resultadosMapa, setResultadosMapa] = useState<GeocodingResult[]>([]);
-  const [erroresMapa, setErroresMapa] = useState<string | null>(null);
+  const [erroresMapa,    setErroresMapa]    = useState<string | null>(null);
 
-  // ── Imagen ─────────────────────────────────────────────────
-  const [imagenUrl, setImagenUrl] = useState<string | null>(evento?.imagenUrl ?? null);
-  const [subiendoImg, setSubiendoImg] = useState(false);
-  const [errorImg, setErrorImg] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  // ── Imagen ────────────────────────────────────────────────────────────────────
+  const [imagenUrl,    setImagenUrl]    = useState<string | null>(evento?.imagenUrl ?? null);
+  const [subiendoImg,  setSubiendoImg]  = useState(false);
+  const [errorImg,     setErrorImg]     = useState<string | null>(null);
+  const fileInputRef   = useRef<HTMLInputElement>(null);
+  const debounceRef    = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [dragOver,    setDragOver]    = useState(false);
 
   const onSeleccionarImagen = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (file.size > 5 * 1024 * 1024) {
-      setErrorImg("La imagen no puede pesar más de 5 MB");
-      return;
-    }
-    setSubiendoImg(true);
-    setErrorImg(null);
+    if (file.size > 5 * 1024 * 1024) { setErrorImg("La imagen no puede pesar más de 5 MB"); return; }
+    setSubiendoImg(true); setErrorImg(null);
     try {
       const url = await subirImagenEvento(file);
       if (!url) { setErrorImg("Error al subir la imagen"); return; }
@@ -79,58 +122,52 @@ export function ModalEvento({ evento, esSuperAdmin, onClose, onGuardado }: Props
     }
   };
 
-  const quitarImagen = () => {
-    setImagenUrl(null);
-    setErrorImg(null);
-  };
-
-  const buscar = async () => {
-    if (!lugar.trim()) return;
-    setBuscandoMapa(true);
-    setErroresMapa(null);
-    setResultadosMapa([]);
+  const buscar = useCallback(async (query?: string) => {
+    const q = (query ?? lugar).trim();
+    if (!q) return;
+    setBuscandoMapa(true); setErroresMapa(null); setResultadosMapa([]);
     try {
-      const res = await buscarDireccion(lugar, 5);
+      const res = await buscarDireccion(q, 5);
       if (res.length === 0) setErroresMapa("Sin resultados — prueba con más detalles");
       else setResultadosMapa(res);
-    } finally {
-      setBuscandoMapa(false);
+    } finally { setBuscandoMapa(false); }
+  }, [lugar]);
+
+  const onLugarChange = (val: string) => {
+    setLugar(val);
+    setResultadosMapa([]); setErroresMapa(null);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (val.trim().length >= 3) {
+      debounceRef.current = setTimeout(() => buscar(val), 900);
     }
   };
 
   const seleccionar = (r: GeocodingResult) => {
-    setLatitud(r.latitud);
-    setLongitud(r.longitud);
-    setLugar(r.etiqueta);
-    setResultadosMapa([]);
+    setLatitud(r.latitud); setLongitud(r.longitud);
+    setLugar(r.etiqueta); setResultadosMapa([]);
   };
 
   const limpiarUbicacion = () => {
-    setLatitud(null);
-    setLongitud(null);
-    setLugar("");
-    setResultadosMapa([]);
-    setErroresMapa(null);
+    setLatitud(null); setLongitud(null);
+    setLugar(""); setResultadosMapa([]); setErroresMapa(null);
   };
 
   const enviar = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!titulo.trim() || !fechaInicio) {
       setError("Título y fecha de inicio son obligatorios");
+      goTab("informacion");
       return;
     }
-    setEnviando(true);
-    setError(null);
+    setEnviando(true); setError(null);
     try {
       const payload: ComunidadEventoInput = {
-        titulo:      titulo.trim(),
+        titulo: titulo.trim(),
         descripcion: descripcion.trim() || null,
         fechaInicio: new Date(fechaInicio).toISOString(),
-        fechaFin:    fechaFin ? new Date(fechaFin).toISOString() : null,
-        lugar:       lugar.trim() || null,
-        latitud,
-        longitud,
-        imagenUrl,
+        fechaFin: fechaFin ? new Date(fechaFin).toISOString() : null,
+        lugar: lugar.trim() || null,
+        latitud, longitud, imagenUrl,
         ...(esSuperAdmin && { esGlobal }),
       };
       const guardado = esNuevo
@@ -139,265 +176,381 @@ export function ModalEvento({ evento, esSuperAdmin, onClose, onGuardado }: Props
       onGuardado(guardado);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Error al guardar");
-    } finally {
-      setEnviando(false);
-    }
+    } finally { setEnviando(false); }
   };
 
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
-      style={{ background: "rgba(0,0,0,0.55)" }}
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100">
-          <h2 className="text-base font-bold text-slate-800 flex items-center gap-2">
-            <Calendar className="w-5 h-5 text-blue-700" />
-            {esNuevo ? "Crear evento" : "Editar evento"}
-          </h2>
-          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-slate-100">
-            <X className="w-4 h-4 text-slate-500" />
-          </button>
-        </div>
+  const focusOn  = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+    { e.currentTarget.style.borderColor = TAB_COLOR; e.currentTarget.style.boxShadow = `0 0 0 3px ${TAB_COLOR}18`; };
+  const focusOff = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+    { e.currentTarget.style.borderColor = "rgba(0,0,0,0.12)"; e.currentTarget.style.boxShadow = "none"; };
 
-        <form onSubmit={enviar} className="px-6 py-5 flex flex-col gap-4 max-h-[80vh] overflow-y-auto">
-          {/* Imagen de portada (opcional) */}
-          <div>
-            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
-              Imagen de portada (opcional)
-            </label>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/png,image/jpeg,image/webp"
-              onChange={onSeleccionarImagen}
-              className="hidden"
-            />
-            {imagenUrl ? (
-              <div className="relative rounded-xl overflow-hidden border border-slate-200 group"
-                style={{ aspectRatio: "16 / 9", background: "#f1f5f9" }}>
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={imagenUrl} alt="Portada del evento" className="absolute inset-0 w-full h-full object-cover" />
-                <div className="absolute inset-0 flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity"
-                  style={{ background: "rgba(0,0,0,0.45)" }}>
-                  <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-semibold bg-white text-slate-700 hover:bg-slate-50"
-                  >
-                    <ImagePlus className="w-3.5 h-3.5" />
-                    Cambiar
+  const content = (
+    <AnimatePresence>
+      <motion.div
+        key="modal-evento-overlay"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.22 }}
+        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+        style={{ background: "var(--overlay)" }}
+        onMouseDown={e => { if (e.target === e.currentTarget) onClose(); }}
+      >
+        <motion.div
+          key="modal-evento-panel"
+          initial={{ opacity: 0, y: 28, scale: 0.96 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 16, scale: 0.97 }}
+          transition={{ duration: 0.26, ease: [0.34, 1.15, 0.64, 1] }}
+          className="w-full sm:max-w-lg rounded-t-3xl sm:rounded-2xl flex flex-col overflow-hidden"
+          style={{ maxHeight: "92dvh", background: "var(--gris-panel)", boxShadow: "0 24px 56px rgba(0,0,0,0.18)" }}
+          onMouseDown={e => e.stopPropagation()}
+        >
+          {/* ── Header con Grainient ── */}
+          <div className="relative shrink-0 flex items-center justify-between px-5 sm:px-6"
+            style={{ paddingTop: 20, paddingBottom: 20, background: TAB_COLOR, overflow: "hidden" }}>
+            <div className="absolute inset-0 pointer-events-none">
+              <Grainient
+                color1="#0F766E" color2="#0D9488" color3="#065F46"
+                timeSpeed={0.15} warpStrength={1.0} warpFrequency={3.5}
+                warpSpeed={1.2} warpAmplitude={50} grainAmount={0.07}
+              />
+            </div>
+            <div className="relative z-10 flex flex-col gap-0.5 min-w-0">
+              <h2 style={{
+                fontFamily: "var(--font-raleway), sans-serif",
+                fontWeight: 800, fontSize: "clamp(1.4rem, 4vw, 1.8rem)",
+                lineHeight: 1.1, letterSpacing: "-0.03em", color: "#fff", margin: 0,
+              }}>
+                {esNuevo ? "Crear evento" : "Editar evento"}
+              </h2>
+              <p className="text-sm" style={{ color: "rgba(255,255,255,0.65)", marginTop: 2 }}>
+                {esNuevo ? "Visible para los empleados de tu empresa" : "Los cambios se aplicarán inmediatamente"}
+              </p>
+            </div>
+            <div className="relative z-10 shrink-0 ml-4">
+              <IconButton onClick={onClose} variant="glass" label="Cerrar" />
+            </div>
+          </div>
+
+          {/* ── Tabs internos ── */}
+          <div className="shrink-0 relative"
+            style={{ background: "var(--gris-superficie)", borderBottom: "1px solid var(--gris-borde)" }}>
+            <div className="flex">
+              {TABS.map(({ id, label }) => {
+                const isActive = activeTab === id;
+                return (
+                  <button key={id} type="button" onClick={() => goTab(id)}
+                    className="flex-1 py-3.5 text-sm font-semibold focus:outline-none cursor-pointer"
+                    style={{
+                      color: isActive ? TAB_COLOR : "var(--texto-muted)",
+                      background: "none", border: "none",
+                      transition: "color 0.18s ease",
+                    }}>
+                    {label}
                   </button>
-                  <button
-                    type="button"
-                    onClick={quitarImagen}
-                    className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-semibold bg-red-500 text-white hover:bg-red-600"
-                  >
-                    <Trash2 className="w-3.5 h-3.5" />
-                    Quitar
-                  </button>
+                );
+              })}
+            </div>
+            {/* Underline animado */}
+            <div style={{
+              position: "absolute", bottom: -1, left: 0,
+              width: `${100 / TABS.length}%`, height: 2,
+              background: TAB_COLOR,
+              transform: `translateX(${TABS.findIndex(t => t.id === activeTab) * 100}%)`,
+              transition: "transform 0.24s cubic-bezier(0.4,0,0.2,1)",
+              borderRadius: 2,
+            }} />
+          </div>
+
+          {/* ── Body scrollable ── */}
+          <form onSubmit={enviar} className="flex flex-col overflow-hidden flex-1 min-h-0">
+            <div className="overflow-y-auto flex-1" style={{ background: "var(--gris-panel)" }}>
+
+              {/* ══ TAB: Información ══ */}
+              <div style={{ display: activeTab === "informacion" ? "block" : "none" }}>
+                <div className="flex flex-col gap-5 px-5 sm:px-6 py-6">
+
+                  {/* Imagen de portada */}
+                  <div>
+                    <label style={labelBase}>
+                      Imagen de portada{" "}
+                      <span style={{ color: "var(--texto-muted)", fontWeight: 400 }}>(opcional)</span>
+                    </label>
+                    <input ref={fileInputRef} type="file" accept="image/png,image/jpeg,image/webp"
+                      onChange={onSeleccionarImagen} className="hidden" />
+
+                    {imagenUrl ? (
+                      <div className="relative rounded-xl overflow-hidden group"
+                        style={{ height: 160, background: "var(--gris-superficie)", border: "1px solid var(--gris-borde)" }}>
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src={imagenUrl} alt="Portada" className="absolute inset-0 w-full h-full object-cover" />
+                        <div className="absolute inset-0 flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity"
+                          style={{ background: "rgba(0,0,0,0.45)" }}>
+                          <motion.button type="button" onClick={() => fileInputRef.current?.click()}
+                            whileTap={{ scale: 0.93 }}
+                            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-semibold cursor-pointer"
+                            style={{ background: "#fff", color: "var(--texto-primario)", transition: "background 0.15s, box-shadow 0.15s" }}
+                            onMouseEnter={e => { const el = e.currentTarget as HTMLElement; el.style.background = "var(--gris-superficie)"; el.style.boxShadow = "0 4px 12px rgba(0,0,0,0.18)"; }}
+                            onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.background = "#fff"; el.style.boxShadow = "none"; }}>
+                            <ImagePlus size={13} strokeWidth={2} /> Cambiar
+                          </motion.button>
+                          <motion.button type="button" onClick={() => { setImagenUrl(null); setErrorImg(null); }}
+                            whileTap={{ scale: 0.93 }}
+                            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-semibold cursor-pointer"
+                            style={{ background: "var(--error)", color: "#fff", transition: "background 0.15s, box-shadow 0.15s" }}
+                            onMouseEnter={e => { const el = e.currentTarget as HTMLElement; el.style.background = "#b91c1c"; el.style.boxShadow = "0 4px 14px rgba(220,38,38,0.40)"; }}
+                            onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.background = "var(--error)"; el.style.boxShadow = "none"; }}>
+                            <Trash2 size={13} strokeWidth={2} /> Quitar
+                          </motion.button>
+                        </div>
+                      </div>
+                    ) : (
+                      <button type="button" onClick={() => fileInputRef.current?.click()}
+                        disabled={subiendoImg}
+                        className="w-full flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed cursor-pointer disabled:opacity-50 transition-all"
+                        style={{
+                          height: 130,
+                          borderColor: dragOver ? TAB_COLOR : "var(--gris-borde)",
+                          background: dragOver ? `${TAB_COLOR}08` : "var(--blanco)",
+                          color: "var(--texto-muted)",
+                          transition: "border-color 0.18s, background 0.18s, color 0.18s",
+                        }}
+                        onMouseEnter={e => { if (!subiendoImg) { const el = e.currentTarget as HTMLElement; el.style.borderColor = TAB_COLOR; el.style.background = `${TAB_COLOR}08`; } }}
+                        onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.borderColor = dragOver ? TAB_COLOR : "var(--gris-borde)"; el.style.background = dragOver ? `${TAB_COLOR}08` : "var(--blanco)"; }}
+                        onDragOver={e => { e.preventDefault(); setDragOver(true); }}
+                        onDragLeave={() => setDragOver(false)}
+                        onDrop={e => {
+                          e.preventDefault(); setDragOver(false);
+                          const file = e.dataTransfer.files?.[0];
+                          if (file) onSeleccionarImagen({ target: { files: e.dataTransfer.files } } as React.ChangeEvent<HTMLInputElement>);
+                        }}
+                      >
+                        {subiendoImg ? (
+                          <><Loader2 size={22} className="animate-spin" style={{ color: TAB_COLOR }} />
+                          <span className="text-sm font-medium">Subiendo imagen…</span></>
+                        ) : (
+                          <>
+                            <div className="w-11 h-11 rounded-2xl flex items-center justify-center"
+                              style={{ background: "var(--gris-superficie)" }}>
+                              <ImagePlus size={20} style={{ color: "var(--texto-secundario)" }} />
+                            </div>
+                            <div className="text-center">
+                              <p className="text-sm font-semibold" style={{ color: "var(--texto-secundario)" }}>
+                                Arrastra o <span style={{ color: TAB_COLOR }}>selecciona imagen</span>
+                              </p>
+                              <p className="text-xs mt-0.5" style={{ color: "var(--texto-muted)" }}>PNG, JPG o WebP · máx 5 MB</p>
+                            </div>
+                          </>
+                        )}
+                      </button>
+                    )}
+                    {errorImg && <p className="mt-1.5 text-xs" style={{ color: "var(--error)" }}>{errorImg}</p>}
+                  </div>
+
+                  {/* Título */}
+                  <div>
+                    <label style={labelBase}>
+                      Título
+                      <span className="relative group ml-0.5 inline-block" style={{ color: "#ef4444" }}>
+                        *
+                        <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-1.5 px-2 py-1 rounded-lg text-xs font-semibold whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+                          style={{ background: "#1f2937", color: "#fff", boxShadow: "0 2px 8px rgba(0,0,0,0.18)", zIndex: 99 }}>
+                          Obligatorio
+                        </span>
+                      </span>
+                    </label>
+                    <input type="text" value={titulo} onChange={e => setTitulo(e.target.value)}
+                      maxLength={150} required placeholder="Ej: Jornada de Networking EGM"
+                      style={inputBase} onFocus={focusOn} onBlur={focusOff} />
+                  </div>
+
+                  {/* Descripción */}
+                  <div>
+                    <div className="flex items-center justify-between mb-1.5">
+                      <label style={{ ...labelBase, marginBottom: 0 }}>Descripción</label>
+                      <span className="text-[11px] tabular-nums" style={{ color: "var(--texto-muted)" }}>
+                        {(descripcion ?? "").length}/500
+                      </span>
+                    </div>
+                    <textarea value={descripcion ?? ""} onChange={e => setDescripcion(e.target.value)}
+                      maxLength={500} rows={4} placeholder="Detalles, ponentes, programa…"
+                      style={textareaBase}
+                      onFocus={focusOn} onBlur={focusOff} />
+                  </div>
+
                 </div>
               </div>
-            ) : (
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={subiendoImg}
-                className="w-full flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-slate-300 hover:border-blue-400 hover:bg-blue-50/30 transition-colors text-sm font-medium text-slate-600 disabled:opacity-50"
-                style={{ aspectRatio: "16 / 9" }}
-              >
-                {subiendoImg ? (
-                  <>
-                    <Loader2 className="w-6 h-6 animate-spin text-blue-500" />
-                    <span>Subiendo imagen…</span>
-                  </>
-                ) : (
-                  <>
-                    <ImagePlus className="w-6 h-6 text-slate-400" />
-                    <span>Seleccionar imagen</span>
-                    <span className="text-xs text-slate-400">PNG, JPG o WebP · máx 5 MB</span>
-                  </>
-                )}
-              </button>
-            )}
-            {errorImg && (
-              <p className="mt-1.5 text-xs text-red-600">{errorImg}</p>
-            )}
-          </div>
 
-          {/* Título */}
-          <div>
-            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
-              Título <span className="text-red-500">*</span>
-            </label>
-            <input
-              type="text"
-              value={titulo}
-              onChange={(e) => setTitulo(e.target.value)}
-              maxLength={150}
-              required
-              placeholder="Ej: Jornada de Networking EGM"
-              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
-            />
-          </div>
+              {/* ══ TAB: Detalles ══ */}
+              {visitedTabs.current.has("detalles") && (
+                <div style={{ display: activeTab === "detalles" ? "block" : "none" }}>
+                  <div className="flex flex-col gap-5 px-5 sm:px-6 py-6">
 
-          {/* Descripción */}
-          <div>
-            <label className="block text-xs font-semibold text-slate-700 mb-1.5">Descripción</label>
-            <textarea
-              value={descripcion ?? ""}
-              onChange={(e) => setDescripcion(e.target.value)}
-              maxLength={500}
-              rows={3}
-              placeholder="Detalles, lugar, ponentes, etc."
-              className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm resize-none focus:outline-none focus:border-blue-500"
-            />
-            <p className="text-[10px] text-slate-400 text-right mt-1">{(descripcion ?? "").length}/500</p>
-          </div>
+                    {/* Fechas */}
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label style={labelBase}>
+                          Inicio
+                          <span className="relative group ml-0.5 inline-block" style={{ color: "#ef4444" }}>
+                            *
+                            <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-1.5 px-2 py-1 rounded-lg text-xs font-semibold whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+                              style={{ background: "#1f2937", color: "#fff", boxShadow: "0 2px 8px rgba(0,0,0,0.18)", zIndex: 99 }}>
+                              Obligatorio
+                            </span>
+                          </span>
+                        </label>
+                        <input type="datetime-local" value={fechaInicio}
+                          onChange={e => { setFechaInicio(e.target.value); if (fechaFin && e.target.value > fechaFin) setFechaFin(""); }}
+                          min={new Date().toISOString().slice(0, 16)}
+                          required
+                          style={{ ...inputBase, cursor: "pointer" }} onFocus={focusOn} onBlur={focusOff} />
+                      </div>
+                      <div>
+                        <label style={labelBase}>
+                          Fin{" "}
+                          <span style={{ color: "var(--texto-muted)", fontWeight: 400 }}>(opcional)</span>
+                        </label>
+                        <input type="datetime-local" value={fechaFin}
+                          onChange={e => setFechaFin(e.target.value)}
+                          min={fechaInicio || new Date().toISOString().slice(0, 16)}
+                          style={{ ...inputBase, cursor: "pointer" }} onFocus={focusOn} onBlur={focusOff} />
+                      </div>
+                    </div>
 
-          {/* Fechas */}
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs font-semibold text-slate-700 mb-1.5">
-                Inicio <span className="text-red-500">*</span>
-              </label>
-              <input
-                type="datetime-local"
-                value={fechaInicio}
-                onChange={(e) => setFechaInicio(e.target.value)}
-                required
-                className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
-              />
+                    {/* Ubicación */}
+                    <div>
+                      <label style={labelBase}>
+                        Ubicación{" "}
+                        <span style={{ color: "var(--texto-muted)", fontWeight: 400 }}>(opcional)</span>
+                      </label>
+                      <div className="flex gap-2">
+                        <input type="text" value={lugar ?? ""} onChange={e => onLugarChange(e.target.value)}
+                          onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); if (debounceRef.current) clearTimeout(debounceRef.current); buscar(); } }}
+                          placeholder="Ej: Edificio Central EGM Atalayas, Alicante"
+                          style={{ ...inputBase, flex: 1 }} onFocus={focusOn} onBlur={focusOff} />
+                        <button type="button" onClick={buscar}
+                          disabled={!lugar.trim() || buscandoMapa}
+                          className="inline-flex items-center gap-1.5 px-3 rounded-lg text-xs font-semibold shrink-0 cursor-pointer disabled:opacity-50"
+                          style={{
+                            background: "var(--gris-superficie)",
+                            border: "1px solid var(--gris-borde)",
+                            color: "var(--texto-secundario)",
+                            transition: "background 0.15s",
+                          }}
+                          onMouseEnter={e => { const el = e.currentTarget as HTMLElement; el.style.background = TAB_COLOR; el.style.color = "#fff"; el.style.borderColor = TAB_COLOR; }}
+                          onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.background = "var(--gris-superficie)"; el.style.color = "var(--texto-secundario)"; el.style.borderColor = "var(--gris-borde)"; }}
+                        >
+                          {buscandoMapa ? <Loader2 size={13} className="animate-spin" /> : <Search size={13} strokeWidth={2} />}
+                          Buscar
+                        </button>
+                      </div>
+
+                      {resultadosMapa.length > 0 && (
+                        <ul className="mt-2 overflow-hidden rounded-xl"
+                          style={{ border: "1px solid var(--gris-borde)" }}>
+                          {resultadosMapa.map((r, i) => (
+                            <li key={i} style={{ borderTop: i > 0 ? "1px solid var(--gris-superficie)" : "none" }}>
+                              <button type="button" onClick={() => seleccionar(r)}
+                                className="w-full text-left px-3 py-2.5 text-xs flex items-start gap-2 cursor-pointer"
+                                style={{ transition: "background 0.1s" }}
+                                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = `${TAB_COLOR}12`; }}
+                                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}>
+                                <MapPin size={12} strokeWidth={2} className="mt-0.5 shrink-0" style={{ color: TAB_COLOR }} />
+                                <span className="line-clamp-2" style={{ color: "var(--texto-primario)" }}>{r.etiqueta}</span>
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      {erroresMapa && (
+                        <p className="mt-1.5 text-xs" style={{ color: "var(--advertencia)" }}>{erroresMapa}</p>
+                      )}
+
+                      {latitud !== null && longitud !== null && (
+                        <div className="mt-3 flex flex-col gap-2">
+                          <div className="flex items-center justify-between">
+                            <span className="text-xs font-semibold inline-flex items-center gap-1"
+                              style={{ color: "var(--exito)" }}>
+                              <Check size={12} strokeWidth={2.5} /> Ubicación seleccionada
+                            </span>
+                            <button type="button" onClick={limpiarUbicacion}
+                              className="text-xs font-semibold cursor-pointer"
+                              style={{ color: "var(--error)" }}>
+                              Quitar
+                            </button>
+                          </div>
+                          <div className="rounded-xl overflow-hidden"
+                            style={{ border: "1px solid var(--gris-borde)" }}>
+                            <MapaUbicacion latitud={latitud} longitud={longitud}
+                              etiqueta={lugar ?? undefined} alturaPx={180} />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Global toggle — solo superadmin */}
+                    {esSuperAdmin && (
+                      <label className="flex items-center gap-3 cursor-pointer p-3.5 rounded-xl"
+                        style={{ background: "var(--gris-panel)", border: "1px solid var(--gris-borde)" }}>
+                        <input type="checkbox" checked={esGlobal}
+                          onChange={e => setEsGlobal(e.target.checked)}
+                          className="w-4 h-4 shrink-0 cursor-pointer"
+                          style={{ accentColor: TAB_COLOR }} />
+                        <Globe2 size={15} strokeWidth={2} style={{ color: TAB_COLOR, flexShrink: 0 }} />
+                        <div className="flex flex-col min-w-0">
+                          <span className="text-sm font-semibold" style={{ color: "var(--texto-primario)" }}>
+                            Evento global EGM
+                          </span>
+                          <span className="text-xs" style={{ color: "var(--texto-muted)" }}>
+                            Visible para todas las empresas
+                          </span>
+                        </div>
+                      </label>
+                    )}
+
+                  </div>
+                </div>
+              )}
             </div>
-            <div>
-              <label className="block text-xs font-semibold text-slate-700 mb-1.5">Fin (opcional)</label>
-              <input
-                type="datetime-local"
-                value={fechaFin}
-                onChange={(e) => setFechaFin(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
-              />
-            </div>
-          </div>
 
-          {/* Ubicación (opcional) */}
-          <div>
-            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
-              Ubicación (opcional)
-            </label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={lugar ?? ""}
-                onChange={(e) => setLugar(e.target.value)}
-                onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); buscar(); } }}
-                placeholder="Ej: Edificio Central EGM Atalayas, Alicante"
-                className="flex-1 px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-blue-500"
-              />
-              <button
-                type="button"
-                onClick={buscar}
-                disabled={!lugar.trim() || buscandoMapa}
-                className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-semibold border border-slate-200 text-slate-700 hover:bg-slate-50 disabled:opacity-50"
-                title="Buscar en el mapa"
-              >
-                {buscandoMapa ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Search className="w-3.5 h-3.5" />}
-                Buscar
-              </button>
-            </div>
-
-            {/* Resultados de búsqueda */}
-            {resultadosMapa.length > 0 && (
-              <ul className="mt-2 border border-slate-200 rounded-lg overflow-hidden divide-y divide-slate-100">
-                {resultadosMapa.map((r, i) => (
-                  <li key={i}>
-                    <button
-                      type="button"
-                      onClick={() => seleccionar(r)}
-                      className="w-full text-left px-3 py-2 text-xs hover:bg-blue-50 flex items-start gap-2"
-                    >
-                      <MapPin className="w-3.5 h-3.5 text-blue-600 mt-0.5 shrink-0" />
-                      <span className="line-clamp-2">{r.etiqueta}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-            {erroresMapa && (
-              <p className="mt-1.5 text-xs text-amber-700">{erroresMapa}</p>
-            )}
-
-            {/* Preview del mapa cuando hay coordenadas */}
-            {latitud !== null && longitud !== null && (
-              <div className="mt-3 space-y-2">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="text-xs text-emerald-700 inline-flex items-center gap-1">
-                    <Check className="w-3 h-3" />
-                    Ubicación seleccionada
+            {/* ── Footer ── */}
+            <div className="flex items-center justify-between gap-3 px-5 sm:px-6 py-4 shrink-0"
+              style={{
+                borderTop: "1px solid rgba(0,0,0,0.07)",
+                background: "var(--blanco)",
+                paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))",
+              }}>
+              <Button type="button" variant="secondary" size="md" onClick={onClose} disabled={enviando}>
+                Cancelar
+              </Button>
+              <div className="flex items-center gap-2">
+                {error && (
+                  <p className="text-xs font-semibold truncate max-w-[140px]"
+                    style={{ color: "var(--error)" }}>
+                    {error}
                   </p>
-                  <button
-                    type="button"
-                    onClick={limpiarUbicacion}
-                    className="text-xs text-red-600 hover:underline"
-                  >
-                    Quitar
-                  </button>
-                </div>
-                <MapaUbicacion
-                  latitud={latitud}
-                  longitud={longitud}
-                  etiqueta={lugar ?? undefined}
-                  alturaPx={180}
-                />
+                )}
+                {activeTab === "informacion" ? (
+                  <Button type="button" variant="primary" size="md" onClick={() => goTab("detalles")}>
+                    Detalles →
+                  </Button>
+                ) : (
+                  <Button type="submit" variant="primary" size="md" disabled={enviando}>
+                    {enviando
+                      ? <><Loader2 size={14} className="animate-spin" /> Guardando…</>
+                      : esNuevo ? "Crear evento" : "Guardar cambios"
+                    }
+                  </Button>
+                )}
               </div>
-            )}
-          </div>
-
-          {/* Global (solo superadmin) */}
-          {esSuperAdmin && (
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={esGlobal}
-                onChange={(e) => setEsGlobal(e.target.checked)}
-                className="w-4 h-4"
-              />
-              <span className="text-sm text-slate-700">
-                Visible para <strong>todas las empresas</strong> (evento global EGM)
-              </span>
-            </label>
-          )}
-
-          {error && (
-            <div className="px-3 py-2 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
-              {error}
             </div>
-          )}
-
-          {/* Acciones */}
-          <div className="flex gap-3 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={enviando}
-              className="px-4 py-2 rounded-xl text-sm font-semibold border border-slate-200 text-slate-600 hover:bg-slate-50"
-            >
-              Cancelar
-            </button>
-            <button
-              type="submit"
-              disabled={enviando}
-              className="flex-1 inline-flex items-center justify-center gap-2 py-2 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50"
-              style={{ background: "var(--azul-egm)", color: "#fff" }}
-            >
-              {enviando ? <Loader2 className="w-4 h-4 animate-spin" /> : <Calendar className="w-4 h-4" />}
-              {esNuevo ? "Crear evento" : "Guardar cambios"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+          </form>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
   );
+
+  if (typeof document === "undefined") return null;
+  return createPortal(content, document.body);
 }

--- a/components/incidencias/IncidenciasAdminTab.tsx
+++ b/components/incidencias/IncidenciasAdminTab.tsx
@@ -16,6 +16,7 @@ import type { Incidencia, IncidenciaInput } from "@/lib/types/incidencias";
 import { AnimatePresence, motion } from "motion/react";
 import {
   AlertTriangle,
+  CircleAlert,
   Clock,
   CheckCircle2,
   ChevronDown,
@@ -30,9 +31,9 @@ const TAB_COLOR = "#B45309";
 
 // ── Paleta de estados ────────────────────────────────────────────────────────
 const ESTADOS = [
-  { value: "ABIERTA",  label: "Abierta",  color: "#dc2626", bg: "#fee2e2", border: "#fca5a5", Icon: AlertTriangle },
-  { value: "EN_CURSO", label: "En curso", color: "#d97706", bg: "#fef3c7", border: "#fcd34d", Icon: Clock        },
-  { value: "CERRADA",  label: "Cerrada",  color: "#16a34a", bg: "#dcfce7", border: "#86efac", Icon: CheckCircle2 },
+  { value: "ABIERTA",  label: "Abierta",  color: "#dc2626", dark: "#991b1b", bg: "#fee2e2", border: "#fca5a5", Icon: CircleAlert },
+  { value: "EN_CURSO", label: "En curso", color: "#d97706", dark: "#92400e", bg: "#fef3c7", border: "#fcd34d", Icon: Clock        },
+  { value: "CERRADA",  label: "Cerrada",  color: "#16a34a", dark: "#14532d", bg: "#dcfce7", border: "#86efac", Icon: CheckCircle2 },
 ] as const;
 
 const PRIORIDADES = [
@@ -66,96 +67,116 @@ const estadoConf = (v: string) => ESTADOS.find(e => e.value === v) ?? ESTADOS[0]
 // ── Skeleton card ─────────────────────────────────────────────────────────────
 function SkeletonCard() {
   return (
-    <div className="rounded-2xl p-5 animate-pulse"
+    <div className="rounded-2xl overflow-hidden animate-pulse flex"
       style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-      <div className="flex items-start gap-4">
-        <div className="rounded-2xl shrink-0" style={{ width: 48, height: 48, background: "var(--gris-borde)" }} />
-        <div className="flex-1 flex flex-col gap-2.5 pt-0.5">
-          <div className="flex gap-2 items-center">
-            <div className="h-4 rounded-full w-48" style={{ background: "var(--gris-borde)" }} />
-            <div className="h-5 rounded-full w-16" style={{ background: "var(--gris-borde)" }} />
+      {/* Acento lateral */}
+      <div style={{ width: 4, flexShrink: 0, background: "var(--gris-borde)" }} />
+      {/* Contenido */}
+      <div className="flex flex-1 items-center gap-3 px-3 sm:px-4 py-3">
+        <div className="rounded-lg shrink-0" style={{ width: 32, height: 32, background: "var(--gris-borde)" }} />
+        <div className="flex-1 flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <div className="h-3.5 rounded-full w-40" style={{ background: "var(--gris-borde)" }} />
+            <div className="h-3.5 rounded-full w-12" style={{ background: "var(--gris-borde)" }} />
           </div>
-          <div className="h-3 rounded-full w-full" style={{ background: "var(--gris-borde)" }} />
-          <div className="h-3 rounded-full w-2/3" style={{ background: "var(--gris-borde)" }} />
-          <div className="flex gap-3 mt-1">
-            <div className="h-3 rounded-full w-28" style={{ background: "var(--gris-borde)" }} />
-            <div className="h-3 rounded-full w-16" style={{ background: "var(--gris-borde)" }} />
-          </div>
+          <div className="h-3 rounded-full w-3/4" style={{ background: "var(--gris-superficie)" }} />
         </div>
-        <div className="rounded-xl shrink-0 h-8 w-28" style={{ background: "var(--gris-borde)" }} />
+        <div className="hidden sm:block rounded-xl shrink-0 h-7 w-28" style={{ background: "var(--gris-borde)" }} />
       </div>
     </div>
   );
 }
 
 // ── Estado selector ───────────────────────────────────────────────────────────
-function EstadoSelector({ incidenciaId, estadoActual, onChange }: {
+function EstadoSelector({ incidenciaId, estadoActual, onChange, matchButtonHeight = false }: {
   incidenciaId: string; estadoActual: string;
   onChange: (id: string, estado: string) => void;
+  matchButtonHeight?: boolean;
 }) {
   const conf = estadoConf(estadoActual);
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0, width: 0 });
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const calcPos = () => {
+    if (!triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    setPos({ top: r.bottom + 5, left: r.left, width: r.width });
+  };
 
   return (
-    <div className="relative shrink-0" ref={ref}>
+    <div className="shrink-0">
       <button
-        onClick={() => setOpen(v => !v)}
-        className="flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-xl"
+        ref={triggerRef}
+        onClick={() => { calcPos(); setOpen(v => !v); }}
+        className={`flex items-center gap-1 font-semibold cursor-pointer ${matchButtonHeight ? "text-sm px-4" : "text-[11px] px-2 rounded-lg"}`}
         style={{
-          background: conf.bg, color: conf.color,
-          border: `1px solid ${conf.border}`,
-          cursor: "pointer", minWidth: 112,
-          justifyContent: "space-between",
-          transition: "opacity 0.15s",
+          height: matchButtonHeight ? 40 : 26,
+          borderRadius: matchButtonHeight ? "var(--radius-btn)" : "7px",
+          background: conf.bg,
+          border: `1px solid ${open ? conf.color : conf.border}`,
+          color: conf.color,
+          transition: "border-color 0.15s",
         }}
       >
-        <span className="flex items-center gap-1.5">
-          <conf.Icon size={11} strokeWidth={2.5} />
-          {conf.label}
-        </span>
-        <ChevronDown size={11} strokeWidth={2.5}
-          style={{ transform: open ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.18s" }} />
+        <conf.Icon size={matchButtonHeight ? 14 : 10} strokeWidth={2.5} />
+        {conf.label}
+        <motion.span
+          animate={{ rotate: open ? 180 : 0 }}
+          transition={{ duration: 0.18 }}
+          style={{ display: "flex", opacity: 0.55 }}
+        >
+          <ChevronDown size={matchButtonHeight ? 14 : 10} strokeWidth={2.5} />
+        </motion.span>
       </button>
 
-      <AnimatePresence>
-        {open && (
-          <>
-            <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-            <motion.div
-              initial={{ opacity: 0, y: -4, scale: 0.97 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -4, scale: 0.97 }}
-              transition={{ duration: 0.14 }}
-              className="absolute right-0 top-full mt-1 z-20 rounded-xl overflow-hidden"
-              style={{
-                background: "var(--blanco)",
-                border: "1px solid var(--gris-borde)",
-                boxShadow: "0 8px 24px rgba(0,0,0,0.10)",
-                minWidth: 130,
-              }}
-            >
-              {ESTADOS.map(e => (
-                <button
-                  key={e.value}
-                  onClick={() => { onChange(incidenciaId, e.value); setOpen(false); }}
-                  className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-semibold text-left"
-                  style={{
-                    color: e.value === estadoActual ? e.color : "var(--texto-primario)",
-                    background: e.value === estadoActual ? e.bg : "transparent",
-                    cursor: "pointer", transition: "background 0.12s",
-                  }}
-                  onMouseEnter={ev => { if (e.value !== estadoActual) (ev.currentTarget as HTMLButtonElement).style.background = "var(--gris-superficie)"; }}
-                  onMouseLeave={ev => { if (e.value !== estadoActual) (ev.currentTarget as HTMLButtonElement).style.background = "transparent"; }}
-                >
-                  <e.Icon size={12} strokeWidth={2.5} />
-                  {e.label}
-                </button>
-              ))}
-            </motion.div>
-          </>
-        )}
-      </AnimatePresence>
+      {typeof document !== "undefined" && createPortal(
+        <AnimatePresence>
+          {open && (
+            <>
+              <div className="fixed inset-0 z-[200]" onClick={() => setOpen(false)} />
+              <motion.div
+                initial={{ opacity: 0, y: -4, scale: 0.97 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: -4, scale: 0.97 }}
+                transition={{ duration: 0.15, ease: "easeOut" }}
+                style={{
+                  position: "fixed",
+                  top: pos.top,
+                  left: pos.left,
+                  minWidth: Math.max(pos.width, 160),
+                  zIndex: 201,
+                  background: "#ffffff",
+                  border: "1px solid rgba(0,0,0,0.10)",
+                  borderRadius: "12px",
+                  boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
+                  overflow: "hidden",
+                }}
+              >
+                {ESTADOS.map(e => (
+                  <button
+                    key={e.value}
+                    onClick={() => { onChange(incidenciaId, e.value); setOpen(false); }}
+                    className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-sm cursor-pointer"
+                    style={{
+                      background: e.value === estadoActual ? `${e.color}12` : "transparent",
+                      color: e.value === estadoActual ? e.color : "var(--texto-primario)",
+                      fontWeight: e.value === estadoActual ? 600 : 400,
+                      transition: "background 0.1s",
+                    }}
+                    onMouseEnter={ev => { if (e.value !== estadoActual) (ev.currentTarget as HTMLButtonElement).style.background = "var(--gris-superficie)"; }}
+                    onMouseLeave={ev => { if (e.value !== estadoActual) (ev.currentTarget as HTMLButtonElement).style.background = "transparent"; }}
+                  >
+                    <e.Icon size={14} strokeWidth={2.2} />
+                    {e.label}
+                  </button>
+                ))}
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>,
+        document.body
+      )}
     </div>
   );
 }
@@ -199,6 +220,10 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
   const [search, setSearch]       = useState("");
   const [errorMut, setErrorMut]   = useState<string | null>(null);
   const [confirmEliminar, setConfirmEliminar] = useState<Incidencia | null>(null);
+  const [detailInc, setDetailInc] = useState<Incidencia | null>(null);
+  const [filtroDropOpen, setFiltroDropOpen] = useState(false);
+  const [filtroDropPos, setFiltroDropPos] = useState({ top: 0, left: 0, width: 0 });
+  const filtroDropRef = useRef<HTMLButtonElement>(null);
 
   // ── Formulario nueva incidencia ───────────────────────────────────────────
   const [showForm, setShowForm]       = useState(false);
@@ -286,14 +311,132 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
 
   const hayFiltrosActivos = search.trim() !== "" || filtro !== "todas";
 
-  // Scroll lock when modal is open
+  // Scroll lock when any modal is open
   useEffect(() => {
-    if (showForm) {
+    if (showForm || !!detailInc) {
       const prev = document.body.style.overflow;
       document.body.style.overflow = "hidden";
       return () => { document.body.style.overflow = prev; };
     }
-  }, [showForm]);
+  }, [showForm, detailInc]);
+
+  // live ref para el modal de detalle (refleja cambios de estado en tiempo real)
+  const liveDetailInc = detailInc
+    ? incidencias.find(i => i.incidenciaId === detailInc.incidenciaId) ?? detailInc
+    : null;
+
+  // ── Modal detalle incidencia (portal) ─────────────────────────────────────
+  const detailModalNode = typeof document !== "undefined" ? createPortal(
+    <AnimatePresence>
+      {liveDetailInc && (() => {
+        const est = estadoConf(liveDetailInc.estado);
+        return (
+          <motion.div
+            key="inc-detail-overlay"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.22 }}
+            className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+            style={{ background: "var(--overlay, rgba(0,0,0,0.45))" }}
+            onMouseDown={e => { if (e.target === e.currentTarget) setDetailInc(null); }}
+          >
+            <motion.div
+              key="inc-detail-panel"
+              initial={{ opacity: 0, y: 28, scale: 0.96 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 16, scale: 0.97 }}
+              transition={{ duration: 0.26, ease: [0.34, 1.15, 0.64, 1] }}
+              className="w-full sm:max-w-lg rounded-t-3xl sm:rounded-2xl flex flex-col overflow-hidden"
+              style={{ maxHeight: "85dvh", background: "var(--gris-panel)", boxShadow: "0 24px 56px rgba(0,0,0,0.18)" }}
+              onMouseDown={e => e.stopPropagation()}
+            >
+              {/* Header plano con color del estado */}
+              <div className="shrink-0 flex items-start justify-between px-5 sm:px-6"
+                style={{ paddingTop: "20px", paddingBottom: "20px", background: est.color }}>
+                <div className="flex-1 min-w-0 pr-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="inline-flex items-center gap-1.5 text-xs font-bold px-2.5 py-1 rounded-full"
+                      style={{ background: "rgba(255,255,255,0.18)", color: "rgba(255,255,255,0.9)", backdropFilter: "blur(4px)" }}>
+                      <est.Icon size={11} strokeWidth={2.5} />
+                      {est.label}
+                    </span>
+                    {liveDetailInc.prioridad === "CRITICA" && (
+                      <span className="inline-flex items-center justify-center rounded-full"
+                        style={{ width: 28, height: 28, background: "rgba(255,255,255,0.18)", color: "rgba(255,255,255,0.9)", backdropFilter: "blur(4px)" }}
+                        title="Prioridad crítica">
+                        <AlertTriangle size={15} strokeWidth={2.5} />
+                      </span>
+                    )}
+                  </div>
+                  <h2 className="text-lg sm:text-xl font-bold leading-snug" style={{ color: "#ffffff" }}>
+                    {liveDetailInc.titulo}
+                  </h2>
+                </div>
+                <div className="shrink-0">
+                  <IconButton onClick={() => setDetailInc(null)} variant="glass" label="Cerrar" />
+                </div>
+              </div>
+
+              {/* Body */}
+              <div className="overflow-y-auto flex-1 px-5 sm:px-6 py-5 flex flex-col gap-3">
+
+                {/* Meta: creador · fecha en una sola línea */}
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  {liveDetailInc.nombreCreador && (
+                    <>
+                      <span className="text-xs" style={{ color: "var(--texto-muted)" }}>Reportado por</span>
+                      <span className="text-xs font-semibold" style={{ color: "var(--texto-secundario)" }}>
+                        {liveDetailInc.nombreCreador}
+                      </span>
+                      <span className="text-xs" style={{ color: "var(--gris-borde)" }}>·</span>
+                    </>
+                  )}
+                  <span className="text-xs" style={{ color: "var(--texto-muted)" }}>
+                    {tiempoRelativo(liveDetailInc.creadoEn) !== formatFecha(liveDetailInc.creadoEn)
+                      ? tiempoRelativo(liveDetailInc.creadoEn)
+                      : formatFecha(liveDetailInc.creadoEn)}
+                  </span>
+                </div>
+
+                {/* Descripción */}
+                <div>
+                  {liveDetailInc.descripcion?.trim() ? (
+                    <p className="text-sm" style={{ color: "var(--texto-primario)", lineHeight: 1.8 }}>
+                      {liveDetailInc.descripcion}
+                    </p>
+                  ) : (
+                    <p className="text-sm italic" style={{ color: "var(--texto-placeholder)" }}>Sin descripción</p>
+                  )}
+                </div>
+              </div>
+
+              {/* Footer: izq cerrar+eliminar · der estado */}
+              <div className="flex items-center justify-between gap-2 px-5 sm:px-6 py-4 shrink-0"
+                style={{ borderTop: "1px solid rgba(0,0,0,0.07)", background: "#ffffff", paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}>
+                <div className="flex items-center gap-2">
+                  <Button variant="secondary" size="md" onClick={() => setDetailInc(null)}>Cerrar</Button>
+                  {!esDemo && (
+                    <Button variant="danger" size="md" onClick={() => { setConfirmEliminar(liveDetailInc); setDetailInc(null); }}>
+                      <Trash2 size={14} strokeWidth={2} />
+                      <span className="hidden sm:inline">Eliminar</span>
+                    </Button>
+                  )}
+                </div>
+                <EstadoSelector
+                  incidenciaId={liveDetailInc.incidenciaId}
+                  estadoActual={liveDetailInc.estado}
+                  onChange={handleEstado}
+                  matchButtonHeight
+                />
+              </div>
+            </motion.div>
+          </motion.div>
+        );
+      })()}
+    </AnimatePresence>,
+    document.body
+  ) : null;
 
   // ── Modal nueva incidencia (portal) ──────────────────────────────────────
   const modalNode = typeof document !== "undefined" ? createPortal(
@@ -316,68 +459,80 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
             exit={{ opacity: 0, y: 16, scale: 0.97 }}
             transition={{ duration: 0.26, ease: [0.34, 1.15, 0.64, 1] }}
             className="w-full sm:max-w-lg rounded-t-3xl sm:rounded-2xl flex flex-col overflow-hidden"
-            style={{ maxHeight: "92dvh", background: "var(--blanco)" }}
+            style={{ maxHeight: "92dvh", background: "var(--gris-panel)", boxShadow: "0 24px 56px rgba(0,0,0,0.18)" }}
             onMouseDown={e => e.stopPropagation()}
           >
-            {/* Header with color */}
-            <div className="relative overflow-hidden shrink-0 flex items-center justify-between px-6 py-5"
-              style={{ background: TAB_COLOR }}>
-              <div className="absolute inset-0 pointer-events-none">
-                <Grainient color1={TAB_COLOR} color2="#92400e" color3="#451a03" />
+            {/* Header */}
+            <div className="relative overflow-hidden shrink-0 flex items-center justify-between px-5 sm:px-6"
+              style={{ paddingTop: "20px", paddingBottom: "20px", background: "#C8782A" }}>
+              <div className="absolute inset-0">
+                <Grainient
+                  color1="#C8782A" color2="#B45309" color3="#7C3A0E"
+                  timeSpeed={0.18} warpStrength={1.1} warpFrequency={4.0}
+                  warpSpeed={1.4} warpAmplitude={55} grainAmount={0.07}
+                />
               </div>
+              <h2 className="relative z-10" style={{
+                fontFamily: "var(--font-raleway), sans-serif",
+                fontWeight: 800,
+                fontSize: "clamp(1.4rem, 4vw, 1.8rem)",
+                lineHeight: 1.1,
+                letterSpacing: "-0.03em",
+                color: "#ffffff",
+                margin: 0,
+              }}>
+                Nueva incidencia
+              </h2>
               <div className="relative z-10">
-                <h2 className="text-base font-bold text-white" style={{ letterSpacing: "-0.01em" }}>
-                  Nueva incidencia
-                </h2>
-                <p className="text-xs mt-0.5" style={{ color: "rgba(255,255,255,0.72)" }}>
-                  Rellena los datos y pulsa crear
-                </p>
-              </div>
-              <div className="relative z-10">
-                <IconButton onClick={closeForm} variant="glass" label="Cerrar">
-                  <X size={16} strokeWidth={2.5} />
-                </IconButton>
+                <IconButton onClick={closeForm} variant="glass" label="Cerrar" />
               </div>
             </div>
 
             {/* Form body — scrollable */}
-            <div className="overflow-y-auto flex-1 px-6 py-5 flex flex-col gap-4">
+            <div className="overflow-y-auto flex-1 px-5 sm:px-6 py-5 flex flex-col gap-4">
               {/* Título */}
               <div>
-                <label className="text-xs font-semibold mb-1.5 block" style={{ color: "var(--texto-label)" }}>
-                  Título <span style={{ color: "#ef4444" }}>*</span>
+                <label className="text-sm font-semibold mb-1.5 block" style={{ color: "var(--texto-label)" }}>
+                  Título
+                  <span className="relative group ml-0.5 inline-block" style={{ color: "#ef4444" }}>
+                    *
+                    <span className="pointer-events-none absolute top-full left-1/2 -translate-x-1/2 mt-1.5 px-2 py-1 rounded-lg text-xs font-semibold whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+                      style={{ background: "#1f2937", color: "#fff", boxShadow: "0 2px 8px rgba(0,0,0,0.18)", zIndex: 99 }}>
+                      Obligatorio
+                    </span>
+                  </span>
                 </label>
                 <input
                   value={formTitulo}
                   onChange={e => setFormTitulo(e.target.value)}
                   placeholder="Describe brevemente el problema…"
                   autoFocus
-                  className="w-full rounded-xl text-sm px-3.5 outline-none border transition-all"
-                  style={{ height: 42, borderColor: "var(--gris-borde)", background: "#fff", color: "var(--texto-primario)" }}
-                  onFocus={e => e.currentTarget.style.borderColor = TAB_COLOR}
-                  onBlur={e => e.currentTarget.style.borderColor = "var(--gris-borde)"}
+                  className="w-full rounded-lg text-sm px-3.5 outline-none border transition-all"
+                  style={{ height: 44, borderColor: "rgba(0,0,0,0.12)", background: "#fff", color: "var(--texto-primario)" }}
+                  onFocus={e => { e.currentTarget.style.borderColor = TAB_COLOR; e.currentTarget.style.boxShadow = `0 0 0 3px ${TAB_COLOR}22`; }}
+                  onBlur={e => { e.currentTarget.style.borderColor = "rgba(0,0,0,0.12)"; e.currentTarget.style.boxShadow = "none"; }}
                   onKeyDown={e => e.key === "Enter" && handleCrear()}
                 />
               </div>
 
               {/* Descripción */}
               <div>
-                <label className="text-xs font-semibold mb-1.5 block" style={{ color: "var(--texto-label)" }}>Descripción</label>
+                <label className="text-sm font-semibold mb-1.5 block" style={{ color: "var(--texto-label)" }}>Descripción</label>
                 <textarea
                   value={formDesc}
                   onChange={e => setFormDesc(e.target.value)}
                   placeholder="Explica con más detalle qué ocurre, cuándo y a quién afecta…"
                   rows={4}
-                  className="w-full rounded-xl text-sm px-3.5 py-2.5 outline-none border transition-all resize-none"
-                  style={{ borderColor: "var(--gris-borde)", background: "#fff", color: "var(--texto-primario)", lineHeight: 1.6 }}
-                  onFocus={e => e.currentTarget.style.borderColor = TAB_COLOR}
-                  onBlur={e => e.currentTarget.style.borderColor = "var(--gris-borde)"}
+                  className="w-full rounded-lg text-sm px-3.5 py-2.5 outline-none border transition-all resize-none"
+                  style={{ borderColor: "rgba(0,0,0,0.12)", background: "#fff", color: "var(--texto-primario)", lineHeight: 1.6 }}
+                  onFocus={e => { e.currentTarget.style.borderColor = TAB_COLOR; e.currentTarget.style.boxShadow = `0 0 0 3px ${TAB_COLOR}22`; }}
+                  onBlur={e => { e.currentTarget.style.borderColor = "rgba(0,0,0,0.12)"; e.currentTarget.style.boxShadow = "none"; }}
                 />
               </div>
 
               {/* Prioridad */}
               <div>
-                <label className="text-xs font-semibold mb-2 block" style={{ color: "var(--texto-label)" }}>Prioridad</label>
+                <label className="text-sm font-semibold mb-2 block" style={{ color: "var(--texto-label)" }}>Prioridad</label>
                 <div className="flex gap-2">
                   {PRIORIDADES.map(p => (
                     <button
@@ -406,30 +561,32 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
 
               {/* Error */}
               {formError && (
-                <p className="text-xs font-semibold" style={{ color: "#dc2626" }}>{formError}</p>
+                <p className="text-xs font-semibold px-3 py-2 rounded-lg" style={{ background: "rgba(239,68,68,0.07)", color: "var(--error)" }}>
+                  {formError}
+                </p>
               )}
             </div>
 
             {/* Footer */}
-            <div className="shrink-0 px-6 py-4 flex justify-end gap-3"
-              style={{ borderTop: "1px solid var(--gris-borde)" }}>
-              <button
+            <div className="flex flex-col sm:flex-row sm:justify-between gap-2.5 px-5 sm:px-6 py-4 shrink-0"
+              style={{ borderTop: "1px solid rgba(0,0,0,0.07)", background: "#ffffff", paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}>
+              <Button
                 type="button"
+                variant="secondary"
+                className="w-full sm:w-auto order-2 sm:order-1"
                 onClick={closeForm}
-                className="text-sm font-semibold px-5 py-2.5 rounded-xl transition-colors"
-                style={{ background: "var(--gris-superficie)", color: "var(--texto-primario)", border: "1px solid var(--gris-borde)", cursor: "pointer" }}
+                disabled={guardando}
               >
                 Cancelar
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                className="w-full sm:w-auto order-1 sm:order-2"
                 onClick={handleCrear}
-                disabled={guardando}
-                className="flex items-center gap-2 text-sm font-semibold px-5 py-2.5 rounded-xl transition-opacity"
-                style={{ background: TAB_COLOR, color: "#fff", cursor: guardando ? "not-allowed" : "pointer", opacity: guardando ? 0.7 : 1 }}
+                disabled={guardando || !formTitulo.trim()}
               >
                 {guardando ? "Creando…" : "Crear incidencia"}
-              </button>
+              </Button>
             </div>
           </motion.div>
         </motion.div>
@@ -441,9 +598,10 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
   return (
     <div>
       {modalNode}
+      {detailModalNode}
 
       {/* ── Título ── */}
-      <div className="mb-6 sm:mb-8">
+      <div className="mb-8 text-center sm:text-left">
         <h1 style={{
           fontFamily: "var(--font-raleway), sans-serif", fontWeight: 800,
           fontSize: "clamp(1.6rem, 2.5vw, 2.2rem)", color: "var(--texto-primario)",
@@ -546,7 +704,7 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
           </Button>
         </div>
 
-        {/* Móvil: buscador + botón en fila, pills debajo */}
+        {/* Móvil: buscador + botón, dropdown de filtro debajo */}
         <div className="flex flex-col gap-2 sm:hidden">
           <div className="flex gap-2">
             <div className="relative flex-1">
@@ -561,30 +719,76 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
               <Plus size={14} />
             </Button>
           </div>
-          <div className="overflow-x-auto pb-1" style={{ scrollbarWidth: "none" }}>
-            <div className="flex gap-1 p-1 rounded-xl w-fit" style={{ background: "var(--gris-superficie)", border: "1px solid var(--gris-borde)" }}>
-              {["todas", ...ESTADOS.map(e => e.value)].map(v => {
-                const est = v === "todas" ? null : ESTADOS.find(e => e.value === v)!;
-                const isActive = filtro === v;
-                return (
-                  <motion.button key={v}
-                    onClick={() => setFiltro(v === filtro && v !== "todas" ? "todas" : v)}
-                    className="relative text-xs font-semibold px-3 py-1.5 rounded-lg focus:outline-none cursor-pointer whitespace-nowrap"
-                    style={{ color: isActive ? (est ? est.color : "#fff") : "var(--texto-muted)", zIndex: 1, border: "none", background: "transparent" }}
-                    whileTap={{ scale: 0.94 }}>
-                    <AnimatePresence>
-                      {isActive && (
-                        <motion.span key="bg" initial={{ opacity: 0, scale: 0.85 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.85 }}
-                          className="absolute inset-0 rounded-lg"
-                          style={{ background: est ? est.bg : TAB_COLOR, border: est ? `1px solid ${est.border}` : "none", zIndex: -1 }} />
-                      )}
-                    </AnimatePresence>
-                    {v === "todas" ? "Todas" : est!.label}
-                  </motion.button>
-                );
-              })}
-            </div>
-          </div>
+          {/* Dropdown filtro estado — portal, igual que "Todos los tipos" en Documentos */}
+          {(() => {
+            const activo = filtro !== "todas" ? ESTADOS.find(e => e.value === filtro) : null;
+            return (
+              <>
+                <button
+                  ref={filtroDropRef}
+                  onClick={() => {
+                    if (!filtroDropOpen && filtroDropRef.current) {
+                      const r = filtroDropRef.current.getBoundingClientRect();
+                      setFiltroDropPos({ top: r.bottom + 5, left: r.left, width: r.width });
+                    }
+                    setFiltroDropOpen(v => !v);
+                  }}
+                  className="flex items-center justify-between w-full px-3.5 py-2.5 text-sm font-semibold rounded-xl cursor-pointer"
+                  style={{
+                    background: "var(--blanco)",
+                    border: `1.5px solid ${activo ? activo.border : "var(--gris-borde)"}`,
+                    color: activo ? activo.color : "var(--texto-primario)",
+                    transition: "border-color 0.15s",
+                  }}
+                >
+                  <span className="flex items-center gap-2">
+                    {activo && <activo.Icon size={13} strokeWidth={2.3} />}
+                    {activo ? activo.label : "Todos los estados"}
+                  </span>
+                  <ChevronDown size={14} strokeWidth={2.3} style={{ color: "var(--texto-muted)", transform: filtroDropOpen ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.15s" }} />
+                </button>
+                {filtroDropOpen && createPortal(
+                  <>
+                    <div className="fixed inset-0 z-[9998]" onClick={() => setFiltroDropOpen(false)} />
+                    <div
+                      className="fixed z-[9999] rounded-xl overflow-hidden"
+                      style={{
+                        top: filtroDropPos.top,
+                        left: filtroDropPos.left,
+                        minWidth: Math.max(filtroDropPos.width, 180),
+                        background: "var(--blanco)",
+                        border: "1px solid var(--gris-borde)",
+                        boxShadow: "0 8px 24px rgba(0,0,0,0.13)",
+                      }}
+                    >
+                      {[{ value: "todas", label: "Todos los estados", Icon: null as any, color: "var(--texto-primario)", bg: "transparent" },
+                        ...ESTADOS].map(opt => {
+                        const isSelected = filtro === opt.value;
+                        return (
+                          <button
+                            key={opt.value}
+                            onClick={() => { setFiltro(opt.value); setFiltroDropOpen(false); }}
+                            className="flex items-center gap-2 w-full px-4 py-2.5 text-sm font-semibold cursor-pointer text-left"
+                            style={{
+                              color: isSelected ? opt.color : "var(--texto-primario)",
+                              background: isSelected ? (("bg" in opt && opt.bg !== "transparent") ? opt.bg : "var(--gris-superficie)") : "transparent",
+                              transition: "background 0.1s",
+                            }}
+                            onMouseEnter={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = "var(--gris-superficie)"; }}
+                            onMouseLeave={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = "transparent"; }}
+                          >
+                            {opt.Icon && <opt.Icon size={13} strokeWidth={2.3} style={{ color: opt.color }} />}
+                            {opt.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </>,
+                  document.body
+                )}
+              </>
+            );
+          })()}
         </div>
       </div>
 
@@ -604,8 +808,8 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
 
       {/* ── Contenido ── */}
       {cargando ? (
-        <div className="flex flex-col gap-3">
-          {[0, 1, 2].map(i => <SkeletonCard key={i} />)}
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
+          {[0, 1, 2, 3, 4, 5].map(i => <SkeletonCard key={i} />)}
         </div>
 
       ) : isError ? (
@@ -626,22 +830,28 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
         </div>
 
       ) : filtradas.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20 gap-5 rounded-2xl text-center"
-          style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}>
-          <div className="rounded-2xl p-5" style={{ background: "var(--gris-superficie)" }}>
-            <AlertTriangle size={32} strokeWidth={1.4} style={{ color: "var(--texto-muted)" }} />
+        <div className="card flex flex-col items-center justify-center py-16 text-center gap-4">
+          <div className="flex items-center justify-center rounded-full"
+            style={{ width: 72, height: 72, background: "var(--gris-superficie)", color: "var(--texto-muted)" }}>
+            {search || filtro !== "todas"
+              ? <Search size={28} strokeWidth={1.4} />
+              : <AlertTriangle size={28} strokeWidth={1.4} />}
           </div>
           <div>
-            <p className="font-bold text-base" style={{ color: "var(--texto-primario)" }}>
+            <p className="text-lg font-bold mb-1.5" style={{ color: "var(--texto-primario)" }}>
               {search ? "Sin resultados" : filtro === "todas" ? "Todavía no hay incidencias" : `Sin incidencias ${ESTADOS.find(e => e.value === filtro)?.label.toLowerCase()}`}
             </p>
-            <p className="text-sm mt-1" style={{ color: "var(--texto-muted)", maxWidth: 280, margin: "4px auto 0" }}>
-              {search ? `No hay incidencias que coincidan con "${search}"` : filtro === "todas" ? "Los empleados aún no han reportado ninguna" : "Prueba a cambiar el filtro"}
+            <p className="text-sm" style={{ color: "var(--texto-muted)", maxWidth: 320, margin: "0 auto" }}>
+              {search
+                ? <>No hay incidencias que coincidan con <span className="font-semibold" style={{ color: "var(--texto-primario)" }}>"{search}"</span></>
+                : filtro === "todas"
+                  ? "Los empleados aún no han reportado ninguna incidencia."
+                  : "Prueba a cambiar el filtro de estado."}
             </p>
           </div>
           {(search || filtro !== "todas") && (
             <button onClick={() => { setSearch(""); setFiltro("todas"); }}
-              className="text-sm font-semibold px-5 py-2.5 rounded-xl"
+              className="text-sm font-semibold px-5 py-2.5 rounded-xl mt-1"
               style={{ background: "var(--azul-egm)", color: "white", cursor: "pointer" }}>
               Ver todas
             </button>
@@ -649,8 +859,9 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
         </div>
 
       ) : (
-        <div className="flex flex-col gap-3">
-          {filtradas.map(inc => {
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2">
+          <AnimatePresence initial={false}>
+          {filtradas.map((inc, idx) => {
             const est       = estadoConf(inc.estado);
             const esCritica = inc.prioridad === "CRITICA";
 
@@ -658,113 +869,82 @@ export default function IncidenciasAdminTab({ empresaId, esSuperadmin }: Props) 
               <motion.div
                 key={inc.incidenciaId}
                 layout
-                initial={{ opacity: 0, y: 6 }}
+                initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.97 }}
-                transition={{ duration: 0.18 }}
-                className="group rounded-2xl overflow-hidden"
+                transition={{ duration: 0.2, ease: "easeOut", delay: idx * 0.03 }}
+                className="flex rounded-2xl"
                 style={{
                   background: "var(--blanco)",
                   border: "1px solid var(--gris-borde)",
-                  transition: "box-shadow 0.18s",
+                  borderLeft: `3px solid ${est.color}`,
+                  boxShadow: "0 1px 3px rgba(0,0,0,0.04)",
+                  transition: "box-shadow 0.2s ease",
+                  overflow: "visible",
+                  position: "relative",
                 }}
-                onMouseEnter={e => (e.currentTarget as HTMLDivElement).style.boxShadow = "0 4px 18px rgba(0,0,0,0.07)"}
-                onMouseLeave={e => (e.currentTarget as HTMLDivElement).style.boxShadow = "none"}
+                onMouseEnter={e => { e.currentTarget.style.boxShadow = "0 4px 16px rgba(0,0,0,0.09)"; }}
+                onMouseLeave={e => { e.currentTarget.style.boxShadow = "0 1px 3px rgba(0,0,0,0.04)"; }}
               >
-                <div className="flex items-start gap-4 px-5 pt-4 pb-3">
-                  {/* Icono estado */}
-                  <div className="rounded-2xl shrink-0 flex items-center justify-center"
-                    style={{ width: 48, height: 48, background: est.bg, color: est.color, border: `1px solid ${est.border}`, marginTop: 1 }}>
-                    <est.Icon size={20} strokeWidth={2} />
+                {/* Contenido principal */}
+                <div className="flex flex-1 items-center gap-3 px-3 sm:px-4 py-3 min-w-0 cursor-pointer" onClick={() => setDetailInc(inc)}>
+
+                  {/* Icono estado + indicador crítica */}
+                  <div className="relative shrink-0" style={{ width: 36, height: 36 }}>
+                    <div className="flex items-center justify-center rounded-xl w-full h-full"
+                      style={{ background: est.bg }}>
+                      <est.Icon size={17} strokeWidth={2.2} style={{ color: est.color }} />
+                    </div>
+                    {esCritica && (
+                      <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center rounded-full"
+                        style={{ width: 17, height: 17, background: "#dc2626", boxShadow: "0 0 0 2px var(--blanco)" }}
+                        title="Prioridad crítica">
+                        <AlertTriangle size={9} strokeWidth={2.8} style={{ color: "#fff" }} />
+                      </span>
+                    )}
                   </div>
 
-                  {/* Contenido */}
+                  {/* Texto */}
                   <div className="flex-1 min-w-0">
-                    <div className="flex flex-wrap items-center gap-2 mb-1.5">
-                      <span className="font-bold text-sm leading-snug" style={{ color: "var(--texto-primario)" }}>
+                    {/* Fila superior: título + fecha */}
+                    <div className="flex items-start justify-between gap-2 min-w-0">
+                      <span className="font-semibold text-sm line-clamp-1 leading-snug"
+                        style={{ color: "var(--texto-primario)" }}>
                         {inc.titulo}
                       </span>
-                      {esCritica && (
-                        <span className="inline-flex items-center gap-1 text-[10px] font-bold px-2 py-0.5 rounded-full shrink-0"
-                          style={{ background: "#fee2e2", color: "#dc2626", border: "1px solid #fca5a5" }}>
-                          <AlertTriangle size={9} strokeWidth={2.5} />
-                          Crítica
+                      <span className="text-[11px] shrink-0 font-medium whitespace-nowrap"
+                        style={{ color: "var(--texto-muted)" }}
+                        title={formatFecha(inc.creadoEn)}>
+                        {tiempoRelativo(inc.creadoEn)}
+                      </span>
+                    </div>
+                    {/* Fila inferior: descripción + empresa */}
+                    <div className="flex items-center gap-1.5 mt-0.5 min-w-0">
+                      {inc.descripcion?.trim() ? (
+                        <span className="text-[11px] truncate" style={{ color: "var(--texto-muted)" }}>
+                          {inc.descripcion.trim()}
                         </span>
+                      ) : (
+                        <span className="text-[11px] italic" style={{ color: "var(--texto-placeholder)" }}>Sin descripción</span>
+                      )}
+                      {esSuperadmin && inc.nombreEmpresa && (
+                        <>
+                          <span className="text-[11px] shrink-0" style={{ color: "var(--gris-borde)" }}>·</span>
+                          <span className="text-[11px] font-semibold shrink-0" style={{ color: "var(--texto-muted)" }}>
+                            {inc.nombreEmpresa}
+                          </span>
+                        </>
                       )}
                     </div>
-                    {inc.descripcion && (
-                      <p className="text-xs line-clamp-2" style={{ color: "#6b7280", lineHeight: 1.65 }}>
-                        {inc.descripcion}
-                      </p>
-                    )}
                   </div>
 
-                  {/* Acciones — desktop */}
-                  <div className="hidden sm:flex items-center gap-2 shrink-0">
-                    <EstadoSelector
-                      incidenciaId={inc.incidenciaId}
-                      estadoActual={inc.estado}
-                      onChange={handleEstado}
-                    />
-                    {!esDemo && (
-                      <motion.button
-                        onClick={() => setConfirmEliminar(inc)}
-                        whileTap={{ scale: 0.88 }}
-                        className="opacity-0 group-hover:opacity-100 flex items-center justify-center shrink-0 cursor-pointer"
-                        style={{ width: 32, height: 32, borderRadius: "50%", background: "var(--error-light)", color: "var(--error)", border: "1px solid rgba(220,38,38,0.15)", transition: "background 0.15s ease, border-color 0.15s ease, box-shadow 0.18s var(--ease-spring), opacity 0.15s" }}
-                        title="Eliminar incidencia"
-                        onMouseEnter={e => { const el = e.currentTarget as HTMLElement; el.style.background = "var(--error)"; el.style.color = "#fff"; el.style.borderColor = "var(--error)"; el.style.boxShadow = "0 4px 14px rgba(220,38,38,0.35), 0 0 0 3px rgba(220,38,38,0.15)"; }}
-                        onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.background = "var(--error-light)"; el.style.color = "var(--error)"; el.style.borderColor = "rgba(220,38,38,0.15)"; el.style.boxShadow = "none"; }}
-                      >
-                        <Trash2 size={13} strokeWidth={2} />
-                      </motion.button>
-                    )}
-                  </div>
-                </div>
-
-                {/* Meta row */}
-                <div className="flex items-center justify-between gap-3 px-5 pb-4">
-                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px]" style={{ color: "#9ca3af" }}>
-                    {inc.nombreCreador && (
-                      <span>
-                        <strong style={{ color: "var(--texto-primario)", fontWeight: 600 }}>{inc.nombreCreador}</strong>
-                      </span>
-                    )}
-                    {esSuperadmin && inc.nombreEmpresa && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold"
-                        style={{ background: "var(--gris-superficie)", color: "var(--texto-muted)", border: "1px solid var(--gris-borde)" }}>
-                        {inc.nombreEmpresa}
-                      </span>
-                    )}
-                    <span title={formatFecha(inc.creadoEn)} style={{ color: "#9ca3af" }}>
-                      {tiempoRelativo(inc.creadoEn)}
-                    </span>
-                  </div>
-
-                  {/* Acciones — móvil */}
-                  <div className="sm:hidden flex items-center gap-2 shrink-0">
-                    <EstadoSelector
-                      incidenciaId={inc.incidenciaId}
-                      estadoActual={inc.estado}
-                      onChange={handleEstado}
-                    />
-                    {!esDemo && (
-                      <motion.button
-                        onClick={() => setConfirmEliminar(inc)}
-                        whileTap={{ scale: 0.88 }}
-                        className="flex items-center justify-center shrink-0 cursor-pointer"
-                        style={{ width: 32, height: 32, borderRadius: "50%", background: "var(--error-light)", color: "var(--error)", border: "1px solid rgba(220,38,38,0.15)", transition: "background 0.15s ease, border-color 0.15s ease, box-shadow 0.18s var(--ease-spring)" }}
-                        onMouseEnter={e => { const el = e.currentTarget as HTMLElement; el.style.background = "var(--error)"; el.style.color = "#fff"; el.style.borderColor = "var(--error)"; el.style.boxShadow = "0 4px 14px rgba(220,38,38,0.35), 0 0 0 3px rgba(220,38,38,0.15)"; }}
-                        onMouseLeave={e => { const el = e.currentTarget as HTMLElement; el.style.background = "var(--error-light)"; el.style.color = "var(--error)"; el.style.borderColor = "rgba(220,38,38,0.15)"; el.style.boxShadow = "none"; }}
-                      >
-                        <Trash2 size={13} strokeWidth={2} />
-                      </motion.button>
-                    )}
-                  </div>
+                  {/* Indicador visual de que hay detalle */}
+                  <ChevronDown size={13} strokeWidth={2} style={{ color: "var(--texto-muted)", transform: "rotate(-90deg)", opacity: 0.4, flexShrink: 0 }} />
                 </div>
               </motion.div>
             );
           })}
+          </AnimatePresence>
         </div>
       )}
 

--- a/components/ui/ChatbotIA.tsx
+++ b/components/ui/ChatbotIA.tsx
@@ -336,6 +336,16 @@ function MessageBubble({ message, isStreaming, animate = true }: { message: Mess
 export default function ChatbotIA() {
   const { usuario } = useAuth()
   const [open, setOpen] = useState(false)
+  const [modalAbierto, setModalAbierto] = useState(false)
+
+  // Ocultarse cuando cualquier modal está abierto (body overflow: hidden)
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setModalAbierto(document.body.style.overflow === "hidden")
+    })
+    observer.observe(document.body, { attributes: true, attributeFilter: ["style"] })
+    return () => observer.disconnect()
+  }, [])
   const initialMessageIds = useRef<Set<string>>(new Set())
 
   const [messages, setMessages] = useState<Message[]>(() => {
@@ -742,6 +752,8 @@ export default function ChatbotIA() {
         width: `${PANEL_W}px`,
         height: `min(${PANEL_H}px, calc(100dvh - 120px))`,
       }
+
+  if (modalAbierto) return null
 
   return (
     <>

--- a/components/ui/FormAnuncio.tsx
+++ b/components/ui/FormAnuncio.tsx
@@ -540,7 +540,7 @@ export default function FormAnuncio({
         transition={{ duration: 0.26, ease: [0.32, 0.72, 0, 1] }}
         className="relative w-full sm:max-w-2xl rounded-t-3xl sm:rounded-2xl flex flex-col overflow-hidden"
         style={{
-          background: "var(--blanco)",
+          background: "var(--gris-panel)",
           boxShadow: "0 24px 80px rgba(0,0,0,0.22), 0 2px 8px rgba(0,0,0,0.08)",
           maxHeight: "92dvh",
           isolation: "isolate",
@@ -638,7 +638,7 @@ export default function FormAnuncio({
         </div>
 
         {/* Cuerpo con scroll */}
-        <div className="overflow-y-auto" style={{ background: "var(--blanco)" }}>
+        <div className="overflow-y-auto" style={{ background: "var(--gris-panel)" }}>
 
           {/* TAB: Contenido */}
           <div style={{ display: tab === "contenido" ? "block" : "none" }}>
@@ -1007,13 +1007,13 @@ export default function FormAnuncio({
         {/* Footer fijo */}
         <div className="px-6 py-4 flex items-center justify-between gap-3 shrink-0"
           style={{ borderTop: "1px solid var(--gris-borde)", background: "var(--blanco)" }}>
-          <div className="flex-1 min-w-0">
-            {errorMsg && <p className="text-sm truncate" style={{ color: "var(--error)" }}>{errorMsg}</p>}
-          </div>
           <div className="flex items-center gap-2 shrink-0">
             <Button variant="secondary" size="md" onClick={handleRequestClose}>
               Cancelar
             </Button>
+            {errorMsg && <p className="text-sm truncate max-w-[160px]" style={{ color: "var(--error)" }}>{errorMsg}</p>}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
             {editando && editando.estado === "borrador" && (
               <Button
                 variant="ghost" size="md"
@@ -1048,6 +1048,7 @@ export default function FormAnuncio({
           </div>
         </div>
       </motion.div>
+
     </motion.div>
     </AnimatePresence>
 

--- a/components/ui/FormEmpleado.tsx
+++ b/components/ui/FormEmpleado.tsx
@@ -80,7 +80,15 @@ export default function FormEmpleado({
             />
           </div>
           <div className="relative z-10 flex flex-col gap-0.5">
-            <h2 className="text-2xl font-bold" style={{ color: "#ffffff" }}>Añadir empleado</h2>
+            <h2 style={{
+              fontFamily: "var(--font-raleway), sans-serif",
+              fontWeight: 800,
+              fontSize: "clamp(1.4rem, 4vw, 1.8rem)",
+              lineHeight: 1.1,
+              letterSpacing: "-0.03em",
+              color: "#ffffff",
+              margin: 0,
+            }}>Añadir empleado</h2>
             <p className="text-sm" style={{ color: "rgba(255,255,255,0.65)" }}>Crea una cuenta para un nuevo miembro</p>
           </div>
           <div className="relative z-10">


### PR DESCRIPTION
Eventos:
- Rediseño completo de tarjetas: vertical estilo AnuncioCard con cabecera gradiente teal/gris, fecha destacada (día+mes+año), imagen de portada, badges flotantes
- Grid 4 columnas (1→2→3→4 responsive)
- Filtro Todos/Próximos/Finalizados con pills animadas (desktop) y dropdown portal (móvil)
- Toolbar móvil alineado con incidencias: buscador + botón + dropdown
- Botones footer Editar + Desactivar al 50% como anuncios
- Cabecera ModalEvento y FormEmpleado con fuente Raleway 800
- ModalEvento: borderRadius unificado a var(--radius-lg), cursor pointer en datetime, auto-búsqueda ubicación con debounce 900ms, zona upload imagen rediseñada con drag & drop, botones Cambiar/Quitar con motion y hover

Formularios:
- Todos los inputs alineados: rounded-lg (var(--radius-lg)=16px), height 44px, border rgba(0,0,0,0.12), focus box-shadow
- Fondo body formularios: var(--gris-panel)
- Asteriscos * con tooltip Obligatorio en IncidenciasAdminTab y FormAnuncio
- Datetime-local con min bloqueando fechas pasadas

Tabs admin:
- Nuevo orden: Empleados → Incidencias → Anuncios → Eventos → Módulos → Documentos → Estadísticas
- Títulos/subtítulos: mb-8 text-center sm:text-left en todos los tabs
- CSS variable --tab-eventos: #0F766E añadida a globals.css

ChatbotIA: render guard if (modalAbierto) return null