### PR TITLE
fix(invitado): imagen circulos webp y z-index footer CTA

### DIFF
--- a/components/pages/Invitado.tsx
+++ b/components/pages/Invitado.tsx
@@ -487,7 +487,7 @@ export default function Invitado() {
         {/* Imagen decorativa pegada al borde derecho */}
         <div className="hidden lg:block absolute right-0 top-0 bottom-0 pointer-events-none select-none" style={{ width: 500 }}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/circulos-decoracion.png" alt="" aria-hidden
+          <img src="/circulos-decoracion.webp" alt="" aria-hidden
             className="absolute right-0 top-1/2 -translate-y-1/2"
             style={{ width: 500, opacity: 1, filter: "invert(18%) sepia(60%) saturate(800%) hue-rotate(200deg) brightness(60%)" }} />
         </div>

--- a/components/ui/FooterCTA.tsx
+++ b/components/ui/FooterCTA.tsx
@@ -119,7 +119,7 @@ export default function FooterCTA() {
 
       {/* Fade superior — mezcla con sección anterior */}
       <div
-        className="absolute top-0 left-0 right-0 h-40 pointer-events-none z-[50]"
+        className="absolute top-0 left-0 right-0 h-40 pointer-events-none z-[1]"
         style={{ background: "linear-gradient(to bottom, #0a0a0f, transparent)" }}
       />
 


### PR DESCRIPTION
- Corregir ruta circulos-decoracion.png a .webp en seccion Comunidad
- Bajar z-index del fade superior del FooterCTA para no tapar el header