### PR TITLE
feat(formacion): rediseno con paleta unificada y CourseCard extraido

### DIFF
--- a/app/dashboard/formacion/page.tsx
+++ b/app/dashboard/formacion/page.tsx
@@ -9,35 +9,10 @@ import { MODULO_TIPO_LABEL } from "@/lib/types/modulos";
 import DashboardHero from "@/components/ui/DashboardHero";
 import { descargarCertificado } from "@/lib/certificado";
 import { obtenerCertificadoModulo } from "@/lib/api/documentos";
+import { CourseCard } from "@/components/formacion/CourseCard";
+import { TIPO_GRADIENT, getFormacionImg, type ModuloEnriquecido } from "@/lib/formacion-helpers";
 
 // Gradientes por tipo de módulo para las miniaturas (fallback)
-const TIPO_GRADIENT: Record<string, string> = {
-  IDENTIDAD: "linear-gradient(135deg, #1B3F7E 0%, #2A5298 100%)",
-  BASICA: "linear-gradient(135deg, #0D1B2E 0%, #1B3F7E 100%)",
-  ESPECIFICA: "linear-gradient(135deg, #8B9A2D 0%, #A3B535 100%)",
-  DESARROLLO: "linear-gradient(135deg, #1e3a5f 0%, #3b82f6 100%)",
-  RECOMPENSAS: "linear-gradient(135deg, #7c3aed 0%, #a78bfa 100%)",
-  COMUNIDAD: "linear-gradient(135deg, #0f766e 0%, #2dd4bf 100%)",
-};
-
-const FORMACION_IMG_BY_NAME: Array<{ keywords: string[]; imagen: string }> = [
-  { keywords: ["incorporac", "bienvenid"], imagen: "/background-formacion-empleado.webp" },
-  { keywords: ["comunicac", "efectiva"], imagen: "/comunicacion-trabajo.webp" },
-  { keywords: ["herramienta", "digital", "colaborat"], imagen: "/herramientas-digitales.webp" },
-  { keywords: ["negociaci", "habilidad", "directiv"], imagen: "/negociacion-habilidades.webp" },
-  { keywords: ["cibersegur", "datos", "rgpd"], imagen: "/ciberseguridad-datos.webp" },
-  { keywords: ["metodolog", "agil", "scrum", "kanban"], imagen: "/metodologias-agiles.webp" },
-  { keywords: ["diversidad", "inclusi"], imagen: "/diversidad.webp" },
-];
-
-function getFormacionImg(_moduloId: string, nombre: string, imagenPortadaUrl?: string | null): string | undefined {
-  if (imagenPortadaUrl) return imagenPortadaUrl;
-  const lower = nombre.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-  return FORMACION_IMG_BY_NAME.find((e) => e.keywords.some((kw) => lower.includes(kw)))?.imagen;
-}
-
-type ModuloEnriquecido = ModuloConProgreso & { duracion: string; porcentaje: number };
-
 function leerPorcentajeLS(moduloId: string, esAdmin: boolean): number | null {
   try {
     const raw = localStorage.getItem(esAdmin ? `egm_modulo_admin_${moduloId}` : `egm_modulo_${moduloId}`);
@@ -164,13 +139,16 @@ export default function FormacionPage() {
               return (
                 <section id="onboarding" className="mb-14 scroll-mt-8">
                   <div className="flex items-center justify-between mb-6">
-                    <div>
-                      <h2 style={{ fontFamily: "var(--font-raleway), sans-serif", fontWeight: 800, fontSize: "clamp(1.6rem, 3vw, 2.2rem)", color: "var(--texto-primario)", letterSpacing: "-0.02em", lineHeight: 1.1 }}>
-                        Onboarding
-                      </h2>
-                      <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
-                        Tu programa de incorporación a la empresa
-                      </p>
+                    <div className="flex items-start gap-3">
+                      <span aria-hidden style={{ display: "inline-block", width: 6, height: "1.3em", borderRadius: 999, background: "linear-gradient(180deg, #0F766E 0%, #06B6D4 100%)", boxShadow: "0 2px 8px rgba(6,182,212,0.35)", marginTop: "0.25em" }} />
+                      <div>
+                        <h2 style={{ fontFamily: "var(--font-raleway), sans-serif", fontWeight: 800, fontSize: "clamp(1.6rem, 3vw, 2.2rem)", color: "var(--texto-primario)", letterSpacing: "-0.02em", lineHeight: 1.1 }}>
+                          Onboarding
+                        </h2>
+                        <p className="text-sm mt-1" style={{ color: "var(--texto-muted)" }}>
+                          Tu programa de incorporación a la empresa
+                        </p>
+                      </div>
                     </div>
                     <div className="flex items-center gap-3">
                       {modulosOnboarding.length > 0 && (
@@ -383,17 +361,46 @@ export default function FormacionPage() {
                   </div>
                 ) : (
                   <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-                    {modulosOnboarding.map((m) => {
+                    {(() => {
+                      const PALETA_OB = [
+                        { from: "#4338CA", to: "#0EA5E9" }, // Indigo → Cielo
+                        { from: "#0891B2", to: "#10B981" }, // Cian → Verde
+                        { from: "#6B21A8", to: "#7C3AED" }, // Púrpura → Violeta
+                        { from: "#0F766E", to: "#06B6D4" }, // Teal → Cian
+                      ];
+                      return modulosOnboarding.map((m, idx) => {
+                      const ac = PALETA_OB[idx % PALETA_OB.length];
                       const img = getFormacionImg(m.moduloId, m.nombre, m.imagenPortadaUrl);
                       const isCompletadoOnboarding = m.status === "completado";
                       const isEnProgresoOnboarding = m.status === "en progreso";
                       return (
                         <div key={m.moduloId}
-                          className="rounded-2xl overflow-hidden group transition-all cursor-pointer flex flex-col"
-                          style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", boxShadow: "0 1px 4px rgba(0,0,0,0.05)" }}
+                          className="rounded-2xl overflow-hidden group transition-all cursor-pointer flex flex-col relative"
+                          style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", boxShadow: `0 3px 14px -8px ${ac.from}66` }}
                           onClick={() => router.push(`/dashboard/formacion/${m.moduloId}`)}
-                          onMouseEnter={(e) => { e.currentTarget.style.boxShadow = "0 8px 24px rgba(0,0,0,0.1)"; e.currentTarget.style.transform = "translateY(-2px)"; }}
-                          onMouseLeave={(e) => { e.currentTarget.style.boxShadow = "0 1px 4px rgba(0,0,0,0.05)"; e.currentTarget.style.transform = "translateY(0)"; }}>
+                          onMouseEnter={(e) => { e.currentTarget.style.boxShadow = `0 10px 28px -10px ${ac.from}99`; e.currentTarget.style.transform = "translateY(-3px)"; }}
+                          onMouseLeave={(e) => { e.currentTarget.style.boxShadow = `0 3px 14px -8px ${ac.from}66`; e.currentTarget.style.transform = "translateY(0)"; }}>
+
+                          {/* Banda superior de color */}
+                          <div className="absolute top-0 left-0 right-0 pointer-events-none z-10" style={{ height: 3, background: `linear-gradient(90deg, ${ac.from} 0%, ${ac.to} 100%)` }} />
+
+                          {/* Botón editar admin */}
+                          {isAdmin && (
+                            <button
+                              onClick={(e) => { e.stopPropagation(); router.push(`/dashboard/admin?tab=formaciones&edit=${m.moduloId}`); }}
+                              className="absolute top-3 right-3 z-20 inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider px-2.5 py-1.5 rounded-full opacity-0 group-hover:opacity-100 transition-all hover:scale-105"
+                              style={{
+                                background: `linear-gradient(135deg, ${ac.from} 0%, ${ac.to} 100%)`,
+                                color: "#fff",
+                                boxShadow: `0 4px 12px -3px ${ac.from}88`,
+                              }}
+                            >
+                              <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                              </svg>
+                              Editar
+                            </button>
+                          )}
 
                           {/* Imagen */}
                           <div className="relative overflow-hidden aspect-[16/10]">
@@ -419,8 +426,8 @@ export default function FormacionPage() {
                           <div className="p-4 flex flex-col flex-1 gap-2">
                             {/* Fila: tipo (chip) + duración */}
                             <div className="flex items-center justify-between gap-2">
-                              <span className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full"
-                                style={{ background: "var(--gris-superficie)", color: "var(--texto-primario)" }}>
+                              <span className="inline-flex items-center gap-1 text-[11px] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full"
+                                style={{ background: `${ac.from}1a`, color: ac.from }}>
                                 {isCompletadoOnboarding ? "Completado" : isEnProgresoOnboarding ? "En curso" : "Onboarding"}
                               </span>
                               <span className="inline-flex items-center gap-1 text-xs" style={{ color: "var(--texto-muted)" }}>
@@ -441,12 +448,11 @@ export default function FormacionPage() {
                             {/* Barra de progreso si hay progreso */}
                             {(isEnProgresoOnboarding || isCompletadoOnboarding) && (
                               <div className="flex items-center gap-2 mt-auto pt-2">
-                                <div className="flex-1 h-1 rounded-full overflow-hidden" style={{ background: "var(--gris-borde)" }}>
+                                <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: "var(--gris-borde)" }}>
                                   <div className="h-full rounded-full transition-all duration-700"
-                                    style={{ width: `${m.porcentaje}%`, background: isCompletadoOnboarding ? "var(--exito)" : "var(--azul-egm)" }} />
+                                    style={{ width: `${m.porcentaje}%`, background: `linear-gradient(90deg, ${ac.from} 0%, ${ac.to} 100%)`, boxShadow: `0 0 8px ${ac.to}88` }} />
                                 </div>
-                                <span className="text-[11px] font-semibold tabular-nums"
-                                  style={{ color: isCompletadoOnboarding ? "var(--exito)" : "var(--azul-egm)" }}>
+                                <span className="text-[11px] font-bold tabular-nums" style={{ color: ac.from }}>
                                   {m.porcentaje}%
                                 </span>
                               </div>
@@ -461,7 +467,8 @@ export default function FormacionPage() {
                           </div>
                         </div>
                         );
-                      })}
+                      });
+                    })()}
                     </div>
                   )}
                 </section>
@@ -469,61 +476,67 @@ export default function FormacionPage() {
             })()}
 
             {/* ── Formación continua heading ───────────────────────────── */}
-            <div className="mb-10">
+            <div className="mb-10 flex items-center gap-3">
+              <span aria-hidden style={{ display: "inline-block", width: 6, height: "1.3em", borderRadius: 999, background: "linear-gradient(180deg, #4338CA 0%, #0EA5E9 100%)", boxShadow: "0 2px 8px rgba(14,165,233,0.35)" }} />
               <h2 style={{ fontFamily: "var(--font-raleway), sans-serif", fontWeight: 800, fontSize: "clamp(1.6rem, 3vw, 2.2rem)", color: "var(--texto-primario)", letterSpacing: "-0.02em", lineHeight: 1.1 }}>
                 Formación continua
               </h2>
             </div>
 
-            {/* ── Continue Learning card ───────────────────────────────── */}
+            {/* ── Continue Learning card — gradiente lleno colorido ─────── */}
             {continuar && (
               <div
-                className="w-full rounded-2xl flex flex-col sm:flex-row items-stretch overflow-hidden"
-                style={{ border: "2px solid var(--azul-egm)", background: "var(--blanco)", marginBottom: "2.5rem" }}
+                className="w-full rounded-3xl flex flex-col sm:flex-row items-stretch overflow-hidden relative transition-transform hover:-translate-y-1 cursor-pointer"
+                style={{
+                  background: "linear-gradient(135deg, #4338CA 0%, #7C3AED 50%, #0EA5E9 100%)",
+                  marginBottom: "2.5rem",
+                  boxShadow: "0 18px 40px -14px rgba(67,56,202,0.6)",
+                }}
+                onClick={() => router.push(`/dashboard/formacion/${continuar.moduloId}`)}
               >
+                {/* Halos decorativos */}
+                <div style={{ position: "absolute", top: -80, right: -60, width: 280, height: 280, borderRadius: "50%", background: "rgba(255,255,255,0.12)" }} />
+                <div style={{ position: "absolute", bottom: -60, left: "30%", width: 200, height: 200, borderRadius: "50%", background: "rgba(255,255,255,0.06)" }} />
+
                 {(() => {
                   const img = getFormacionImg(continuar.moduloId, continuar.nombre, continuar.imagenPortadaUrl);
                   return img ? (
-                    <div className="w-full sm:w-48 h-36 sm:h-auto shrink-0 relative overflow-hidden">
+                    <div className="w-full sm:w-56 h-40 sm:h-auto shrink-0 relative overflow-hidden">
                       <img src={img} alt={continuar.nombre} className="w-full h-full object-cover" />
-                      <div className="absolute inset-0" style={{ background: "rgba(10,20,40,0.25)" }} />
+                      <div className="absolute inset-0" style={{ background: "linear-gradient(135deg, rgba(67,56,202,0.5), rgba(14,165,233,0.3))" }} />
                     </div>
-                  ) : (
-                    <div className="w-full sm:w-48 h-36 sm:h-auto shrink-0"
-                      style={{ background: TIPO_GRADIENT[continuar.tipoModulo] }} />
-                  );
+                  ) : null;
                 })()}
-                <div className="flex-1 px-6 py-5 flex flex-col justify-center gap-3">
+                <div className="relative z-10 flex-1 px-6 py-5 flex flex-col justify-center gap-3">
                   <div>
-                    <p className="text-sm font-semibold uppercase tracking-widest mb-1" style={{ color: "var(--azul-egm)" }}>
+                    <span className="text-[10px] font-bold uppercase tracking-[0.2em] px-3 py-1 rounded-full inline-block mb-2"
+                      style={{ background: "rgba(255,255,255,0.22)", color: "#fff", backdropFilter: "blur(8px)" }}>
                       Continuar aprendiendo
-                    </p>
-                    <h2 className="text-xl font-bold leading-snug" style={{ color: "var(--texto-primario)" }}>
+                    </span>
+                    <h2 className="text-2xl font-bold leading-snug text-white" style={{ textShadow: "0 2px 8px rgba(0,0,0,0.25)" }}>
                       {continuar.nombre}
                     </h2>
                   </div>
                   <div className="flex items-center gap-3">
-                    <div className="flex-1 max-w-xs h-2 rounded-full overflow-hidden" style={{ background: "var(--gris-borde)" }}>
-                      <div className="h-full rounded-full transition-all" style={{ width: `${continuar.porcentaje}%`, background: "var(--azul-egm)" }} />
+                    <div className="flex-1 max-w-xs h-2 rounded-full overflow-hidden" style={{ background: "rgba(255,255,255,0.22)" }}>
+                      <div className="h-full rounded-full transition-all"
+                        style={{ width: `${continuar.porcentaje}%`, background: "linear-gradient(90deg, #FFFFFF 0%, #67E8F9 100%)", boxShadow: "0 0 10px rgba(255,255,255,0.5)" }} />
                     </div>
-                    <span className="text-sm font-semibold shrink-0" style={{ color: "var(--azul-egm)" }}>
+                    <span className="text-sm font-bold shrink-0 text-white tabular-nums">
                       {continuar.porcentaje}%
-                    </span>
-                    <span className="text-sm shrink-0 px-2 py-0.5 rounded-full font-medium" style={{ background: "#FFF3CD", color: "#856404" }}>
-                      En progreso
                     </span>
                   </div>
                 </div>
-                <div className="px-6 py-5 flex items-center shrink-0">
-                  <button
-                    onClick={() => router.push(`/dashboard/formacion/${continuar.moduloId}`)}
-                    className="px-6 py-2.5 rounded-lg text-base font-semibold transition-colors"
-                    style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)", color: "var(--texto-primario)" }}
-                    onMouseEnter={(e) => (e.currentTarget.style.background = "var(--gris-superficie)")}
-                    onMouseLeave={(e) => (e.currentTarget.style.background = "var(--blanco)")}
+                <div className="relative z-10 px-6 py-5 flex items-center shrink-0">
+                  <span
+                    className="px-5 py-2.5 rounded-xl text-sm font-bold transition-all inline-flex items-center gap-2"
+                    style={{ background: "rgba(255,255,255,0.95)", color: "#4338CA", boxShadow: "0 4px 14px rgba(0,0,0,0.15)" }}
                   >
                     Continuar
-                  </button>
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </span>
                 </div>
               </div>
             )}
@@ -595,192 +608,6 @@ function PillFiltro({ label, active, onClick, count }: {
         {count}
       </span>
     </button>
-  );
-}
-
-// ── Tarjeta de curso ──────────────────────────────────────────────────────────
-function CourseCard({
-  m, isAdmin, router,
-}: {
-  m: ModuloEnriquecido;
-  isAdmin: boolean;
-  router: ReturnType<typeof useRouter>;
-}) {
-  const { usuario } = useAuth();
-  const isCompletado = m.status === "completado";
-  const isEnProgreso = m.status === "en progreso";
-
-  const [descargando, setDescargando] = useState(false);
-
-  const handleDescargarCertificado = async () => {
-    setDescargando(true);
-    try {
-      // Priorizar el certificado guardado en Supabase (generado automáticamente por el backend)
-      const url = await obtenerCertificadoModulo(m.moduloId);
-      if (url) {
-        window.open(url, "_blank", "noopener,noreferrer");
-        setDescargando(false);
-        return;
-      }
-    } catch { /* fallback */ }
-
-    // Fallback: generar localmente con jsPDF si el backend aún no lo tiene
-    descargarCertificado({
-      nombreEmpleado: usuario?.nombre ?? "Empleado",
-      apellidosEmpleado: usuario?.apellidos,
-      nombreModulo: m.nombre,
-      tipoModulo: MODULO_TIPO_LABEL[m.tipoModulo] ?? m.tipoModulo,
-      nombreEmpresa: usuario?.nombreEmpresa,
-      fechaCompletado: new Date(),
-    });
-    setDescargando(false);
-  };
-
-  const img = getFormacionImg(m.moduloId, m.nombre, m.imagenPortadaUrl);
-
-  return (
-    <div
-      className="rounded-2xl overflow-hidden flex group relative transition-shadow hover:shadow-md cursor-pointer"
-      style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}
-      onClick={() => router.push(`/dashboard/formacion/${m.moduloId}`)}
-    >
-      {/* Botón editar admin */}
-      {isAdmin && (
-        <button
-          onClick={(e) => { e.stopPropagation(); router.push(`/dashboard/admin?tab=formaciones&edit=${m.moduloId}`); }}
-          className="absolute top-3 right-3 z-10 text-xs font-semibold px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity"
-          style={{ background: "var(--azul-egm-light)", color: "var(--azul-egm)", border: "1px solid var(--gris-borde)" }}
-        >
-          Editar
-        </button>
-      )}
-
-      {/* Thumbnail — IZQUIERDA */}
-      <div className="shrink-0 relative overflow-hidden" style={{ width: "200px" }}>
-        {img ? (
-          <img src={img} alt={m.nombre} className="w-full h-full object-cover absolute inset-0" />
-        ) : (
-          <div className="w-full h-full absolute inset-0" style={{ background: TIPO_GRADIENT[m.tipoModulo] }} />
-        )}
-        {/* Overlay sutil */}
-        <div className="absolute inset-0 pointer-events-none" style={{ background: "rgba(10,20,40,0.15)" }} />
-        {/* Check si completado */}
-        {isCompletado && (
-          <div className="absolute top-2 left-2 w-7 h-7 rounded-full flex items-center justify-center"
-            style={{ background: "var(--exito, #16a34a)", boxShadow: "0 2px 8px rgba(0,0,0,0.25)" }}>
-            <svg className="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-            </svg>
-          </div>
-        )}
-      </div>
-
-      {/* Contenido — DERECHA */}
-      <div className="flex flex-col flex-1 p-4 gap-2 min-w-0">
-        {/* Título */}
-        <h3 className="text-base font-bold leading-snug line-clamp-2" style={{ color: "var(--texto-primario)" }}>
-          {m.nombre}
-        </h3>
-
-        {/* Descripción */}
-        {m.descripcion && (
-          <p className="text-sm leading-snug line-clamp-2" style={{ color: "var(--texto-muted)" }}>
-            {m.descripcion}
-          </p>
-        )}
-
-        {/* Metadata: duración + tipo + IA */}
-        <div className="flex items-center gap-3 flex-wrap text-xs" style={{ color: "var(--texto-muted)" }}>
-          <span className="inline-flex items-center gap-1">
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <circle cx="12" cy="12" r="10" /><path strokeLinecap="round" d="M12 6v6l4 2" />
-            </svg>
-            {m.duracion}
-          </span>
-          {MODULO_TIPO_LABEL[m.tipoModulo] && (
-            <>
-              <span>·</span>
-              <span className="font-semibold" style={{ color: "var(--azul-egm)" }}>
-                {MODULO_TIPO_LABEL[m.tipoModulo]}
-              </span>
-            </>
-          )}
-          {m.esEspecializadoIa && (
-            <span className="inline-flex items-center gap-1 text-xs font-bold px-2 py-0.5 rounded"
-              style={{ background: "#f3e8ff", color: "#7c3aed" }}>
-              <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 2l2.09 7.26L22 12l-7.91 2.74L12 22l-2.09-7.26L2 12l7.91-2.74z" />
-              </svg>
-              IA
-            </span>
-          )}
-        </div>
-
-        {/* Progress bar */}
-        <div className="flex items-center gap-2 mt-1">
-          <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: "var(--gris-borde)" }}>
-            <div
-              className="h-full rounded-full transition-all"
-              style={{
-                width: `${m.porcentaje}%`,
-                background: isCompletado ? "var(--exito, #16a34a)" : "var(--azul-egm)",
-              }}
-            />
-          </div>
-          <span className="text-xs font-semibold tabular-nums shrink-0" style={{ color: isCompletado ? "var(--exito, #16a34a)" : "var(--azul-egm)" }}>
-            {m.porcentaje}%
-          </span>
-        </div>
-
-        {/* CTA */}
-        <div className="mt-auto pt-2">
-          {isCompletado ? (
-            <div className="flex gap-2">
-              <button
-                onClick={(e) => { e.stopPropagation(); handleDescargarCertificado(); }}
-                disabled={descargando}
-                className="flex-1 py-2 rounded-lg text-xs font-semibold transition-colors flex items-center justify-center gap-1.5 disabled:opacity-70"
-                style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
-                onMouseEnter={(e) => { if (!descargando) e.currentTarget.style.background = "var(--azul-egm-hover)"; }}
-                onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
-              >
-                {descargando ? (
-                  <div className="w-3 h-3 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                ) : (
-                  <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
-                )}
-                {descargando ? "Obteniendo..." : "Descargar certificado"}
-              </button>
-            </div>
-          ) : (
-            <button
-              onClick={(e) => { e.stopPropagation(); router.push(`/dashboard/formacion/${m.moduloId}`); }}
-              className="w-full py-2 rounded-lg text-xs font-semibold transition-colors flex items-center justify-center gap-1.5"
-              style={
-                isEnProgreso
-                  ? { background: "var(--blanco)", border: "1px solid var(--azul-egm)", color: "var(--azul-egm)" }
-                  : { background: "var(--azul-egm)", color: "var(--blanco)" }
-              }
-              onMouseEnter={(e) => {
-                if (isEnProgreso) e.currentTarget.style.background = "var(--azul-egm-light)";
-                else e.currentTarget.style.background = "var(--azul-egm-hover)";
-              }}
-              onMouseLeave={(e) => {
-                if (isEnProgreso) e.currentTarget.style.background = "var(--blanco)";
-                else e.currentTarget.style.background = "var(--azul-egm)";
-              }}
-            >
-              {isEnProgreso ? "Continuar" : "Empezar"}
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
-          )}
-        </div>
-      </div>
-    </div>
   );
 }
 

--- a/components/formacion/CourseCard.tsx
+++ b/components/formacion/CourseCard.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+import type { useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
+import { MODULO_TIPO_LABEL } from "@/lib/types/modulos";
+import { descargarCertificado } from "@/lib/certificado";
+import { obtenerCertificadoModulo } from "@/lib/api/documentos";
+import { TIPO_GRADIENT, getFormacionImg, type ModuloEnriquecido } from "@/lib/formacion-helpers";
+
+interface CourseCardProps {
+  m: ModuloEnriquecido;
+  isAdmin: boolean;
+  router: ReturnType<typeof useRouter>;
+}
+
+export function CourseCard({ m, isAdmin, router }: CourseCardProps) {
+  const { usuario } = useAuth();
+  const isCompletado = m.status === "completado";
+  const isEnProgreso = m.status === "en progreso";
+
+  const [descargando, setDescargando] = useState(false);
+
+  const handleDescargarCertificado = async () => {
+    setDescargando(true);
+    try {
+      const url = await obtenerCertificadoModulo(m.moduloId);
+      if (url) {
+        window.open(url, "_blank", "noopener,noreferrer");
+        setDescargando(false);
+        return;
+      }
+    } catch { /* fallback */ }
+
+    descargarCertificado({
+      nombreEmpleado: usuario?.nombre ?? "Empleado",
+      apellidosEmpleado: usuario?.apellidos,
+      nombreModulo: m.nombre,
+      tipoModulo: MODULO_TIPO_LABEL[m.tipoModulo] ?? m.tipoModulo,
+      nombreEmpresa: usuario?.nombreEmpresa,
+      fechaCompletado: new Date(),
+    });
+    setDescargando(false);
+  };
+
+  const img = getFormacionImg(m.moduloId, m.nombre, m.imagenPortadaUrl);
+
+  return (
+    <div
+      className="rounded-2xl overflow-hidden flex group relative transition-shadow hover:shadow-md cursor-pointer"
+      style={{ background: "var(--blanco)", border: "1px solid var(--gris-borde)" }}
+      onClick={() => router.push(`/dashboard/formacion/${m.moduloId}`)}
+    >
+      {/* Botón editar admin */}
+      {isAdmin && (
+        <button
+          onClick={(e) => { e.stopPropagation(); router.push(`/dashboard/admin?tab=formaciones&edit=${m.moduloId}`); }}
+          className="absolute top-3 right-3 z-10 inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider px-2.5 py-1.5 rounded-full opacity-0 group-hover:opacity-100 transition-all hover:scale-105"
+          style={{
+            background: "linear-gradient(135deg, #4338CA 0%, #0EA5E9 100%)",
+            color: "#fff",
+            boxShadow: "0 4px 12px -3px rgba(67,56,202,0.55)",
+            backdropFilter: "blur(6px)",
+          }}
+        >
+          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+          </svg>
+          Editar
+        </button>
+      )}
+
+      {/* Thumbnail — IZQUIERDA */}
+      <div className="shrink-0 relative overflow-hidden" style={{ width: "200px" }}>
+        {img ? (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img src={img} alt={m.nombre} className="w-full h-full object-cover absolute inset-0" />
+        ) : (
+          <div className="w-full h-full absolute inset-0" style={{ background: TIPO_GRADIENT[m.tipoModulo] }} />
+        )}
+        <div className="absolute inset-0 pointer-events-none" style={{ background: "rgba(10,20,40,0.15)" }} />
+        {isCompletado && (
+          <div className="absolute top-2 left-2 w-7 h-7 rounded-full flex items-center justify-center"
+            style={{ background: "var(--exito, #16a34a)", boxShadow: "0 2px 8px rgba(0,0,0,0.25)" }}>
+            <svg className="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      {/* Contenido — DERECHA */}
+      <div className="flex flex-col flex-1 p-4 gap-2 min-w-0">
+        <h3 className="text-base font-bold leading-snug line-clamp-2" style={{ color: "var(--texto-primario)" }}>
+          {m.nombre}
+        </h3>
+
+        {m.descripcion && (
+          <p className="text-sm leading-snug line-clamp-2" style={{ color: "var(--texto-muted)" }}>
+            {m.descripcion}
+          </p>
+        )}
+
+        <div className="flex items-center gap-3 flex-wrap text-xs" style={{ color: "var(--texto-muted)" }}>
+          <span className="inline-flex items-center gap-1">
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <circle cx="12" cy="12" r="10" /><path strokeLinecap="round" d="M12 6v6l4 2" />
+            </svg>
+            {m.duracion}
+          </span>
+          {MODULO_TIPO_LABEL[m.tipoModulo] && (
+            <>
+              <span>·</span>
+              <span className="font-semibold" style={{ color: "var(--azul-egm)" }}>
+                {MODULO_TIPO_LABEL[m.tipoModulo]}
+              </span>
+            </>
+          )}
+          {m.esEspecializadoIa && (
+            <span className="inline-flex items-center gap-1 text-xs font-bold px-2 py-0.5 rounded"
+              style={{ background: "#f3e8ff", color: "#7c3aed" }}>
+              <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2l2.09 7.26L22 12l-7.91 2.74L12 22l-2.09-7.26L2 12l7.91-2.74z" />
+              </svg>
+              IA
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 mt-1">
+          <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: "var(--gris-borde)" }}>
+            <div className="h-full rounded-full transition-all"
+              style={{
+                width: `${m.porcentaje}%`,
+                background: isCompletado ? "var(--exito, #16a34a)" : "var(--azul-egm)",
+              }} />
+          </div>
+          <span className="text-xs font-semibold tabular-nums shrink-0" style={{ color: isCompletado ? "var(--exito, #16a34a)" : "var(--azul-egm)" }}>
+            {m.porcentaje}%
+          </span>
+        </div>
+
+        <div className="mt-auto pt-2 flex justify-end">
+          {isCompletado ? (
+            <button
+              onClick={(e) => { e.stopPropagation(); handleDescargarCertificado(); }}
+              disabled={descargando}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors disabled:opacity-70"
+              style={{ background: "var(--azul-egm)", color: "var(--blanco)" }}
+              onMouseEnter={(e) => { if (!descargando) e.currentTarget.style.background = "var(--azul-egm-hover)"; }}
+              onMouseLeave={(e) => (e.currentTarget.style.background = "var(--azul-egm)")}
+            >
+              {descargando ? (
+                <div className="w-3 h-3 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              ) : (
+                <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+              )}
+              {descargando ? "Obteniendo…" : "Certificado"}
+            </button>
+          ) : (
+            <button
+              onClick={(e) => { e.stopPropagation(); router.push(`/dashboard/formacion/${m.moduloId}`); }}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors"
+              style={
+                isEnProgreso
+                  ? { background: "var(--blanco)", border: "1px solid var(--azul-egm)", color: "var(--azul-egm)" }
+                  : { background: "var(--azul-egm)", color: "var(--blanco)" }
+              }
+              onMouseEnter={(e) => {
+                if (isEnProgreso) e.currentTarget.style.background = "var(--azul-egm-light)";
+                else e.currentTarget.style.background = "var(--azul-egm-hover)";
+              }}
+              onMouseLeave={(e) => {
+                if (isEnProgreso) e.currentTarget.style.background = "var(--blanco)";
+                else e.currentTarget.style.background = "var(--azul-egm)";
+              }}
+            >
+              {isEnProgreso ? "Continuar" : "Empezar"}
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/formacion-helpers.ts
+++ b/lib/formacion-helpers.ts
@@ -1,0 +1,29 @@
+import type { ModuloConProgreso } from "@/lib/types/modulos";
+
+export const TIPO_GRADIENT: Record<string, string> = {
+  IDENTIDAD: "linear-gradient(135deg, #1B3F7E 0%, #2A5298 100%)",
+  BASICA: "linear-gradient(135deg, #0D1B2E 0%, #1B3F7E 100%)",
+  ESPECIFICA: "linear-gradient(135deg, #8B9A2D 0%, #A3B535 100%)",
+  DESARROLLO: "linear-gradient(135deg, #1e3a5f 0%, #3b82f6 100%)",
+  RECOMPENSAS: "linear-gradient(135deg, #7c3aed 0%, #a78bfa 100%)",
+  COMUNIDAD: "linear-gradient(135deg, #0f766e 0%, #2dd4bf 100%)",
+};
+
+const FORMACION_IMG_BY_NAME: Array<{ keywords: string[]; imagen: string }> = [
+  { keywords: ["incorporac", "bienvenid"], imagen: "/background-formacion-empleado.webp" },
+  { keywords: ["comunicac", "efectiva"], imagen: "/comunicacion-trabajo.webp" },
+  { keywords: ["herramienta", "digital", "colaborat"], imagen: "/herramientas-digitales.webp" },
+  { keywords: ["negociaci", "habilidad", "directiv"], imagen: "/negociacion-habilidades.webp" },
+  { keywords: ["cibersegur", "datos", "rgpd"], imagen: "/ciberseguridad-datos.webp" },
+  { keywords: ["metodolog", "agil", "scrum", "kanban"], imagen: "/metodologias-agiles.webp" },
+  { keywords: ["diversidad", "inclusi"], imagen: "/diversidad.webp" },
+];
+
+export function getFormacionImg(_moduloId: string, nombre: string, imagenPortadaUrl?: string | null): string | undefined {
+  // Ignorar URLs placeholder de ejemplo que no resuelven
+  if (imagenPortadaUrl && !imagenPortadaUrl.includes("storage.example.com")) return imagenPortadaUrl;
+  const lower = nombre.toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "");
+  return FORMACION_IMG_BY_NAME.find((e) => e.keywords.some((kw) => lower.includes(kw)))?.imagen;
+}
+
+export type ModuloEnriquecido = ModuloConProgreso & { duracion: string; porcentaje: number };


### PR DESCRIPTION
- Cards de Onboarding con gradientes rotativos (indigo/cian/purpura/teal)
- Card "Continuar aprendiendo" como banner gradiente colorido
- Boton Empezar/Certificado compacto alineado a la derecha
- Boton Editar como pill con gradiente segun el color de la card
- CourseCard extraido a components/formacion/CourseCard.tsx
- Helpers compartidos en lib/formacion-helpers.ts
- Fallback para URLs storage.example.com que no resuelven
- Anadido jspdf-autotable a dependencias